### PR TITLE
[FEAT][ECART-NORMALE] add all territory in selector

### DIFF
--- a/frontend/app/components/ecartNormale/searchStation.vue
+++ b/frontend/app/components/ecartNormale/searchStation.vue
@@ -3,7 +3,7 @@ import { refDebounced, useIntersectionObserver } from "@vueuse/core";
 import type { PaginatedResponse, Station } from "~/types/api";
 
 const deviationStore = useDeviationStore();
-const { selectedStations } = storeToRefs(deviationStore);
+const { includeNational, selectedStations } = storeToRefs(deviationStore);
 
 const searchQuery = ref<undefined | string>(undefined);
 const page = ref<number>(0);
@@ -79,10 +79,19 @@ useIntersectionObserver(sentinel, ([entry]) => {
             placeholder="Entrez le nom d'une station"
         />
         <div
-            v-if="selectedStations.length > 0"
+            v-if="selectedStations.length > 0 || includeNational"
             class="max-h-44 overflow-y-auto shrink-0"
         >
             <ul>
+                <li
+                    v-if="includeNational"
+                    class="cursor-pointer pr-2 font-bold py-1 text-sm flex items-center justify-between"
+                    :title="'France Métropolitaine'"
+                    @click="deviationStore.setIncludeNational(false)"
+                >
+                    <span>France Métropolitaine</span>
+                    <UIcon :name="'i-lucide-x'" class="shrink-0" />
+                </li>
                 <li
                     v-for="station in selectedStations"
                     :key="`selected-${station.code}`"
@@ -98,10 +107,19 @@ useIntersectionObserver(sentinel, ([entry]) => {
             </ul>
         </div>
 
-        <USeparator v-if="selectedStations.length > 0" />
+        <USeparator v-if="selectedStations.length > 0 || includeNational" />
 
         <div class="overflow-y-auto">
             <ul>
+                <li
+                    v-if="!includeNational"
+                    class="cursor-pointer pr-2 py-1 text-sm flex items-center justify-between"
+                    :title="'France Métropolitaine'"
+                    @click="deviationStore.setIncludeNational(true)"
+                >
+                    <span>France Métropolitaine</span>
+                    <UIcon :name="'i-lucide-plus'" class="shrink-0" />
+                </li>
                 <li
                     v-for="station in unselectedFilteredStations"
                     :key="`filtered-${station.code}`"

--- a/frontend/app/components/ecartNormale/searchStation.vue
+++ b/frontend/app/components/ecartNormale/searchStation.vue
@@ -10,8 +10,12 @@ const page = ref<number>(0);
 const allStations = ref<Station[]>([]);
 const hasMore = ref<boolean>(false);
 
+const debouncedSearch = refDebounced(searchQuery, 300);
+watch(debouncedSearch, () => {
+    page.value = 0;
+});
 const params = computed(() => ({
-    search: searchQuery.value,
+    search: debouncedSearch.value,
     offset: page.value * 100,
 }));
 const { data: stationsData, refresh } = useStations(params);
@@ -50,12 +54,6 @@ const unselectedFilteredStations = computed(() =>
         ? allStations.value
         : allStations.value.filter((s) => !isStationSelected(s)),
 );
-
-const debouncedSearch = refDebounced(searchQuery, 300);
-watch(debouncedSearch, () => {
-    page.value = 0;
-    refresh();
-});
 
 const sentinel = ref<HTMLElement | undefined>(undefined);
 

--- a/frontend/app/composables/useTemperature.ts
+++ b/frontend/app/composables/useTemperature.ts
@@ -6,25 +6,33 @@ export function useTemperatureDeviation(
 ) {
     const { useApiFetch } = useApiClient();
 
-    if (enabled === undefined) {
-        return useApiFetch<DeviationResponse>("/temperature/deviation", {
-            query: params,
-        });
-    }
+    const hasRequiredParams = computed(() => {
+        const resolved = toValue(params);
+        return (
+            resolved.include_national === true ||
+            (resolved.station_ids !== undefined && resolved.station_ids !== "")
+        );
+    });
 
-    const isEnabled = toRef(enabled);
+    const isEnabled = computed(() =>
+        enabled !== undefined ? toValue(enabled) : true,
+    );
 
     const result = useApiFetch<DeviationResponse>("/temperature/deviation", {
         query: params,
-        imediate: isEnabled.value,
+        immediate: false,
         watch: false,
     });
 
-    watch([isEnabled, params], () => {
-        if (isEnabled.value) {
-            result.execute();
-        }
-    });
+    watch(
+        [isEnabled, hasRequiredParams, params],
+        ([enabled, hasParams]) => {
+            if (enabled && hasParams) {
+                result.execute();
+            }
+        },
+        { immediate: true },
+    );
 
     return result;
 }

--- a/frontend/app/stores/deviationStore.ts
+++ b/frontend/app/stores/deviationStore.ts
@@ -61,9 +61,13 @@ export const useDeviationStore = defineStore("deviationStore", () => {
         stationIds.value = stations.map((station) => station.code);
         selectedStations.value = stations;
     };
+    const setIncludeNational = (value: boolean) => {
+        includeNational.value = value;
+    };
 
     return {
         deviationChartRef,
+        includeNational,
         pickedDateStart,
         pickedDateEnd,
         granularity,
@@ -73,11 +77,11 @@ export const useDeviationStore = defineStore("deviationStore", () => {
         chartTypeSwitchEnabled,
         chartType,
         setGranularity,
+        setIncludeNational,
         setChartType,
         setStations,
         stationIds,
         selectedStations,
-        includeNational,
         deviationData,
         pending,
         error,


### PR DESCRIPTION
## Type de PR
- [ ] Bugfix
- [x] Feature
- [ ] Refactor
- [ ] Chore / Tech debt
- [ ] Documentation
- [ ] Autre (à préciser)

## Objectif
Sélectionner "France métropolitaine" par défaut dans la sélection des stations. 

## Contexte
Pouvoir sélectionner tout le territoire

## Changements
- Résolution du bug du double appel api en passant le `debouncedSearch` dans las paramètres api

## Décisions techniques
J'ai pris le parti de mettre "France métropolitaine" en premier dans la liste des stations non-sélectionnées pour deux raisons: 
- Eviter de recalculer l'ordre de la liste côté front pour avoir France Métropolitaine classer par ordre alphabétique (gain de perf)
- Je trouve ca plus logique d'un point de vue UX de l'avoir toujours en premier car ce n'est pas vraiment une station


## Impacts
- [ ] API / contrat
- [ ] Modèle de données / DB
- [ ] Calculs métier
- [ ] Performance
- [ ] Sécurité
- [ ] Infra / déploiement
- [ ] Aucun impact transverse identifié

## Tests
<!-- Décris ce qui a été fait dans cette PR pour vérifier le comportement introduit ou modifié. -->
- [ ] Tests unitaires
- [ ] Tests d’intégration
- [ ] Tests manuels
- [ ] Non applicable (à justifier)

## Points d’attention pour la review
<!-- Parties sensibles du code, dette technique introduite, risques. -->

## Suivi
- [ ] Migration à prévoir
- [ ] Documentation à mettre à jour
- [ ] Tâche(s) de suivi à créer
