### PR TITLE
Bugfix/deviation

### DIFF
--- a/backend/weather/services/temperature_deviation/service.py
+++ b/backend/weather/services/temperature_deviation/service.py
@@ -3,7 +3,11 @@ from __future__ import annotations
 import datetime as dt
 from collections import defaultdict
 
-from weather.utils.date_range import period_start
+from weather.utils.date_range import (
+    iter_month_starts_intersecting,
+    iter_year_starts_intersecting,
+    period_start,
+)
 
 from .protocols import TemperatureDeviationDailyDataSource
 from .types import (
@@ -17,6 +21,59 @@ from .types import (
 )
 
 
+def _compute_source_window(
+    *,
+    date_start: dt.date,
+    date_end: dt.date,
+    granularity: str,
+) -> tuple[dt.date, dt.date]:
+    if granularity == "day":
+        return date_start, date_end
+
+    if granularity == "month":
+        month_starts = list(iter_month_starts_intersecting(date_start, date_end))
+        start = month_starts[0]
+        last = month_starts[-1]
+        if last.month == 12:
+            next_month = dt.date(last.year + 1, 1, 1)
+        else:
+            next_month = dt.date(last.year, last.month + 1, 1)
+        end = next_month - dt.timedelta(days=1)
+        return start, end
+
+    if granularity == "year":
+        year_starts = list(iter_year_starts_intersecting(date_start, date_end))
+        start = year_starts[0]
+        end = dt.date(year_starts[-1].year, 12, 31)
+        return start, end
+
+    raise ValueError(f"Granularité non supportée : {granularity}")
+
+
+def _requested_bucket_starts(
+    *,
+    date_start: dt.date,
+    date_end: dt.date,
+    granularity: str,
+) -> set[dt.date]:
+    if granularity == "day":
+        cur = date_start
+        out = set()
+        one_day = dt.timedelta(days=1)
+        while cur <= date_end:
+            out.add(cur)
+            cur += one_day
+        return out
+
+    if granularity == "month":
+        return set(iter_month_starts_intersecting(date_start, date_end))
+
+    if granularity == "year":
+        return set(iter_year_starts_intersecting(date_start, date_end))
+
+    raise ValueError(f"Granularité non supportée : {granularity}")
+
+
 def _aggregate(
     daily: list[DailyDeviationPoint],
     *,
@@ -24,7 +81,11 @@ def _aggregate(
     date_end: dt.date,
     granularity: str,
 ) -> list[AggregatedDeviationPoint]:
-    daily = [p for p in daily if date_start <= p.date <= date_end]
+    requested_bucket_starts = _requested_bucket_starts(
+        date_start=date_start,
+        date_end=date_end,
+        granularity=granularity,
+    )
 
     if granularity == "day":
         return [
@@ -34,11 +95,14 @@ def _aggregate(
                 baseline_mean=p.baseline_mean,
             )
             for p in sorted(daily, key=lambda x: x.date)
+            if p.date in requested_bucket_starts
         ]
 
     buckets: dict[dt.date, list[DailyDeviationPoint]] = defaultdict(list)
     for p in daily:
-        buckets[period_start(p.date, granularity)].append(p)
+        start = period_start(p.date, granularity)
+        if start in requested_bucket_starts:
+            buckets[start].append(p)
 
     out: list[AggregatedDeviationPoint] = []
     for start_date in sorted(buckets.keys()):
@@ -60,14 +124,23 @@ def _aggregate_observed(
     date_end: dt.date,
     granularity: str,
 ) -> list[ObservedPoint]:
-    observed = [p for p in observed if date_start <= p.date <= date_end]
+    requested_bucket_starts = _requested_bucket_starts(
+        date_start=date_start,
+        date_end=date_end,
+        granularity=granularity,
+    )
 
     if granularity == "day":
-        return sorted(observed, key=lambda x: x.date)
+        return sorted(
+            [p for p in observed if p.date in requested_bucket_starts],
+            key=lambda x: x.date,
+        )
 
     buckets: dict[dt.date, list[ObservedPoint]] = defaultdict(list)
     for p in observed:
-        buckets[period_start(p.date, granularity)].append(p)
+        start = period_start(p.date, granularity)
+        if start in requested_bucket_starts:
+            buckets[start].append(p)
 
     out: list[ObservedPoint] = []
     for start_date in sorted(buckets.keys()):
@@ -175,9 +248,15 @@ def compute_temperature_deviation_series(
     station_ids: tuple[str, ...] = (),
     include_national: bool = True,
 ) -> TemperatureDeviationResult:
-    query = DailyDeviationSeriesQuery(
+    src_start, src_end = _compute_source_window(
         date_start=date_start,
         date_end=date_end,
+        granularity=granularity,
+    )
+
+    query = DailyDeviationSeriesQuery(
+        date_start=src_start,
+        date_end=src_end,
         station_ids=station_ids,
         include_national=include_national,
     )

--- a/backend/weather/services/temperature_deviation/service.py
+++ b/backend/weather/services/temperature_deviation/service.py
@@ -4,6 +4,7 @@ import datetime as dt
 from collections import defaultdict
 
 from weather.utils.date_range import (
+    iter_days_intersecting,
     iter_month_starts_intersecting,
     iter_year_starts_intersecting,
     period_start,
@@ -57,19 +58,32 @@ def _requested_bucket_starts(
     granularity: str,
 ) -> set[dt.date]:
     if granularity == "day":
-        cur = date_start
-        out = set()
-        one_day = dt.timedelta(days=1)
-        while cur <= date_end:
-            out.add(cur)
-            cur += one_day
-        return out
+        return set(iter_days_intersecting(date_start, date_end))
 
     if granularity == "month":
         return set(iter_month_starts_intersecting(date_start, date_end))
 
     if granularity == "year":
         return set(iter_year_starts_intersecting(date_start, date_end))
+
+    raise ValueError(f"Granularité non supportée : {granularity}")
+
+
+def _bucket_days(bucket_start: dt.date, granularity: str) -> tuple[dt.date, ...]:
+    if granularity == "day":
+        return (bucket_start,)
+
+    if granularity == "month":
+        if bucket_start.month == 12:
+            next_month = dt.date(bucket_start.year + 1, 1, 1)
+        else:
+            next_month = dt.date(bucket_start.year, bucket_start.month + 1, 1)
+        bucket_end = next_month - dt.timedelta(days=1)
+        return tuple(iter_days_intersecting(bucket_start, bucket_end))
+
+    if granularity == "year":
+        bucket_end = dt.date(bucket_start.year, 12, 31)
+        return tuple(iter_days_intersecting(bucket_start, bucket_end))
 
     raise ValueError(f"Granularité non supportée : {granularity}")
 
@@ -155,57 +169,78 @@ def _aggregate_observed(
 
 
 def _inject_national_baseline(
-    observed: list[ObservedPoint],
+    observed_daily: list[ObservedPoint],
+    observed_aggregated: list[ObservedPoint],
     *,
     granularity: str,
     data_source: TemperatureDeviationDailyDataSource,
 ) -> list[AggregatedDeviationPoint]:
-    if granularity == "day":
-        baseline = {
-            (p.month, p.day_of_month): p.mean
-            for p in data_source.fetch_national_daily_baseline()
-        }
+    daily_baseline = {
+        (p.month, p.day_of_month): p.mean
+        for p in data_source.fetch_national_daily_baseline()
+    }
 
+    if granularity == "day":
         return [
             AggregatedDeviationPoint(
                 date=p.date,
                 temperature=p.temperature,
-                baseline_mean=baseline[(p.date.month, p.date.day)],
+                baseline_mean=daily_baseline[(p.date.month, p.date.day)],
             )
-            for p in observed
-            if (p.date.month, p.date.day) in baseline
+            for p in observed_aggregated
+            if (p.date.month, p.date.day) in daily_baseline
         ]
 
+    observed_days_by_bucket: dict[dt.date, set[dt.date]] = defaultdict(set)
+    for p in observed_daily:
+        observed_days_by_bucket[period_start(p.date, granularity)].add(p.date)
+
+    monthly_baseline = None
+    yearly_baseline = None
+
     if granularity == "month":
-        baseline = {
+        monthly_baseline = {
             p.month: p.mean for p in data_source.fetch_national_monthly_baseline()
         }
 
-        return [
-            AggregatedDeviationPoint(
-                date=p.date,
-                temperature=p.temperature,
-                baseline_mean=baseline[p.date.month],
-            )
-            for p in observed
-            if p.date.month in baseline
-        ]
-
     if granularity == "year":
-        baseline = data_source.fetch_national_yearly_baseline()
-        if baseline is None:
-            return []
+        yearly_baseline = data_source.fetch_national_yearly_baseline()
 
-        return [
+    out: list[AggregatedDeviationPoint] = []
+    for p in observed_aggregated:
+        observed_days = observed_days_by_bucket.get(p.date, set())
+        if not observed_days:
+            continue
+
+        full_bucket_days = set(_bucket_days(p.date, granularity))
+        is_complete_bucket = observed_days == full_bucket_days
+
+        if granularity == "month" and is_complete_bucket:
+            assert monthly_baseline is not None
+            baseline_mean = monthly_baseline[p.date.month]
+        elif granularity == "year" and is_complete_bucket:
+            if yearly_baseline is None:
+                continue
+            baseline_mean = yearly_baseline.mean
+        else:
+            baseline_values = [
+                daily_baseline[(d.month, d.day)]
+                for d in sorted(observed_days)
+                if (d.month, d.day) in daily_baseline
+            ]
+            if not baseline_values:
+                continue
+            baseline_mean = sum(baseline_values) / len(baseline_values)
+
+        out.append(
             AggregatedDeviationPoint(
                 date=p.date,
                 temperature=p.temperature,
-                baseline_mean=baseline.mean,
+                baseline_mean=baseline_mean,
             )
-            for p in observed
-        ]
+        )
 
-    raise ValueError(f"Granularité non supportée : {granularity}")
+    return out
 
 
 def _point_to_payload(p: AggregatedDeviationPoint) -> dict:
@@ -263,14 +298,15 @@ def compute_temperature_deviation_series(
 
     national = None
     if include_national:
-        national_observed = data_source.fetch_national_observed_series(query)
+        national_observed_daily = data_source.fetch_national_observed_series(query)
         national_aggregated_observed = _aggregate_observed(
-            national_observed,
+            national_observed_daily,
             date_start=date_start,
             date_end=date_end,
             granularity=granularity,
         )
         nat_points = _inject_national_baseline(
+            national_observed_daily,
             national_aggregated_observed,
             granularity=granularity,
             data_source=data_source,

--- a/backend/weather/services/temperature_deviation/service.py
+++ b/backend/weather/services/temperature_deviation/service.py
@@ -22,6 +22,36 @@ from .types import (
 )
 
 
+def _month_end(first_day_of_month: dt.date) -> dt.date:
+    if first_day_of_month.month == 12:
+        next_month = dt.date(first_day_of_month.year + 1, 1, 1)
+    else:
+        next_month = dt.date(first_day_of_month.year, first_day_of_month.month + 1, 1)
+    return next_month - dt.timedelta(days=1)
+
+
+def _year_end(first_day_of_year: dt.date) -> dt.date:
+    return dt.date(first_day_of_year.year, 12, 31)
+
+
+def _month_source_window(
+    date_start: dt.date, date_end: dt.date
+) -> tuple[dt.date, dt.date]:
+    month_starts = list(iter_month_starts_intersecting(date_start, date_end))
+    start = month_starts[0]
+    end = _month_end(month_starts[-1])
+    return start, end
+
+
+def _year_source_window(
+    date_start: dt.date, date_end: dt.date
+) -> tuple[dt.date, dt.date]:
+    year_starts = list(iter_year_starts_intersecting(date_start, date_end))
+    start = year_starts[0]
+    end = dt.date(year_starts[-1].year, 12, 31)
+    return start, end
+
+
 def _compute_source_window(
     *,
     date_start: dt.date,
@@ -32,21 +62,10 @@ def _compute_source_window(
         return date_start, date_end
 
     if granularity == "month":
-        month_starts = list(iter_month_starts_intersecting(date_start, date_end))
-        start = month_starts[0]
-        last = month_starts[-1]
-        if last.month == 12:
-            next_month = dt.date(last.year + 1, 1, 1)
-        else:
-            next_month = dt.date(last.year, last.month + 1, 1)
-        end = next_month - dt.timedelta(days=1)
-        return start, end
+        return _month_source_window(date_start, date_end)
 
     if granularity == "year":
-        year_starts = list(iter_year_starts_intersecting(date_start, date_end))
-        start = year_starts[0]
-        end = dt.date(year_starts[-1].year, 12, 31)
-        return start, end
+        return _year_source_window(date_start, date_end)
 
     raise ValueError(f"Granularité non supportée : {granularity}")
 
@@ -74,16 +93,10 @@ def _bucket_days(bucket_start: dt.date, granularity: str) -> tuple[dt.date, ...]
         return (bucket_start,)
 
     if granularity == "month":
-        if bucket_start.month == 12:
-            next_month = dt.date(bucket_start.year + 1, 1, 1)
-        else:
-            next_month = dt.date(bucket_start.year, bucket_start.month + 1, 1)
-        bucket_end = next_month - dt.timedelta(days=1)
-        return tuple(iter_days_intersecting(bucket_start, bucket_end))
+        return tuple(iter_days_intersecting(bucket_start, _month_end(bucket_start)))
 
     if granularity == "year":
-        bucket_end = dt.date(bucket_start.year, 12, 31)
-        return tuple(iter_days_intersecting(bucket_start, bucket_end))
+        return tuple(iter_days_intersecting(bucket_start, _year_end(bucket_start)))
 
     raise ValueError(f"Granularité non supportée : {granularity}")
 

--- a/backend/weather/tests/unit/test_temperature_deviation_acceptance.py
+++ b/backend/weather/tests/unit/test_temperature_deviation_acceptance.py
@@ -75,8 +75,8 @@ def test_temperature_deviation_acceptance_month_uses_monthly_baseline_for_nation
 
     assert point["date"] == dt.date(2024, 1, 1)
     assert point["temperature"] == 12.0
-    assert point["baseline_mean"] == 20.0
-    assert point["deviation"] == -8.0
+    assert point["baseline_mean"] == 2.0  # (1 + 3) / 2
+    assert point["deviation"] == 10
 
     station = stations[0]
     assert station["station_id"] == "07149"

--- a/backend/weather/tests/unit/test_temperature_deviation_business.py
+++ b/backend/weather/tests/unit/test_temperature_deviation_business.py
@@ -152,7 +152,7 @@ def test_temperature_deviation_business_returns_expected_payload_on_simple_input
             ]
 
 
-def test_temperature_deviation_business_national_month_uses_monthly_baseline():
+def test_temperature_deviation_business_national_month_partial_uses_daily_baseline():
     class DS:
         def fetch_national_observed_series(self, query):
             return [
@@ -195,8 +195,250 @@ def test_temperature_deviation_business_national_month_uses_monthly_baseline():
     # moyenne observée : (10 + 14) / 2 = 12
     assert point["temperature"] == 12.0
 
-    # doit utiliser la baseline MONTHLY (20.0), pas la moyenne daily (2.0)
+    # bucket partiel → fallback daily : (1 + 3) / 2 = 2
+    assert point["baseline_mean"] == 2.0
+
+    # deviation = 12 - 2 = 10
+    assert point["deviation"] == 10.0
+
+
+def test_national_month_full_bucket_uses_monthly_baseline():
+    class DS:
+        def fetch_national_observed_series(self, query):
+            # mois complet
+            return [
+                ObservedPoint(date=dt.date(2024, 1, d), temperature=10.0)
+                for d in range(1, 32)
+            ]
+
+        def fetch_national_daily_baseline(self):
+            return [
+                DailyBaselinePoint(month=1, day_of_month=d, mean=1.0)
+                for d in range(1, 32)
+            ]
+
+        def fetch_national_monthly_baseline(self):
+            return [MonthlyBaselinePoint(month=1, mean=20.0)]
+
+        def fetch_national_yearly_baseline(self):
+            return YearlyBaselinePoint(mean=999.0)
+
+        def fetch_stations_daily_series(self, query):
+            return []
+
+    out = get_temperature_deviation(
+        data_source=DS(),
+        date_start=dt.date(2024, 1, 1),
+        date_end=dt.date(2024, 1, 31),
+        granularity="month",
+        station_ids=(),
+        include_national=True,
+    )
+
+    point = out["national"]["data"][0]
+
     assert point["baseline_mean"] == 20.0
 
-    # deviation = 12 - 20 = -8
-    assert point["deviation"] == -8.0
+
+def test_national_month_partial_bucket_uses_daily_baseline():
+    class DS:
+        def fetch_national_observed_series(self, query):
+            return [
+                ObservedPoint(date=dt.date(2024, 1, 1), temperature=10.0),
+                ObservedPoint(date=dt.date(2024, 1, 2), temperature=14.0),
+            ]
+
+        def fetch_national_daily_baseline(self):
+            return [
+                DailyBaselinePoint(month=1, day_of_month=1, mean=1.0),
+                DailyBaselinePoint(month=1, day_of_month=2, mean=3.0),
+            ]
+
+        def fetch_national_monthly_baseline(self):
+            return [MonthlyBaselinePoint(month=1, mean=20.0)]
+
+        def fetch_national_yearly_baseline(self):
+            return YearlyBaselinePoint(mean=999.0)
+
+        def fetch_stations_daily_series(self, query):
+            return []
+
+    out = get_temperature_deviation(
+        data_source=DS(),
+        date_start=dt.date(2024, 1, 1),
+        date_end=dt.date(2024, 1, 2),
+        granularity="month",
+        station_ids=(),
+        include_national=True,
+    )
+
+    point = out["national"]["data"][0]
+
+    assert point["baseline_mean"] == 2.0
+
+
+def test_national_year_full_bucket_uses_yearly_baseline():
+    class DS:
+        def fetch_national_observed_series(self, query):
+            return [
+                ObservedPoint(
+                    date=dt.date(2024, 1, 1) + dt.timedelta(days=i), temperature=10.0
+                )
+                for i in range(366)  # 2024 bissextile
+            ]
+
+        def fetch_national_daily_baseline(self):
+            return [
+                DailyBaselinePoint(
+                    month=(dt.date(2024, 1, 1) + dt.timedelta(days=i)).month,
+                    day_of_month=(dt.date(2024, 1, 1) + dt.timedelta(days=i)).day,
+                    mean=1.0,
+                )
+                for i in range(366)
+            ]
+
+        def fetch_national_monthly_baseline(self):
+            return []
+
+        def fetch_national_yearly_baseline(self):
+            return YearlyBaselinePoint(mean=50.0)
+
+        def fetch_stations_daily_series(self, query):
+            return []
+
+    out = get_temperature_deviation(
+        data_source=DS(),
+        date_start=dt.date(2024, 1, 1),
+        date_end=dt.date(2024, 12, 31),
+        granularity="year",
+        station_ids=(),
+        include_national=True,
+    )
+
+    point = out["national"]["data"][0]
+
+    assert point["baseline_mean"] == 50.0
+
+
+def test_national_year_partial_bucket_uses_daily_baseline():
+    class DS:
+        def fetch_national_observed_series(self, query):
+            return [
+                ObservedPoint(date=dt.date(2024, 1, 1), temperature=10.0),
+                ObservedPoint(date=dt.date(2024, 1, 2), temperature=14.0),
+            ]
+
+        def fetch_national_daily_baseline(self):
+            return [
+                DailyBaselinePoint(month=1, day_of_month=1, mean=1.0),
+                DailyBaselinePoint(month=1, day_of_month=2, mean=3.0),
+            ]
+
+        def fetch_national_monthly_baseline(self):
+            return []
+
+        def fetch_national_yearly_baseline(self):
+            return YearlyBaselinePoint(mean=999.0)
+
+        def fetch_stations_daily_series(self, query):
+            return []
+
+    out = get_temperature_deviation(
+        data_source=DS(),
+        date_start=dt.date(2024, 1, 1),
+        date_end=dt.date(2024, 1, 2),
+        granularity="year",
+        station_ids=(),
+        include_national=True,
+    )
+
+    point = out["national"]["data"][0]
+
+    assert point["baseline_mean"] == 2.0
+
+
+def test_temperature_deviation_business_month_extends_source_window_to_full_month():
+    class DS:
+        def fetch_national_observed_series(self, query):
+            assert query.date_start == dt.date(2024, 1, 1)
+            assert query.date_end == dt.date(2024, 1, 31)
+
+            return [
+                ObservedPoint(date=dt.date(2024, 1, 1), temperature=10.0),
+                ObservedPoint(date=dt.date(2024, 1, 31), temperature=14.0),
+            ]
+
+        def fetch_national_daily_baseline(self):
+            return [
+                DailyBaselinePoint(month=1, day_of_month=1, mean=1.0),
+                DailyBaselinePoint(month=1, day_of_month=31, mean=3.0),
+            ]
+
+        def fetch_national_monthly_baseline(self):
+            return [MonthlyBaselinePoint(month=1, mean=20.0)]
+
+        def fetch_national_yearly_baseline(self):
+            return YearlyBaselinePoint(mean=999.0)
+
+        def fetch_stations_daily_series(self, query):
+            assert query.date_start == dt.date(2024, 1, 1)
+            assert query.date_end == dt.date(2024, 1, 31)
+            return []
+
+    out = get_temperature_deviation(
+        data_source=DS(),
+        date_start=dt.date(2024, 1, 15),
+        date_end=dt.date(2024, 1, 20),
+        granularity="month",
+        station_ids=(),
+        include_national=True,
+    )
+
+    point = out["national"]["data"][0]
+
+    # observé agrégé sur le mois complet fetché
+    assert point["date"] == dt.date(2024, 1, 1)
+    assert point["temperature"] == 12.0
+
+
+def test_temperature_deviation_business_year_extends_source_window_to_full_year():
+    class DS:
+        def fetch_national_observed_series(self, query):
+            assert query.date_start == dt.date(2024, 1, 1)
+            assert query.date_end == dt.date(2024, 12, 31)
+
+            return [
+                ObservedPoint(date=dt.date(2024, 1, 1), temperature=10.0),
+                ObservedPoint(date=dt.date(2024, 12, 31), temperature=14.0),
+            ]
+
+        def fetch_national_daily_baseline(self):
+            return [
+                DailyBaselinePoint(month=1, day_of_month=1, mean=1.0),
+                DailyBaselinePoint(month=12, day_of_month=31, mean=3.0),
+            ]
+
+        def fetch_national_monthly_baseline(self):
+            return []
+
+        def fetch_national_yearly_baseline(self):
+            return YearlyBaselinePoint(mean=50.0)
+
+        def fetch_stations_daily_series(self, query):
+            assert query.date_start == dt.date(2024, 1, 1)
+            assert query.date_end == dt.date(2024, 12, 31)
+            return []
+
+    out = get_temperature_deviation(
+        data_source=DS(),
+        date_start=dt.date(2024, 3, 15),
+        date_end=dt.date(2024, 9, 10),
+        granularity="year",
+        station_ids=(),
+        include_national=True,
+    )
+
+    point = out["national"]["data"][0]
+
+    assert point["date"] == dt.date(2024, 1, 1)
+    assert point["temperature"] == 12.0


### PR DESCRIPTION
## Type de PR
- [X] Bugfix
- [ ] Feature
- [ ] Refactor
- [ ] Chore / Tech debt
- [ ] Documentation
- [ ] Autre (à préciser)

## Objectif
Corriger le calcul de déviation en :

- agrégeant systématiquement sur des buckets calendaires complets (mois / année), pour national et stations
- alignant la baseline nationale avec le périmètre réel des données (fallback journalier pour les buckets partiels). Pour les stations, la baseline était déjà agrégée à partir du journalier (=> pas de correction nécessaire).

## Contexte
Deux problèmes indépendants affectaient le calcul de déviation :

Construction incorrecte des buckets (mois / année)
Les données étaient agrégées uniquement sur l’intervalle demandé (date_start / date_end).
Ainsi, une requête couvrant une partie d’un mois ou d’une année produisait un bucket tronqué (ex : janvier limité aux jours 15–20), au lieu d’un bucket calendaire complet.
Ce comportement était incohérent avec celui de l’ITN.

Baseline nationale non alignée avec l’observé
La baseline nationale mensuelle ou annuelle était utilisée systématiquement, même lorsque les données observées ne couvraient qu’une partie du bucket.
Cela revenait à comparer :

un observé partiel (ex : début de mois)
à une baseline complète (mois ou année entière)

→ Les écarts produits étaient incorrects.

À noter :

côté stations, la baseline était déjà agrégée à partir du journalier, donc cohérente
en revanche, le problème de construction des buckets concernait à la fois le national et les stations

## Changements
- Extension de la fenêtre source :
   - month → récupération du mois complet
   - year → récupération de l’année complète
- Application à tous les flux :
- national
- stations
- Modification de l’agrégation :
   - agrégation sur buckets calendaires complets
   - filtrage par buckets intersectants
- Refonte de la baseline nationale :
   - détection des buckets complets vs partiels
   - utilisation des MVs ITN monthly/yearly uniquement si bucket complet
   - fallback sur baseline journalière sinon
- Mise à jour des tests existants
- Ajout de tests couvrant :
   - extension des buckets
   - logique full vs partial

## Décisions techniques
- Séparation claire des deux problèmes :
   - construction correcte des buckets
   - calcul correct de la baseline
- Réutilisation du pattern ITN pour la fenêtre source
- Détection de complétude basée sur les jours réellement observés
- Conservation des MVs agrégées pour les cas complets (performance)
- Fallback journalier uniquement si nécessaire

Alternative possible :

- recalcul systématique depuis le journalier (plus simple mais plus coûteux)
- ou restriction API (interdire les buckets partiels)
- 
## Impacts
- [ ] API / contrat
- [ ] Modèle de données / DB
- [X] Calculs métier
- [ ] Performance
- [ ] Sécurité
- [ ] Infra / déploiement
- [ ] Aucun impact transverse identifié

## Tests
<!-- Décris ce qui a été fait dans cette PR pour vérifier le comportement introduit ou modifié. -->
- [X] Tests unitaires
- [ ] Tests d’intégration
- [ ] Tests manuels
- [ ] Non applicable (à justifier)

## Points d’attention pour la review
<!-- Parties sensibles du code, dette technique introduite, risques. -->

## Suivi
- [ ] Migration à prévoir
- [ ] Documentation à mettre à jour
- [ ] Tâche(s) de suivi à créer
- [ ] 
