### PR TITLE
[FEAT][ECART][FRONT] Stack multiple Deviation plots

### DIFF
--- a/frontend/app/components/charts/DeviationChart.vue
+++ b/frontend/app/components/charts/DeviationChart.vue
@@ -6,15 +6,16 @@ import type { DeviationResponse } from "~/types/api";
 import { useDeviationStore } from "#imports";
 import { deviationChartTooltipFormatter } from "./tooltipFormatters/deviationChartTooltipFormatter";
 import {
+    DataZoomComponent,
+    GridComponent,
+    LegendComponent,
     TitleComponent,
     TooltipComponent,
-    GridComponent,
-    DataZoomComponent,
-    LegendComponent,
 } from "echarts/components";
 import { BarChart } from "echarts/charts";
 import { UniversalTransition } from "echarts/features";
 import { CanvasRenderer } from "echarts/renderers";
+
 echarts.registerLocale("FR", langFR);
 echarts.use([
     TitleComponent,
@@ -143,13 +144,12 @@ const option = computed<ECOption>(() => {
         tooltip: {
             trigger: "axis",
             axisPointer: { type: "line" },
-            formatter: (params) => {
-                return deviationChartTooltipFormatter(
+            formatter: (params) =>
+                deviationChartTooltipFormatter(
                     params,
                     props.adapter.granularity.value,
                     selectedStationsNames.value,
-                );
-            },
+                ),
         },
         dataZoom: [
             {

--- a/frontend/app/components/charts/DeviationChart.vue
+++ b/frontend/app/components/charts/DeviationChart.vue
@@ -3,6 +3,7 @@ import * as echarts from "echarts/core";
 import langFR from "~/i18n/langFR.js";
 import type { SelectBarAdapter } from "../ui/commons/selectBar/types";
 import type { DeviationResponse } from "~/types/api";
+import { useDeviationStore } from "#imports";
 import { deviationChartTooltipFormatter } from "./tooltipFormatters/deviationChartTooltipFormatter";
 import {
     TitleComponent,
@@ -29,8 +30,16 @@ echarts.use([
 interface Props {
     adapter: SelectBarAdapter<DeviationResponse>;
 }
-
+const { selectedStations } = storeToRefs(useDeviationStore());
 const props = defineProps<Props>();
+
+const selectedStationsNames = computed(() =>
+    selectedStations.value.length > 0
+        ? selectedStations.value.map(
+              (station) => `${station.nom} (${station.departement})`,
+          )
+        : ["France Métropolitaine"],
+);
 
 // provide init-options
 const renderer = ref<"svg" | "canvas">("canvas");
@@ -42,91 +51,109 @@ const initOptions = computed(() => ({
 provide(INIT_OPTIONS_KEY, initOptions);
 
 const option = computed<ECOption>(() => {
-    const data = props.adapter.data.value?.national.data;
+    const stations =
+        (props.adapter.data.value?.stations.length ?? 0) > 1
+            ? (props.adapter.data.value?.stations ?? [])
+            : [props.adapter.data.value?.national];
+
+    const plotAmountToDisplay = props.adapter.data.value?.stations.length || 1;
 
     return {
-        dataset: {
-            dimensions: [
-                "date",
-                "deviation",
-                "deviation_positive",
-                "deviation_negative",
-            ],
-            source:
-                data?.map((p) => ({
-                    date: p.date,
-                    deviation: p.deviation,
-                    deviation_positive: p.deviation >= 0 ? p.deviation : null,
-                    deviation_negative: p.deviation < 0 ? p.deviation : null,
-                })) ?? [],
-        },
-        grid: {
+        dataset:
+            stations.map((station) => ({
+                dimensions: [
+                    "date",
+                    "deviation_positive",
+                    "deviation_negative",
+                ],
+                source:
+                    station?.data?.map((p) => ({
+                        date: p.date,
+                        deviation_positive:
+                            p.deviation >= 0 ? p.deviation : null,
+                        deviation_negative:
+                            p.deviation < 0 ? p.deviation : null,
+                    })) ?? [],
+            })) ?? [],
+        grid: stations.map((_, index) => ({
+            top: `${index * (100 / plotAmountToDisplay) + 3}%`,
+            height: `${100 / plotAmountToDisplay - 10}%`,
             left: 30,
             right: 10,
-            bottom: 150,
             containLabel: true,
-        },
-        xAxis: {
+        })),
+        xAxis: stations.map((_, index) => ({
             type: "time",
+            gridIndex: index,
             axisTick: { show: false },
             nameLocation: "middle",
             nameGap: 25,
             nameTextStyle: { fontSize: 11, fontWeight: "bold" },
-            axisPointer: { type: "shadow", label: { show: false } },
-        },
-        yAxis: {
+            axisPointer: { type: "line", label: { show: false } },
+        })),
+        yAxis: stations.map((_, index) => ({
             type: "value",
+            gridIndex: index,
             splitNumber: 3,
-            name: "Température (°C)",
+            name: "Ecart à la normale (°C)",
             nameRotate: 90,
             nameLocation: "middle",
             nameGap: 40,
             nameTextStyle: { fontSize: 10, fontWeight: "bold" },
             axisLabel: { fontSize: 10 },
             splitLine: { lineStyle: { type: "dashed" } },
-        },
-        series: [
+        })),
+        series: stations.flatMap((_, index) => [
             {
                 name: "Ecart positif",
                 type: "bar",
-                stack: "deviation",
+                stack: `deviation-${index}`,
+                datasetIndex: index,
                 encode: { x: "date", y: "deviation_positive" },
                 color: "#d32f2f",
                 tooltip: { show: true },
+                xAxisIndex: index,
+                yAxisIndex: index,
             },
             {
                 name: "Ecart négatif",
                 type: "bar",
-                stack: "deviation",
+                stack: `deviation-${index}`,
+                datasetIndex: index,
                 encode: { x: "date", y: "deviation_negative" },
                 color: "#1976d2",
                 tooltip: { show: true },
+                xAxisIndex: index,
+                yAxisIndex: index,
             },
-        ],
-        title: {
-            text: "Ecart à la normale",
-            left: "center",
+        ]),
+        title: stations.map((station, index) => ({
+            text: selectedStationsNames.value[index],
+            right: "right",
+            top: `${index * (100 / plotAmountToDisplay)}%`,
+        })),
+        axisPointer: {
+            link: [{ xAxisIndex: "all" }],
+            label: { backgroundColor: "#3a5080" },
         },
         legend: {
             data: ["Ecart positif", "Ecart négatif"],
-            bottom: 85,
+            bottom: 0,
         },
         tooltip: {
             trigger: "axis",
-            axisPointer: { type: "shadow" },
-            formatter: (params) =>
-                deviationChartTooltipFormatter(
+            axisPointer: { type: "line" },
+            formatter: (params) => {
+                return deviationChartTooltipFormatter(
                     params,
                     props.adapter.granularity.value,
-                ),
+                    selectedStationsNames.value,
+                );
+            },
         },
         dataZoom: [
             {
-                type: "slider",
-                minSpan: 20,
-                showDataShadow: false,
-            },
-            {
+                xAxisIndex: "all",
                 type: "inside",
                 minSpan: 20,
             },

--- a/frontend/app/components/charts/DeviationChart.vue
+++ b/frontend/app/components/charts/DeviationChart.vue
@@ -51,12 +51,12 @@ const initOptions = computed(() => ({
 provide(INIT_OPTIONS_KEY, initOptions);
 
 const option = computed<ECOption>(() => {
-    const stations =
-        (props.adapter.data.value?.stations.length ?? 0) > 1
-            ? (props.adapter.data.value?.stations ?? [])
-            : [props.adapter.data.value?.national];
-
-    const plotAmountToDisplay = props.adapter.data.value?.stations.length || 1;
+    const data = props.adapter.data.value;
+    if (!data) {
+        return {};
+    }
+    const stations = data.stations.length > 1 ? data.stations : [data.national];
+    const plotAmountToDisplay = data.stations.length || 1;
 
     return {
         dataset:

--- a/frontend/app/components/charts/tooltipFormatters/deviationChartTooltipFormatter.test.ts
+++ b/frontend/app/components/charts/tooltipFormatters/deviationChartTooltipFormatter.test.ts
@@ -1,22 +1,28 @@
 import { describe, it, expect } from "vitest";
 import { deviationChartTooltipFormatter } from "./deviationChartTooltipFormatter";
-import type { TooltipComponentFormatterCallbackParams } from "echarts";
+import type {
+    TooltipComponentFormatterCallbackParams,
+    DefaultLabelFormatterCallbackParams,
+} from "echarts";
 
 const makeParam = (
     seriesName: string,
     value: Record<string, number | string>,
     marker = `<span style="color:red;">●</span>`,
     axisIndex = 0,
-) =>
-    ({
-        seriesName,
-        value,
-        data: value,
-        marker,
-        axisIndex,
-    }) as unknown as NonNullable<
-        Extract<TooltipComponentFormatterCallbackParams, unknown[]>[number]
-    >;
+): DefaultLabelFormatterCallbackParams & { axisIndex: number } => ({
+    componentType: "series",
+    componentSubType: "bar",
+    componentIndex: 0,
+    seriesName,
+    name: "",
+    dataIndex: 0,
+    data: value,
+    value,
+    marker,
+    $vars: ["seriesName", "name", "value"],
+    axisIndex,
+});
 
 describe("deviationChartTooltipFormatter", () => {
     // --- Guard cases ---
@@ -38,7 +44,9 @@ describe("deviationChartTooltipFormatter", () => {
     // --- Whole returned string ---
 
     it("returns the right string with granularity : day", () => {
-        const params: TooltipComponentFormatterCallbackParams = [
+        const params: (DefaultLabelFormatterCallbackParams & {
+            axisIndex: number;
+        })[] = [
             {
                 componentType: "series",
                 componentSubType: "bar",
@@ -85,7 +93,7 @@ describe("deviationChartTooltipFormatter", () => {
                 marker: "marker-negatif",
                 axisIndex: 0,
             },
-        ] as unknown as TooltipComponentFormatterCallbackParams;
+        ];
         const result = deviationChartTooltipFormatter(params, "day", ["Lyon"]);
         expect(result).toBe(
             "dim. 2 mars 2025<br/>marker-negatif Lyon : -0.4°C",
@@ -93,7 +101,9 @@ describe("deviationChartTooltipFormatter", () => {
     });
 
     it("returns the right string with granularity : month", () => {
-        const params: TooltipComponentFormatterCallbackParams = [
+        const params: (DefaultLabelFormatterCallbackParams & {
+            axisIndex: number;
+        })[] = [
             {
                 componentType: "series",
                 componentSubType: "bar",
@@ -141,7 +151,7 @@ describe("deviationChartTooltipFormatter", () => {
                 marker: "marker-negatif",
                 axisIndex: 0,
             },
-        ] as unknown as TooltipComponentFormatterCallbackParams;
+        ];
         const result = deviationChartTooltipFormatter(params, "month", [
             "Lyon",
         ]);
@@ -149,7 +159,9 @@ describe("deviationChartTooltipFormatter", () => {
     });
 
     it("returns the right string with granularity : year", () => {
-        const params: TooltipComponentFormatterCallbackParams = [
+        const params: (DefaultLabelFormatterCallbackParams & {
+            axisIndex: number;
+        })[] = [
             {
                 componentType: "series",
                 componentSubType: "bar",
@@ -198,7 +210,7 @@ describe("deviationChartTooltipFormatter", () => {
                 marker: "marker-negatif",
                 axisIndex: 0,
             },
-        ] as unknown as TooltipComponentFormatterCallbackParams;
+        ];
         const result = deviationChartTooltipFormatter(params, "year", ["Lyon"]);
         expect(result).toBe("2026<br/>marker-positif Lyon : +0.0°C");
     });

--- a/frontend/app/components/charts/tooltipFormatters/deviationChartTooltipFormatter.test.ts
+++ b/frontend/app/components/charts/tooltipFormatters/deviationChartTooltipFormatter.test.ts
@@ -6,8 +6,15 @@ const makeParam = (
     seriesName: string,
     value: Record<string, number | string>,
     marker = `<span style="color:red;">●</span>`,
+    axisIndex = 0,
 ) =>
-    ({ seriesName, value, marker }) as unknown as NonNullable<
+    ({
+        seriesName,
+        value,
+        data: value,
+        marker,
+        axisIndex,
+    }) as unknown as NonNullable<
         Extract<TooltipComponentFormatterCallbackParams, unknown[]>[number]
     >;
 
@@ -18,12 +25,13 @@ describe("deviationChartTooltipFormatter", () => {
         const result = deviationChartTooltipFormatter(
             "not an array" as unknown as TooltipComponentFormatterCallbackParams,
             "day",
+            [],
         );
         expect(result).toBe("");
     });
 
     it("returns empty string when params array is empty", () => {
-        const result = deviationChartTooltipFormatter([], "day");
+        const result = deviationChartTooltipFormatter([], "day", []);
         expect(result).toBe("");
     });
 
@@ -52,6 +60,7 @@ describe("deviationChartTooltipFormatter", () => {
                 },
                 $vars: ["seriesName", "name", "value"],
                 marker: "marker-positif",
+                axisIndex: 0,
             },
             {
                 componentType: "series",
@@ -74,10 +83,13 @@ describe("deviationChartTooltipFormatter", () => {
                 },
                 $vars: ["seriesName", "name", "value"],
                 marker: "marker-negatif",
+                axisIndex: 0,
             },
-        ];
-        const result = deviationChartTooltipFormatter(params, "day");
-        expect(result).toBe("dim. 2 mars 2025<br/>marker-negatif : -0.4°C");
+        ] as unknown as TooltipComponentFormatterCallbackParams;
+        const result = deviationChartTooltipFormatter(params, "day", ["Lyon"]);
+        expect(result).toBe(
+            "dim. 2 mars 2025<br/>marker-negatif Lyon : -0.4°C",
+        );
     });
 
     it("returns the right string with granularity : month", () => {
@@ -103,6 +115,7 @@ describe("deviationChartTooltipFormatter", () => {
                 },
                 $vars: ["seriesName", "name", "value"],
                 marker: "marker-positif",
+                axisIndex: 0,
             },
             {
                 componentType: "series",
@@ -126,10 +139,13 @@ describe("deviationChartTooltipFormatter", () => {
                 },
                 $vars: ["seriesName", "name", "value"],
                 marker: "marker-negatif",
+                axisIndex: 0,
             },
-        ];
-        const result = deviationChartTooltipFormatter(params, "month");
-        expect(result).toBe("mars 2026<br/>marker-positif : +0.1°C");
+        ] as unknown as TooltipComponentFormatterCallbackParams;
+        const result = deviationChartTooltipFormatter(params, "month", [
+            "Lyon",
+        ]);
+        expect(result).toBe("mars 2026<br/>marker-positif Lyon : +0.1°C");
     });
 
     it("returns the right string with granularity : year", () => {
@@ -156,6 +172,7 @@ describe("deviationChartTooltipFormatter", () => {
                 },
                 $vars: ["seriesName", "name", "value"],
                 marker: "marker-positif",
+                axisIndex: 0,
             },
             {
                 componentType: "series",
@@ -179,10 +196,11 @@ describe("deviationChartTooltipFormatter", () => {
                 },
                 $vars: ["seriesName", "name", "value"],
                 marker: "marker-negatif",
+                axisIndex: 0,
             },
-        ];
-        const result = deviationChartTooltipFormatter(params, "year");
-        expect(result).toBe("2026<br/>marker-positif : +0.0°C");
+        ] as unknown as TooltipComponentFormatterCallbackParams;
+        const result = deviationChartTooltipFormatter(params, "year", ["Lyon"]);
+        expect(result).toBe("2026<br/>marker-positif Lyon : +0.0°C");
     });
 
     // --- Date formatting by granularity ---
@@ -195,7 +213,9 @@ describe("deviationChartTooltipFormatter", () => {
             }),
         ];
 
-        const result = deviationChartTooltipFormatter(params, "month");
+        const result = deviationChartTooltipFormatter(params, "month", [
+            "Station",
+        ]);
 
         // French locale: "juin 2024"
         expect(result).toContain("2024");
@@ -214,7 +234,9 @@ describe("deviationChartTooltipFormatter", () => {
             }),
         ];
 
-        const result = deviationChartTooltipFormatter(params, "year");
+        const result = deviationChartTooltipFormatter(params, "year", [
+            "Station",
+        ]);
 
         expect(result).toContain("2024");
         expect(result).not.toContain("juin");
@@ -229,7 +251,9 @@ describe("deviationChartTooltipFormatter", () => {
             }),
         ];
 
-        const result = deviationChartTooltipFormatter(params, "day");
+        const result = deviationChartTooltipFormatter(params, "day", [
+            "Station",
+        ]);
 
         expect(result).toContain("2024");
         expect(result).toContain("juin");
@@ -253,7 +277,9 @@ describe("deviationChartTooltipFormatter", () => {
             }),
         ];
 
-        const result = deviationChartTooltipFormatter(params, "month");
+        const result = deviationChartTooltipFormatter(params, "month", [
+            "Station",
+        ]);
 
         expect(result).toContain(marker);
         expect(result).toContain("+3.7°C");
@@ -267,7 +293,9 @@ describe("deviationChartTooltipFormatter", () => {
             }),
         ];
 
-        const result = deviationChartTooltipFormatter(params, "month");
+        const result = deviationChartTooltipFormatter(params, "month", [
+            "Station",
+        ]);
 
         expect(result).toContain("+3.0°C");
     });
@@ -285,7 +313,9 @@ describe("deviationChartTooltipFormatter", () => {
             ),
         ];
 
-        const result = deviationChartTooltipFormatter(params, "month");
+        const result = deviationChartTooltipFormatter(params, "month", [
+            "Station",
+        ]);
 
         expect(result).toContain(marker);
         expect(result).toContain("-2.3°C");
@@ -300,14 +330,16 @@ describe("deviationChartTooltipFormatter", () => {
             }),
         ];
 
-        const result = deviationChartTooltipFormatter(params, "month");
+        const result = deviationChartTooltipFormatter(params, "month", [
+            "Station",
+        ]);
 
         expect(result).toContain("-1.0°C");
     });
 
     // --- Zero deviation ---
 
-    it("treats zero deviation as positive (uses '+' sign and 'Ecart positif' series)", () => {
+    it("treats zero deviation as neutral (no sign, 'Ecart positif' series)", () => {
         const marker = `<span>◆</span>`;
         const params = [
             makeParam(
@@ -317,9 +349,11 @@ describe("deviationChartTooltipFormatter", () => {
             ),
         ];
 
-        const result = deviationChartTooltipFormatter(params, "month");
+        const result = deviationChartTooltipFormatter(params, "month", [
+            "Station",
+        ]);
 
-        expect(result).toContain("+0.0°C");
+        expect(result).toContain("0.0°C");
         expect(result).toContain(marker);
     });
 
@@ -337,7 +371,9 @@ describe("deviationChartTooltipFormatter", () => {
         // Override marker to undefined
         (params[0] as unknown as Record<string, unknown>).marker = undefined;
 
-        const result = deviationChartTooltipFormatter(params, "month");
+        const result = deviationChartTooltipFormatter(params, "month", [
+            "Station",
+        ]);
 
         // Should still produce output, marker part is just empty
         expect(result).toContain("+1.0°C");
@@ -354,7 +390,9 @@ describe("deviationChartTooltipFormatter", () => {
             }),
         ];
 
-        const result = deviationChartTooltipFormatter(params, "month");
+        const result = deviationChartTooltipFormatter(params, "month", [
+            "Station",
+        ]);
 
         const parts = result.split("<br/>");
         expect(parts).toHaveLength(2);

--- a/frontend/app/components/charts/tooltipFormatters/deviationChartTooltipFormatter.test.ts
+++ b/frontend/app/components/charts/tooltipFormatters/deviationChartTooltipFormatter.test.ts
@@ -1,9 +1,6 @@
-import { describe, it, expect } from "vitest";
+import { describe, expect, it } from "vitest";
 import { deviationChartTooltipFormatter } from "./deviationChartTooltipFormatter";
-import type {
-    TooltipComponentFormatterCallbackParams,
-    DefaultLabelFormatterCallbackParams,
-} from "echarts";
+import type { DefaultLabelFormatterCallbackParams } from "echarts";
 
 const makeParam = (
     seriesName: string,
@@ -27,7 +24,7 @@ describe("deviationChartTooltipFormatter", () => {
 
     it("returns empty string when params is not an array", () => {
         const result = deviationChartTooltipFormatter(
-            "not an array" as unknown as TooltipComponentFormatterCallbackParams,
+            makeParam("", {}),
             "day",
             [],
         );
@@ -42,13 +39,12 @@ describe("deviationChartTooltipFormatter", () => {
     // --- Whole returned string ---
 
     it("returns the right string with granularity : day", () => {
-        const params: (DefaultLabelFormatterCallbackParams & {
-            axisIndex: number;
-        })[] = [
+        const params: DefaultLabelFormatterCallbackParams[] = [
             {
                 componentType: "series",
                 componentSubType: "bar",
                 componentIndex: 0,
+                seriesIndex: 0,
                 seriesName: "Ecart positif",
                 name: "",
                 dataIndex: 2,
@@ -66,12 +62,12 @@ describe("deviationChartTooltipFormatter", () => {
                 },
                 $vars: ["seriesName", "name", "value"],
                 marker: "marker-positif",
-                axisIndex: 0,
             },
             {
                 componentType: "series",
                 componentSubType: "bar",
                 componentIndex: 1,
+                seriesIndex: 0,
                 seriesName: "Ecart négatif",
                 name: "",
                 dataIndex: 2,
@@ -89,7 +85,6 @@ describe("deviationChartTooltipFormatter", () => {
                 },
                 $vars: ["seriesName", "name", "value"],
                 marker: "marker-negatif",
-                axisIndex: 0,
             },
         ];
         const result = deviationChartTooltipFormatter(params, "day", ["Lyon"]);
@@ -99,13 +94,12 @@ describe("deviationChartTooltipFormatter", () => {
     });
 
     it("returns the right string with granularity : month", () => {
-        const params: (DefaultLabelFormatterCallbackParams & {
-            axisIndex: number;
-        })[] = [
+        const params: DefaultLabelFormatterCallbackParams[] = [
             {
                 componentType: "series",
                 componentSubType: "bar",
                 componentIndex: 0,
+                seriesIndex: 0,
                 seriesName: "Ecart positif",
                 name: "",
                 dataIndex: 12,
@@ -123,13 +117,13 @@ describe("deviationChartTooltipFormatter", () => {
                 },
                 $vars: ["seriesName", "name", "value"],
                 marker: "marker-positif",
-                axisIndex: 0,
             },
             {
                 componentType: "series",
                 componentSubType: "bar",
                 componentIndex: 1,
                 seriesType: "bar",
+                seriesIndex: 0,
                 seriesName: "Ecart négatif",
                 name: "",
                 dataIndex: 12,
@@ -147,7 +141,6 @@ describe("deviationChartTooltipFormatter", () => {
                 },
                 $vars: ["seriesName", "name", "value"],
                 marker: "marker-negatif",
-                axisIndex: 0,
             },
         ];
         const result = deviationChartTooltipFormatter(params, "month", [
@@ -157,14 +150,13 @@ describe("deviationChartTooltipFormatter", () => {
     });
 
     it("returns the right string with granularity : year", () => {
-        const params: (DefaultLabelFormatterCallbackParams & {
-            axisIndex: number;
-        })[] = [
+        const params: DefaultLabelFormatterCallbackParams[] = [
             {
                 componentType: "series",
                 componentSubType: "bar",
                 componentIndex: 0,
                 seriesType: "bar",
+                seriesIndex: 0,
                 seriesName: "Ecart positif",
                 name: "",
                 dataIndex: 1,
@@ -182,13 +174,13 @@ describe("deviationChartTooltipFormatter", () => {
                 },
                 $vars: ["seriesName", "name", "value"],
                 marker: "marker-positif",
-                axisIndex: 0,
             },
             {
                 componentType: "series",
                 componentSubType: "bar",
                 componentIndex: 1,
                 seriesType: "bar",
+                seriesIndex: 0,
                 seriesName: "Ecart négatif",
                 name: "",
                 dataIndex: 1,
@@ -206,7 +198,6 @@ describe("deviationChartTooltipFormatter", () => {
                 },
                 $vars: ["seriesName", "name", "value"],
                 marker: "marker-negatif",
-                axisIndex: 0,
             },
         ];
         const result = deviationChartTooltipFormatter(params, "year", ["Lyon"]);

--- a/frontend/app/components/charts/tooltipFormatters/deviationChartTooltipFormatter.test.ts
+++ b/frontend/app/components/charts/tooltipFormatters/deviationChartTooltipFormatter.test.ts
@@ -9,8 +9,7 @@ const makeParam = (
     seriesName: string,
     value: Record<string, number | string>,
     marker = `<span style="color:red;">●</span>`,
-    axisIndex = 0,
-): DefaultLabelFormatterCallbackParams & { axisIndex: number } => ({
+): DefaultLabelFormatterCallbackParams => ({
     componentType: "series",
     componentSubType: "bar",
     componentIndex: 0,
@@ -21,7 +20,6 @@ const makeParam = (
     value,
     marker,
     $vars: ["seriesName", "name", "value"],
-    axisIndex,
 });
 
 describe("deviationChartTooltipFormatter", () => {

--- a/frontend/app/components/charts/tooltipFormatters/deviationChartTooltipFormatter.ts
+++ b/frontend/app/components/charts/tooltipFormatters/deviationChartTooltipFormatter.ts
@@ -1,4 +1,7 @@
-import type { TooltipComponentFormatterCallbackParams } from "echarts";
+import type {
+    DefaultLabelFormatterCallbackParams,
+    TooltipComponentFormatterCallbackParams,
+} from "echarts";
 import type { GranularityType } from "~/components/ui/commons/selectBar/types";
 
 export function deviationChartTooltipFormatter(
@@ -16,47 +19,47 @@ export function deviationChartTooltipFormatter(
         }
         if (granularity === "year") {
             return { year: "numeric" };
-        } else {
-            return {
-                weekday: "short",
-                day: "numeric",
-                month: "short",
-                year: "numeric",
-            };
         }
+        return {
+            weekday: "short",
+            day: "numeric",
+            month: "short",
+            year: "numeric",
+        };
     })();
 
     const formattedDate = new Date(
         firstParam.date as string,
     ).toLocaleDateString("fr-FR", dateOptions);
 
+    const tooltipLabelFormatter = (
+        serie: DefaultLabelFormatterCallbackParams,
+    ) => {
+        const data = serie.data as Record<string, number | null>;
+        if (
+            serie.seriesName === "Ecart positif" &&
+            data?.deviation_positive === null
+        )
+            return [];
+        if (
+            serie.seriesName === "Ecart négatif" &&
+            data?.deviation_negative === null
+        )
+            return [];
+        const stationName =
+            stationsNames[
+                (serie as typeof serie & { axisIndex: number }).axisIndex
+            ];
+        const deviation =
+            data?.deviation_positive || data?.deviation_negative || 0;
+        const plusSign = Math.sign(deviation) === 1 ? "+" : "";
+        return [
+            `${serie?.marker ?? ""} ${stationName} : ${plusSign}${deviation?.toFixed(1)}°C`,
+        ];
+    };
+
     const tooltipContent = () =>
-        params
-            .flatMap((serie) => {
-                const data = serie.data as Record<string, number | null>;
-                if (
-                    serie.seriesName === "Ecart positif" &&
-                    data?.deviation_positive === null
-                )
-                    return [];
-                if (
-                    serie.seriesName === "Ecart négatif" &&
-                    data?.deviation_negative === null
-                )
-                    return [];
-                const stationName =
-                    stationsNames[
-                        (serie as typeof serie & { axisIndex: number })
-                            .axisIndex
-                    ];
-                const deviation =
-                    data?.deviation_positive || data?.deviation_negative || 0;
-                const plusSign = Math.sign(deviation) === 1 ? "+" : "";
-                return [
-                    `${serie?.marker ?? ""} ${stationName} : ${plusSign}${deviation?.toFixed(1)}°C`,
-                ];
-            })
-            .join("<br/>");
+        params.flatMap(tooltipLabelFormatter).join("<br/>");
 
     return [formattedDate, tooltipContent()].join("<br/>");
 }

--- a/frontend/app/components/charts/tooltipFormatters/deviationChartTooltipFormatter.ts
+++ b/frontend/app/components/charts/tooltipFormatters/deviationChartTooltipFormatter.ts
@@ -47,9 +47,9 @@ export function deviationChartTooltipFormatter(
         )
             return [];
         const stationName =
-            stationsNames[
-                (serie as typeof serie & { axisIndex: number }).axisIndex
-            ];
+            serie.seriesIndex !== undefined
+                ? stationsNames[serie.seriesIndex]
+                : "";
         const deviation =
             data?.deviation_positive || data?.deviation_negative || 0;
         const plusSign = Math.sign(deviation) === 1 ? "+" : "";

--- a/frontend/app/components/charts/tooltipFormatters/deviationChartTooltipFormatter.ts
+++ b/frontend/app/components/charts/tooltipFormatters/deviationChartTooltipFormatter.ts
@@ -4,39 +4,59 @@ import type { GranularityType } from "~/components/ui/commons/selectBar/types";
 export function deviationChartTooltipFormatter(
     params: TooltipComponentFormatterCallbackParams,
     granularity: GranularityType,
+    stationsNames: string[],
 ): string {
-    if (!Array.isArray(params)) return "";
-    const [first] = params;
-    if (!first) return "";
+    if (!Array.isArray(params) || params.length === 0) return "";
 
-    const d = first.value as Record<string, number | string>;
-    const fmt = (v: number) => `${v.toFixed(1)}°C`;
-    const find = (name: string) => params.find((p) => p.seriesName === name);
+    const firstParam = params[0]?.value as Record<string, number | string>;
 
-    const dateOptions: Intl.DateTimeFormatOptions =
-        granularity === "month"
-            ? { year: "numeric", month: "long" }
-            : granularity === "year"
-              ? { year: "numeric" }
-              : {
-                    weekday: "short",
-                    day: "numeric",
-                    month: "short",
-                    year: "numeric",
-                };
+    const dateOptions: Intl.DateTimeFormatOptions = (() => {
+        if (granularity === "month") {
+            return { year: "numeric", month: "long" };
+        }
+        if (granularity === "year") {
+            return { year: "numeric" };
+        } else {
+            return {
+                weekday: "short",
+                day: "numeric",
+                month: "short",
+                year: "numeric",
+            };
+        }
+    })();
 
-    const formattedDate = new Date(d.date as string).toLocaleDateString(
-        "fr-FR",
-        dateOptions,
-    );
+    const formattedDate = new Date(
+        firstParam.date as string,
+    ).toLocaleDateString("fr-FR", dateOptions);
 
-    const deviation = (d.deviation_positive ?? d.deviation_negative) as number;
-    const serie =
-        deviation >= 0 ? find("Ecart positif") : find("Ecart négatif");
-    const sign = deviation >= 0 ? "+" : "";
+    const tooltipContent = () =>
+        params
+            .flatMap((serie) => {
+                const data = serie.data as Record<string, number | null>;
+                if (
+                    serie.seriesName === "Ecart positif" &&
+                    data?.deviation_positive === null
+                )
+                    return [];
+                if (
+                    serie.seriesName === "Ecart négatif" &&
+                    data?.deviation_negative === null
+                )
+                    return [];
+                const stationName =
+                    stationsNames[
+                        (serie as typeof serie & { axisIndex: number })
+                            .axisIndex
+                    ];
+                const deviation =
+                    data?.deviation_positive || data?.deviation_negative || 0;
+                const plusSign = Math.sign(deviation) === 1 ? "+" : "";
+                return [
+                    `${serie?.marker ?? ""} ${stationName} : ${plusSign}${deviation?.toFixed(1)}°C`,
+                ];
+            })
+            .join("<br/>");
 
-    return [
-        formattedDate,
-        `${serie?.marker ?? ""} : ${sign}${fmt(deviation)}`,
-    ].join("<br/>");
+    return [formattedDate, tooltipContent()].join("<br/>");
 }


### PR DESCRIPTION
## Type de PR
- [X] Feature

## Objectif
Afficher plusieurs stations en parallèle, avec gestion homogène  du zoom, du tooltip, de l'affichage des nom de villes

## Contexte
<!-- Contexte fonctionnel ou technique nécessaire à la revue. -->
<!-- Lien(s) vers issue(s), discussion(s), doc(s). -->

## Changements
- DeviationChart.vue : mise en place du layout multi-stations (grilles, axes et séries dupliqués par station) ; calcul de selectedStationsNames transmis au formateur de tooltip
 
- deviationChartTooltipFormatter.ts : ajout du paramètre stationsNames ; résolution du nom de station via serie.axisIndex et inclusion dans chaque ligne du tooltip
 
- Mise à jour des tests pour passer stationsNames, ajout de axisIndex et data dans les paramètres, correction de l'assertion sur l'écart nul (plus de signe +)

## Décisions techniques
<!-- Choix structurants, arbitrages, compromis. -->
<!-- Ce qui aurait pu être fait autrement. -->

## Impacts
- [X] Aucun impact transverse identifié

## Tests
- [X] Tests unitaires
