### PR TITLE
feat: the data source is based on MOCKED_DATA env variable

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -2,6 +2,7 @@
 DEBUG=true
 SECRET_KEY=django-insecure-change-this-in-production
 ALLOWED_HOSTS=localhost,127.0.0.1
+MOCKED_DATA=false
 
 # Database - TimescaleDB
 DB_NAME=meteodb

--- a/backend/README.md
+++ b/backend/README.md
@@ -19,6 +19,15 @@ uv sync --extra dev
 # Copier la configuration
 cp .env.example .env
 ```
+## Données Simulées
+Il est possible de lancer le projet sans utiliser de base de données.
+Les données servies par l'API sont alors des données simulées.
+Pour ce faire, mettre dans .env :
+```
+MOCKED_DATA=true
+```
+
+Si au contraire on souhaite utiliser une vraie base de données, voir la section sur TimescaleDB ci-dessous.
 
 ## Demarrer TimescaleDB
 

--- a/backend/config/settings.py
+++ b/backend/config/settings.py
@@ -15,6 +15,7 @@ env = environ.Env(
     DEBUG=(bool, False),
     ALLOWED_HOSTS=(list, ["localhost", "127.0.0.1"]),
     CORS_ALLOWED_ORIGINS=(list, ["http://localhost:5173", "http://localhost:3000"]),
+    MOCKED_DATA=(bool, False),
 )
 
 # Read .env file if it exists
@@ -24,6 +25,9 @@ environ.Env.read_env(BASE_DIR / ".env")
 SECRET_KEY = env("SECRET_KEY", default="django-insecure-change-me-in-production")
 DEBUG = env("DEBUG")
 ALLOWED_HOSTS = env("ALLOWED_HOSTS")
+
+# Data Source
+MOCKED_DATA = env("MOCKED_DATA", False)
 
 # Application definition
 INSTALLED_APPS = [

--- a/backend/weather/bootstrap_itn.py
+++ b/backend/weather/bootstrap_itn.py
@@ -2,14 +2,21 @@ from __future__ import annotations
 
 from collections.abc import Callable
 
+from django.conf import settings
+
 from weather.services.national_indicator.protocols import (
     NationalIndicatorDailyDataSource,
 )
 
 
 def _default_builder() -> NationalIndicatorDailyDataSource:
+    from weather.data_sources.national_indicator_fake import (
+        FakeNationalIndicatorDailyDataSource,
+    )
     from weather.data_sources.timescale import TimescaleNationalIndicatorDailyDataSource
 
+    if settings.MOCKED_DATA:
+        return FakeNationalIndicatorDailyDataSource()
     return TimescaleNationalIndicatorDailyDataSource()
 
 


### PR DESCRIPTION
## Type de PR
- [ ] Bugfix
- [X] Feature
- [ ] Refactor
- [ ] Chore / Tech debt
- [ ] Documentation
- [ ] Autre (à préciser)

## Objectif
Pouvoir facilement (via le .env) activer les data source mocked plutot que les data sources de la base de données

## Contexte
Il est pénible pour les développeurs front d'avoir à set up et seed la base de dev. On propose donc ici qu'ils puissent facilement activer les fake data sources. 

## Changements
- Ajout d'une variable MOCKED_DATA dans les settings de l'app
- Modification du bootstrap_itn pour modifier la data source selon la valeur de settings.MOCKED_DATA
- Mise à jour de la doc

## Décisions techniques
<!-- Choix structurants, arbitrages, compromis. -->
<!-- Ce qui aurait pu être fait autrement. -->

## Impacts
- [ ] API / contrat
- [X] Modèle de données / DB
- [ ] Calculs métier
- [ ] Performance
- [ ] Sécurité
- [ ] Infra / déploiement
- [ ] Aucun impact transverse identifié

## Tests
Les tests continuent tous de passer, quelle que soit la valeur de MOCKED_DATA

## Points d’attention pour la review
<!-- Parties sensibles du code, dette technique introduite, risques. -->

## Suivi
- [ ] Migration à prévoir
- [ ] Documentation à mettre à jour
- [ ] Tâche(s) de suivi à créer
