### PR TITLE
feat: openapi: ajoute les spécifications du endpoint temperature deviation

### DIFF
--- a/backend/openapi/target-specs/openapi.yaml
+++ b/backend/openapi/target-specs/openapi.yaml
@@ -82,8 +82,10 @@ paths:
               type: string
           style: form
           explode: false
-          description: Liste d'identifiants de stations spécifiques à inclure pour superposer les graphes.
-          example: ["07149", "07255"]
+          description: >
+            Liste d'identifiants de stations spécifiques à inclure pour superposer les graphes.
+            Si ce paramètre est absent ou vide, et que 'include_national' vaut 'false', l'API retourne une erreur 400.
+          example: "07149,07255"
 
         - name: include_national
           in: query
@@ -91,7 +93,9 @@ paths:
           schema:
             type: boolean
             default: true
-          description: Permet d'afficher ou masquer les données moyennées sur toute la France.
+          description: >
+            Permet d'afficher ou masquer les données moyennées sur toute la France.
+            Si ce paramètre est défini à 'false', et que 'station_ids' est absent ou vide, l'API retourne une erreur 400.
 
       responses:
         "200":
@@ -101,11 +105,8 @@ paths:
               schema:
                 $ref: "#/components/schemas/TemperatureDeviationResponse"
         "400":
-          description: Paramètre invalide ou manquant.
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/Error"
+          $ref: '#/components/responses/BadRequest'
+
   /temperature/extremes:
     get:
       summary: Pics de chaleur et de froid
@@ -542,6 +543,31 @@ components:
                     minimum: 0
                     maximum: 1
                     description: Pourcentage de données disponibles
+
+    TemperatureDeviationPoint:
+      type: object
+      required:
+        - date
+        - deviation
+        - temperature
+        - baseline_mean
+      properties:
+        date:
+          type: string
+          format: date
+        deviation:
+          type: number
+          format: float
+          description: "Écart de température par rapport à la normale (temperature - baseline_mean)"
+        temperature:
+          type: number
+          format: float
+          description: "Température moyenne observée sur la période"
+        baseline_mean:
+          type: number
+          format: float
+          description: "Température moyenne de référence 1991-2020 pour cette période"
+
     TemperatureDeviationResponse:
       type: object
       required:
@@ -574,45 +600,41 @@ components:
           type: array
           description: "Liste des séries de données (moyenne nationale et/ou stations demandées pour superposition)"
           items:
-            type: object
-            required:
-              - is_national
-              - data
-            properties:
-              is_national:
-                type: boolean
-                description: "Vrai s'il s'agit de la moyenne sur toute la France"
-              station_id:
-                type: string
-                description: "Identifiant de la station (absent ou null si is_national=true)"
-              station_name:
-                type: string
-                description: "Nom de la station (utile pour la légende du graphe)"
-              data:
-                type: array
-                items:
-                  type: object
-                  required:
-                    - date
-                    - deviation
-                    - temperature
-                    - baseline_mean
-                  properties:
-                    date:
-                      type: string
-                      format: date
-                    deviation:
-                      type: number
-                      format: float
-                      description: "Écart de température par rapport à la normale (temperature - baseline_mean)"
-                    temperature:
-                      type: number
-                      format: float
-                      description: "Température moyenne observée sur la période"
-                    baseline_mean:
-                      type: number
-                      format: float
-                      description: "Température moyenne de référence 1991-2020 pour cette période"
+            oneOf:
+              - type: object
+                required:
+                  - is_national
+                  - data
+                properties:
+                  is_national:
+                    type: boolean
+                    enum: [true]
+                    description: "Série correspondant à la moyenne nationale"
+                  data:
+                    type: array
+                    items:
+                      $ref: "#/components/schemas/TemperatureDeviationPoint"
+              - type: object
+                required:
+                  - is_national
+                  - station_id
+                  - station_name
+                  - data
+                properties:
+                  is_national:
+                    type: boolean
+                    enum: [false]
+                    description: "Série correspondant à une station spécifique"
+                  station_id:
+                    type: string
+                    description: "Identifiant de la station"
+                  station_name:
+                    type: string
+                    description: "Nom de la station (utile pour la légende du graphe)"
+                  data:
+                    type: array
+                    items:
+                      $ref: "#/components/schemas/TemperatureDeviationPoint"
     Error:
       type: object
       required:


### PR DESCRIPTION
## Type de PR
- [ ] Bugfix
- [ ] Feature
- [ ] Refactor
- [ ] Chore / Tech debt
- [X] Documentation
- [ ] Autre (à préciser)

## Objectif
Définir le contrat d'interface pour le endpoint '/temperature/deviation' afin de permettre au Front-End de tracer les graphiques d'écart à la normale.

## Contexte
Suite aux User Stories définies pour les écarts de température, cette PR traduit le besoin métier en spécifications techniques cibles. Construit en cohérence avec le endpoint existant '/temperature/national-indicator'.
Basé sur les users stories : 
https://github.com/dataforgoodfr/14_ValorisationDonneeMeteo/issues/7
https://github.com/dataforgoodfr/14_ValorisationDonneeMeteo/issues/8
https://github.com/dataforgoodfr/14_ValorisationDonneeMeteo/issues/10

## Changements
- Mise à jour du endpoint '/temperature/deviation' dans 'openapi.yaml'.
- Ajout des paramètres de requête : 'date_start', 'date_end', 'granularity', 'station_ids' et 'include_national'.
- Création du schéma de réponse 'TemperatureDeviationResponse'.

## Décisions techniques
- **Période de référence :** Fixée à 1991-2020 côté backend. Elle n'est pas modifiable par l'utilisateur pour respecter les règles métier, mais elle est renvoyée dans les 'metadata' pour information.
- **Axe temporel :** Utilisation d'une 'granularity' (day, month, year) pour s'adapter dynamiquement au niveau de zoom du graphique Front-End. Cohérence maintenue avec le endpoint existant '/temperature/national-indicator'
- **Superposition des données :** Plutôt que de faire des appels multiples, le endpoint accepte un tableau 'station_ids' et un booléen 'include_national'. La réponse renvoie un tableau 'series', pour pouvoir superposer la moyenne nationale et plusieurs villes sur le même graphe.

## Impacts
- [X] API / contrat
- [ ] Modèle de données / DB
- [ ] Calculs métier
- [ ] Performance
- [ ] Sécurité
- [ ] Infra / déploiement
- [ ] Aucun impact transverse identifié

## Tests
- [ ] Tests unitaires
- [ ] Tests d’intégration
- [ ] Tests manuels
- [X] Non applicable (à justifier)
C'est la documentation, sans code produit

## Points d’attention pour la review
Côté Front-End : Il faut valider que la structure de la réponse (le tableau 'series' contenant un tableau 'data') correspond bien au format attendu par la bibliotheque FrontEnd.

## Suivi
- [ ] Migration à prévoir
- [ ] Documentation à mettre à jour
- [X] Tâche(s) de suivi à créer
