### PR TITLE
fix: ecart-normale: display all selected stations and national on graph

### DIFF
--- a/frontend/app/components/charts/DeviationChart.vue
+++ b/frontend/app/components/charts/DeviationChart.vue
@@ -35,15 +35,12 @@ const { selectedStations, includeNational } = storeToRefs(useDeviationStore());
 const props = defineProps<Props>();
 
 const selectedStationsAndNationalNames = computed(() => {
-    const stations =
-        selectedStations.value.length > 0
-            ? selectedStations.value.map(
-                  (station) => `${station.nom} (${station.departement})`,
-              )
-            : [];
-    const national = includeNational.value ? ["France Métropolitaine"] : [];
-
-    return [national, ...stations].flat();
+    const stations = selectedStations.value.map(
+        (station) => `${station.nom} (${station.departement})`,
+    );
+    return includeNational.value
+        ? ["France Métropolitaine", ...stations]
+        : stations;
 });
 
 // provide init-options
@@ -110,43 +107,40 @@ const option = computed<ECOption>(() => {
             axisLabel: { fontSize: 10 },
             splitLine: { lineStyle: { type: "dashed" } },
         })),
-        series:
-            stationsAndNational.flatMap((_, index) => [
-                {
-                    name: "Ecart positif",
-                    type: "bar",
-                    stack: `deviation-${index}`,
-                    datasetIndex: index,
-                    encode: { x: "date", y: "deviation_positive" },
-                    color: "#d32f2f",
-                    tooltip: { show: true },
-                    xAxisIndex: index,
-                    yAxisIndex: index,
-                },
-                {
-                    name: "Ecart négatif",
-                    type: "bar",
-                    stack: `deviation-${index}`,
-                    datasetIndex: index,
-                    encode: { x: "date", y: "deviation_negative" },
-                    color: "#1976d2",
-                    tooltip: { show: true },
-                    xAxisIndex: index,
-                    yAxisIndex: index,
-                },
-            ]) ?? [],
-        title:
-            stationsAndNational.map((stationOrNational, index) => ({
-                text: selectedStationsAndNationalNames.value[index],
-                right: "right",
-                top: `${index * (100 / plotAmountToDisplay)}%`,
-            })) ?? [],
+        series: stationsAndNational.flatMap((_, index) => [
+            {
+                name: "Ecart positif",
+                type: "bar",
+                stack: `deviation-${index}`,
+                datasetIndex: index,
+                encode: { x: "date", y: "deviation_positive" },
+                color: "#d32f2f",
+                tooltip: { show: true },
+                xAxisIndex: index,
+                yAxisIndex: index,
+            },
+            {
+                name: "Ecart négatif",
+                type: "bar",
+                stack: `deviation-${index}`,
+                datasetIndex: index,
+                encode: { x: "date", y: "deviation_negative" },
+                color: "#1976d2",
+                tooltip: { show: true },
+                xAxisIndex: index,
+                yAxisIndex: index,
+            },
+        ]),
+        title: stationsAndNational.map((stationOrNational, index) => ({
+            text: selectedStationsAndNationalNames.value[index],
+            right: "right",
+            top: `${index * (100 / plotAmountToDisplay)}%`,
+        })),
         axisPointer: {
             link: [{ xAxisIndex: "all" }],
             label: { backgroundColor: "#3a5080" },
         },
         legend: {
-            data: ["Ecart positif", "Ecart négatif"],
             bottom: 0,
         },
         tooltip: {
@@ -171,13 +165,26 @@ const option = computed<ECOption>(() => {
 </script>
 
 <template>
-    <VChart
-        :ref="adapter.chartRef"
-        :key="adapter.granularity.value"
-        :option="option"
-        :init-options="initOptions"
-        :loading="adapter.pending.value"
-        :loading-options="{ text: 'Chargement…', color: '#3b82f6' }"
-        autoresize
-    />
+    <div class="h-full">
+        <div
+            v-if="!props.adapter.data.value"
+            class="flex flex-col justify-center h-full items-center text-stone-400"
+        >
+            <p>Selectionnez au moins une station</p>
+            <p>
+                pour afficher ces écarts à la normale, pour la période
+                sélectionnée.
+            </p>
+        </div>
+        <VChart
+            v-else
+            :ref="adapter.chartRef"
+            :key="adapter.granularity.value"
+            :option="option"
+            :init-options="initOptions"
+            :loading="adapter.pending.value"
+            :loading-options="{ text: 'Chargement…', color: '#3b82f6' }"
+            autoresize
+        />
+    </div>
 </template>

--- a/frontend/app/components/charts/DeviationChart.vue
+++ b/frontend/app/components/charts/DeviationChart.vue
@@ -31,16 +31,20 @@ echarts.use([
 interface Props {
     adapter: SelectBarAdapter<DeviationResponse>;
 }
-const { selectedStations } = storeToRefs(useDeviationStore());
+const { selectedStations, includeNational } = storeToRefs(useDeviationStore());
 const props = defineProps<Props>();
 
-const selectedStationsNames = computed(() =>
-    selectedStations.value.length > 0
-        ? selectedStations.value.map(
-              (station) => `${station.nom} (${station.departement})`,
-          )
-        : ["France Métropolitaine"],
-);
+const selectedStationsAndNationalNames = computed(() => {
+    const stations =
+        selectedStations.value.length > 0
+            ? selectedStations.value.map(
+                  (station) => `${station.nom} (${station.departement})`,
+              )
+            : [];
+    const national = includeNational.value ? ["France Métropolitaine"] : [];
+
+    return [national, ...stations].flat();
+});
 
 // provide init-options
 const renderer = ref<"svg" | "canvas">("canvas");
@@ -56,19 +60,21 @@ const option = computed<ECOption>(() => {
     if (!data) {
         return {};
     }
-    const stations = data.stations.length > 1 ? data.stations : [data.national];
-    const plotAmountToDisplay = data.stations.length || 1;
+    const stationsAndNational = includeNational.value
+        ? [data.national, ...data.stations]
+        : data.stations;
+    const plotAmountToDisplay = stationsAndNational.length || 1;
 
     return {
         dataset:
-            stations.map((station) => ({
+            stationsAndNational.map((stationOrNational) => ({
                 dimensions: [
                     "date",
                     "deviation_positive",
                     "deviation_negative",
                 ],
                 source:
-                    station?.data?.map((p) => ({
+                    stationOrNational?.data?.map((p) => ({
                         date: p.date,
                         deviation_positive:
                             p.deviation >= 0 ? p.deviation : null,
@@ -76,14 +82,14 @@ const option = computed<ECOption>(() => {
                             p.deviation < 0 ? p.deviation : null,
                     })) ?? [],
             })) ?? [],
-        grid: stations.map((_, index) => ({
+        grid: stationsAndNational.map((_, index) => ({
             top: `${index * (100 / plotAmountToDisplay) + 3}%`,
             height: `${100 / plotAmountToDisplay - 10}%`,
             left: 30,
             right: 10,
             containLabel: true,
         })),
-        xAxis: stations.map((_, index) => ({
+        xAxis: stationsAndNational.map((_, index) => ({
             type: "time",
             gridIndex: index,
             axisTick: { show: false },
@@ -92,7 +98,7 @@ const option = computed<ECOption>(() => {
             nameTextStyle: { fontSize: 11, fontWeight: "bold" },
             axisPointer: { type: "line", label: { show: false } },
         })),
-        yAxis: stations.map((_, index) => ({
+        yAxis: stationsAndNational.map((_, index) => ({
             type: "value",
             gridIndex: index,
             splitNumber: 3,
@@ -104,35 +110,37 @@ const option = computed<ECOption>(() => {
             axisLabel: { fontSize: 10 },
             splitLine: { lineStyle: { type: "dashed" } },
         })),
-        series: stations.flatMap((_, index) => [
-            {
-                name: "Ecart positif",
-                type: "bar",
-                stack: `deviation-${index}`,
-                datasetIndex: index,
-                encode: { x: "date", y: "deviation_positive" },
-                color: "#d32f2f",
-                tooltip: { show: true },
-                xAxisIndex: index,
-                yAxisIndex: index,
-            },
-            {
-                name: "Ecart négatif",
-                type: "bar",
-                stack: `deviation-${index}`,
-                datasetIndex: index,
-                encode: { x: "date", y: "deviation_negative" },
-                color: "#1976d2",
-                tooltip: { show: true },
-                xAxisIndex: index,
-                yAxisIndex: index,
-            },
-        ]),
-        title: stations.map((station, index) => ({
-            text: selectedStationsNames.value[index],
-            right: "right",
-            top: `${index * (100 / plotAmountToDisplay)}%`,
-        })),
+        series:
+            stationsAndNational.flatMap((_, index) => [
+                {
+                    name: "Ecart positif",
+                    type: "bar",
+                    stack: `deviation-${index}`,
+                    datasetIndex: index,
+                    encode: { x: "date", y: "deviation_positive" },
+                    color: "#d32f2f",
+                    tooltip: { show: true },
+                    xAxisIndex: index,
+                    yAxisIndex: index,
+                },
+                {
+                    name: "Ecart négatif",
+                    type: "bar",
+                    stack: `deviation-${index}`,
+                    datasetIndex: index,
+                    encode: { x: "date", y: "deviation_negative" },
+                    color: "#1976d2",
+                    tooltip: { show: true },
+                    xAxisIndex: index,
+                    yAxisIndex: index,
+                },
+            ]) ?? [],
+        title:
+            stationsAndNational.map((stationOrNational, index) => ({
+                text: selectedStationsAndNationalNames.value[index],
+                right: "right",
+                top: `${index * (100 / plotAmountToDisplay)}%`,
+            })) ?? [],
         axisPointer: {
             link: [{ xAxisIndex: "all" }],
             label: { backgroundColor: "#3a5080" },
@@ -148,7 +156,7 @@ const option = computed<ECOption>(() => {
                 deviationChartTooltipFormatter(
                     params,
                     props.adapter.granularity.value,
-                    selectedStationsNames.value,
+                    selectedStationsAndNationalNames.value,
                 ),
         },
         dataZoom: [

--- a/frontend/app/composables/useTemperature.ts
+++ b/frontend/app/composables/useTemperature.ts
@@ -29,6 +29,8 @@ export function useTemperatureDeviation(
         ([enabled, hasParams]) => {
             if (enabled && hasParams) {
                 result.execute();
+            } else if (!hasParams) {
+                result.data.value = undefined;
             }
         },
         { immediate: true },

--- a/frontend/app/pages/ecart-normale.vue
+++ b/frontend/app/pages/ecart-normale.vue
@@ -29,7 +29,12 @@ const heroData = {
                 <SearchStation />
             </template>
             <template #chart>
-                <DeviationChart :adapter="selectBarAdapter" class="px-3 py-2" />
+                <ClientOnly>
+                    <DeviationChart
+                        :adapter="selectBarAdapter"
+                        class="px-3 py-2"
+                    />
+                </ClientOnly>
             </template>
         </ChartLayout>
     </UContainer>


### PR DESCRIPTION
## Type de PR
- [x] Bugfix
- [ ] Feature
- [ ] Refactor
- [ ] Chore / Tech debt
- [ ] Documentation
- [ ] Autre (à préciser)

## Objectif
Afficher les données du national et les données des stations sélectionnées sur les graph d'écart à la normale

## Contexte
#269 

## Changements
-

## Décisions techniques
<!-- Choix structurants, arbitrages, compromis. -->
<!-- Ce qui aurait pu être fait autrement. -->

## Impacts
- [ ] API / contrat
- [ ] Modèle de données / DB
- [ ] Calculs métier
- [ ] Performance
- [ ] Sécurité
- [ ] Infra / déploiement
- [ ] Aucun impact transverse identifié

## Tests
<!-- Décris ce qui a été fait dans cette PR pour vérifier le comportement introduit ou modifié. -->
- [ ] Tests unitaires
- [ ] Tests d’intégration
- [ ] Tests manuels
- [ ] Non applicable (à justifier)

## Points d’attention pour la review
<!-- Parties sensibles du code, dette technique introduite, risques. -->

## Suivi
- [ ] Migration à prévoir
- [ ] Documentation à mettre à jour
- [ ] Tâche(s) de suivi à créer
