### PR TITLE
feat:1991-2020 normal baseline on all stations

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -66,6 +66,7 @@ Ce script :
   - stations
   - données quotidiennes
   - applique les vues SQL utilisées par l'API
+  - applique les materialized views utilisées par l'API
 
 ## Lancer le serveur
 

--- a/backend/scripts/apply_materialized_views.sh
+++ b/backend/scripts/apply_materialized_views.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Root directory (backend/)
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+# Load .env if present
+if [[ -f "$ROOT_DIR/.env" ]]; then
+  export $(grep -v '^#' "$ROOT_DIR/.env" | xargs)
+fi
+
+: "${DB_HOST:=localhost}"
+: "${DB_PORT:=5432}"
+: "${DB_NAME:=meteodb}"
+: "${DB_USER:=infoclimat}"
+: "${DB_PASSWORD:=}"
+
+export PGPASSWORD="$DB_PASSWORD"
+
+MATVIEWS_DIR="${ROOT_DIR}/sql/materialized_views"
+
+if [[ ! -d "$MATVIEWS_DIR" ]]; then
+  echo "ERROR: materialized views directory not found: $MATVIEWS_DIR" >&2
+  exit 1
+fi
+
+shopt -s nullglob
+files=("$MATVIEWS_DIR"/*.sql)
+shopt -u nullglob
+
+if [[ ${#files[@]} -eq 0 ]]; then
+  echo "ERROR: no .sql files found in $MATVIEWS_DIR" >&2
+  exit 1
+fi
+
+for f in "${files[@]}"; do
+  echo "Applying materialized view $(basename "$f")"
+  psql -h "$DB_HOST" \
+       -p "$DB_PORT" \
+       -U "$DB_USER" \
+       -d "$DB_NAME" \
+       -v ON_ERROR_STOP=1 \
+       -f "$f"
+done
+
+echo "Sanity checks:"
+psql -h "$DB_HOST" -p "$DB_PORT" -U "$DB_USER" -d "$DB_NAME" <<'SQL'
+SELECT COUNT(*) AS baseline_station_daily_mean_1991_2020_count
+FROM public.baseline_station_daily_mean_1991_2020;
+
+SELECT *
+FROM public.baseline_station_daily_mean_1991_2020
+LIMIT 5;
+SQL
+
+echo "Materialized views applied."oui

--- a/backend/scripts/seed_dev.sh
+++ b/backend/scripts/seed_dev.sh
@@ -4,7 +4,9 @@ set -euo pipefail
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 
 if [[ -f "$ROOT_DIR/.env" ]]; then
-  export $(grep -v '^[[:space:]]*#' "$ROOT_DIR/.env" | xargs)
+  set -a
+  source "$ROOT_DIR/.env"
+  set +a
 fi
 
 : "${DB_HOST:=localhost}"
@@ -45,11 +47,16 @@ echo "== Import Quotidienne (CSV) =="
 echo "== Apply views =="
 bash "$ROOT_DIR/scripts/apply_views.sh"
 
+echo "== Apply materialized views =="
+bash "$ROOT_DIR/scripts/apply_materialized_views.sh"
+
 echo "== Sanity checks =="
 "${psql_base[@]}" -c 'SELECT COUNT(*) AS station_count FROM public."Station";'
 "${psql_base[@]}" -c 'SELECT COUNT(*) AS quotidienne_count FROM public."Quotidienne";'
 "${psql_base[@]}" -c 'SELECT COUNT(*) AS v_station_count FROM public.v_station;'
 "${psql_base[@]}" -c 'SELECT COUNT(*) AS v_quotidienne_itn_count FROM public.v_quotidienne_itn;'
 "${psql_base[@]}" -c 'SELECT MIN(date), MAX(date) FROM public.v_quotidienne_itn;'
+"${psql_base[@]}" -c 'SELECT COUNT(*) AS baseline_station_daily_mean_1991_2020_count FROM public.baseline_station_daily_mean_1991_2020;'
+"${psql_base[@]}" -c 'SELECT * FROM public.baseline_station_daily_mean_1991_2020 ORDER BY station_code, month, day LIMIT 5;'
 
 echo "Seed done."

--- a/backend/sql/materialized_views/baseline-station-daily-mean-9120.sql
+++ b/backend/sql/materialized_views/baseline-station-daily-mean-9120.sql
@@ -81,6 +81,9 @@ POINTS DE VIGILANCE
 ===============================================================================
 */
 
+DROP MATERIALIZED VIEW IF EXISTS public.baseline_station_daily_mean_1991_2020;
+
+CREATE MATERIALIZED VIEW public.baseline_station_daily_mean_1991_2020 AS
 
 WITH allowed_stations AS (
     SELECT s.station_code
@@ -101,8 +104,7 @@ base AS (
     WHERE v.date >= DATE '1991-01-01'
       AND v.date <  DATE '2021-01-01'
       AND v.station_code IN (
-          SELECT a.station_code
-          FROM allowed_stations a
+          SELECT station_code FROM allowed_stations
       )
 ),
 
@@ -140,31 +142,21 @@ non_leap_feb29 AS (
             ELSE NULL
         END AS daily_value
     FROM (
-        SELECT
-            b.station_code,
-            b.year,
-            b.tntxm
-        FROM base b
-        WHERE b.month = 2
-          AND b.day = 28
+        SELECT station_code, year, tntxm
+        FROM base
+        WHERE month = 2 AND day = 28
 
         UNION ALL
 
-        SELECT
-            b.station_code,
-            b.year,
-            b.tntxm
-        FROM base b
-        WHERE b.month = 3
-          AND b.day = 1
+        SELECT station_code, year, tntxm
+        FROM base
+        WHERE month = 3 AND day = 1
     ) x
     WHERE NOT (
         (x.year % 4 = 0 AND x.year % 100 <> 0)
         OR x.year % 400 = 0
     )
-    GROUP BY
-        x.station_code,
-        x.year
+    GROUP BY x.station_code, x.year
 ),
 
 normalized_daily AS (
@@ -174,26 +166,24 @@ normalized_daily AS (
     UNION ALL
     SELECT * FROM non_leap_feb29
     WHERE daily_value IS NOT NULL
-),
-
-aggregated AS (
-    SELECT
-        nd.station_code,
-        nd.month,
-        nd.day,
-        COUNT(nd.daily_value) AS sample_count,
-        AVG(nd.daily_value)   AS baseline_mean_tntxm
-    FROM normalized_daily nd
-    GROUP BY
-        nd.station_code,
-        nd.month,
-        nd.day
 )
 
-SELECT *
-FROM aggregated
-WHERE sample_count >= 24
-ORDER BY
-    station_code,
-    month,
-    day;
+SELECT
+    nd.station_code,
+    nd.month,
+    nd.day,
+    COUNT(nd.daily_value) AS sample_count,
+    ROUND(AVG(nd.daily_value)::numeric, 2) AS baseline_mean_tntxm
+FROM normalized_daily nd
+GROUP BY
+    nd.station_code,
+    nd.month,
+    nd.day
+HAVING COUNT(nd.daily_value) >= 24;
+
+-- ============================================================================
+-- INDEX
+-- ============================================================================
+
+CREATE INDEX idx_baseline_station_daily_mean
+ON public.baseline_station_daily_mean_1991_2020 (station_code, month, day);


### PR DESCRIPTION
## Type de PR
- [ ] Bugfix
- [X] Feature
- [ ] Refactor
- [ ] Chore / Tech debt
- [ ] Documentation
- [ ] Autre (à préciser)

## Objectif
Calcul de la baseline 1991-2020 pour les stations (normale des températures)

## Contexte
Implémente #160 

## Changements
- Ajout d'un script SQL pour créer une materialized view de Baseline Normale 1991-2020 par station
- Mise à jour de la procédure de seed de la base de dev
- Mise à jour de la documentation

## Décisions techniques
La matérialized view est uniquement au niveau des stations. Il n'y a pas d'aggrégat "France" ou "Département", c'est django qui les fera

## Impacts
- [ ] API / contrat
- [X] Modèle de données / DB
- [X] Calculs métier
- [ ] Performance
- [ ] Sécurité
- [X] Infra / déploiement
- [ ] Aucun impact transverse identifié

## Tests
<!-- Décris ce qui a été fait dans cette PR pour vérifier le comportement introduit ou modifié. -->
Vérification du seed de la base de dev. 

## Points d’attention pour la review
RAS

## Suivi
Il faudra appliquer le script sur la base de prod.

