### PR TITLE
feat(front) : add date range selector with granularity options (#54)

### DIFF
--- a/frontend/app/components/ui/DateRange.vue
+++ b/frontend/app/components/ui/DateRange.vue
@@ -1,0 +1,44 @@
+<script setup lang="ts">
+const params = defineModel<{
+  date_start: string
+  date_end: string
+  granularity: "day" | "month" | "year"
+}>({ required: true })
+
+const granularityOptions = [
+  { label: "Jour", value: "day" },
+  { label: "Mois", value: "month" },
+  { label: "Année", value: "year" },
+];
+
+const inputType = computed(() => {
+  if (params.value.granularity === "day") return "date";
+  return "month";
+});
+
+const yearOptions = computed(() => {
+  const years = []
+  for (let y = 1990; y <= new Date().getFullYear(); y++) {
+    years.push({ label: String(y), value: String(y) });
+  }
+  return years;
+});
+</script>
+
+<template>
+  <UFormField label="Granularité">
+    <USelect v-model="params.granularity" :items="granularityOptions" />
+  </UFormField>
+
+  <UFormField label="Date de début">
+    <USelect v-if="params.granularity === 'year'" v-model="params.date_start"
+      :items="yearOptions.filter(y => y.value <= params.date_end)" />
+    <UInput v-else v-model="params.date_start" :type="inputType" :max="params.date_end" />
+  </UFormField>
+
+  <UFormField label="Date de fin">
+    <USelect v-if="params.granularity === 'year'" v-model="params.date_end"
+      :items="yearOptions.filter(y => y.value >= params.date_start)" />
+    <UInput v-else v-model="params.date_end" :type="inputType" :min="params.date_start" />
+  </UFormField>
+</template>

--- a/frontend/app/pages/itn.vue
+++ b/frontend/app/pages/itn.vue
@@ -5,13 +5,14 @@
 
 <script setup lang="ts">
 import CombinedChart from "~/components/charts/CombinedChart.vue";
+import DateRange from "~/components/ui/DateRange.vue";
 
-// TODO : replace 'granularity' with dropdown; V0 is : 'Month' only, 'Day' and 'Year' disabled
-// const params = ref({
-//   date_start: "1990-01-01",
-//   date_end: "2024-12-31",
-//   granularity: "day" as const,
-// });
+
+const params = ref({
+  date_start: "1990-01-01",
+  date_end: "2024-12-31",
+  granularity: "day" as "day" | "month" | "year",
+});
 
 // TODO : uncomment below when "useNationalIndicator" is working
 // const { data, status, error } = await useNationalIndicator(params);
@@ -20,7 +21,11 @@ import CombinedChart from "~/components/charts/CombinedChart.vue";
 <template>
   <UContainer>
     <h1>Page Indicateur Thermique National</h1>
+    <div class="flex items-center justify-center py-12 gap-8">
+      <DateRange v-model="params" />
+    </div>
     <CombinedChart />
+
     <!-- TODO : Implement template below when API "useNationalIndicator" is ready-->
     <!-- <div
       v-if="status === 'pending'"
@@ -41,5 +46,6 @@ import CombinedChart from "~/components/charts/CombinedChart.vue";
       v-else-if="data?.time_series"
       :time-series="data.time_series"
     /> -->
+
   </UContainer>
 </template>


### PR DESCRIPTION
## Type de PR
- [ ] Bugfix
- [x] Feature
- [ ] Refactor
- [ ] Chore / Tech debt
- [ ] Documentation
- [ ] Autre (à préciser)

## Objectif
<!-- Problème résolu ou fonctionnalité apportée. Une phrase claire. -->
Créer un formulaire pour sélectionner les dates et la granularité d'affichage des graphiques 

## Contexte
<!-- Contexte fonctionnel ou technique nécessaire à la revue. -->
<!-- Lien(s) vers issue(s), discussion(s), doc(s). -->
https://github.com/dataforgoodfr/14_ValorisationDonneeMeteo/issues/54

## Changements
  - Création du composant réutilisable `DateRange.vue` (components/ui/)
  - Intégration du sélecteur dans la page ITN
  - Support des 3 granularités : jour (date picker), mois (month picker), année (select)

## Décisions techniques
<!-- Choix structurants, arbitrages, compromis. -->
<!-- Ce qui aurait pu être fait autrement. -->

Utilisation de UInput de nuxt.ui qui fonctionne très bien avec Chrome, moins bien avec Mozilla. A voir si on souhaite ajouter un watch() pour être sûre de la compatibilité. 

## Impacts
- [ ] API / contrat
- [ ] Modèle de données / DB
- [ ] Calculs métier
- [ ] Performance
- [ ] Sécurité
- [ ] Infra / déploiement
- [x] Aucun impact transverse identifié

## Tests
<!-- Décris ce qui a été fait dans cette PR pour vérifier le comportement introduit ou modifié. -->
- [ ] Tests unitaires
- [ ] Tests d’intégration
- [x] Tests manuels
- [ ] Non applicable (à justifier)

## Points d’attention pour la review
<!-- Parties sensibles du code, dette technique introduite, risques. -->
- Le type="month" a un rendu différent entre Chrome (nom du mois) et Firefox (format numérique)
- Les dates min/max sont en dur, à brancher sur le backend quand l'API sera prête


## Suivi
- [ ] Migration à prévoir
- [ ] Documentation à mettre à jour
- [ ] Tâche(s) de suivi à créer
