### PR TITLE
records Table - adapt front to api model

### DIFF
--- a/frontend/app/components/table/records/RecordsFilterBar.vue
+++ b/frontend/app/components/table/records/RecordsFilterBar.vue
@@ -19,7 +19,7 @@ const filterFields: FilterField[] = [
 ];
 
 const store = useRecordsTableStore();
-const { filters, typeRecords } = storeToRefs(store);
+const { filters } = storeToRefs(store);
 const { setFilter, clearFilter } = store;
 
 const searchQuery = ref("");
@@ -137,24 +137,5 @@ const filterOptions = computed(() => {
         @clear="clearFilter"
         @search="onSearch"
         @load-more="onLoadMore"
-    >
-        <template #actions>
-            <UFieldGroup class="ml-auto">
-                <UButton
-                    class="cursor-pointer"
-                    color="neutral"
-                    :variant="typeRecords === 'hot' ? 'subtle' : 'outline'"
-                    label="Chaud"
-                    @click="typeRecords = 'hot'"
-                />
-                <UButton
-                    class="cursor-pointer"
-                    color="neutral"
-                    :variant="typeRecords === 'cold' ? 'subtle' : 'outline'"
-                    label="Froid"
-                    @click="typeRecords = 'cold'"
-                />
-            </UFieldGroup>
-        </template>
-    </FilterBar>
+    />
 </template>

--- a/frontend/app/components/table/records/recordsTable.vue
+++ b/frontend/app/components/table/records/recordsTable.vue
@@ -7,13 +7,20 @@ import { useRecordsTableStore } from "~/stores/recordsTableStore";
 import RecordsFilterBar from "~/components/table/records/RecordsFilterBar.vue";
 
 const store = useRecordsTableStore();
-const { page, pageSize, typeRecords, recordsData, pending, error } =
-    storeToRefs(store);
+const {
+    page,
+    pageSize,
+    typeRecords,
+    pagedStations,
+    filteredCount,
+    pending,
+    error,
+} = storeToRefs(store);
 
 // Track the record type that corresponds to the data currently displayed,
 // so the badge color only flips once the new data has arrived.
 const displayedTypeRecords = ref(typeRecords.value);
-watch(recordsData, () => {
+watch(pagedStations, () => {
     displayedTypeRecords.value = typeRecords.value;
 });
 
@@ -21,34 +28,20 @@ const temperatureBadgeColor = computed(() =>
     displayedTypeRecords.value === "hot" ? "error" : "info",
 );
 
-// station_ids and departments in the metadata are parallel arrays
-// zip them to derive the department for each station.
-const stationDeptMap = computed(() => {
-    const { station_ids = [], departments = [] } =
-        recordsData.value?.metadata ?? {};
-    return new Map(station_ids.map((id, i) => [id, departments[i]]));
-});
-
 interface TableRow {
     name: string;
-    departement: string | undefined;
-    record: number | undefined;
-    recordDate: string | undefined;
+    departement: string;
+    record: number;
+    recordDate: string;
 }
 
 const tableData = computed<TableRow[]>(() =>
-    (recordsData.value?.stations ?? []).map((s) => {
-        const record =
-            displayedTypeRecords.value === "cold"
-                ? s.cold_records[0]
-                : s.hot_records[0];
-        return {
-            name: s.name,
-            departement: stationDeptMap.value.get(s.id),
-            record: record?.value,
-            recordDate: record?.date,
-        };
-    }),
+    pagedStations.value.map((s) => ({
+        name: s.station_name,
+        departement: s.department,
+        record: s.record_value,
+        recordDate: s.record_date,
+    })),
 );
 
 const columns = computed<TableColumn<TableRow>[]>(() => [
@@ -94,7 +87,7 @@ const columns = computed<TableColumn<TableRow>[]>(() => [
         <div class="flex justify-center border-t border-accented pt-4">
             <UPagination
                 v-model:page="page"
-                :total="recordsData?.count ?? 0"
+                :total="filteredCount"
                 :items-per-page="pageSize"
             />
         </div>

--- a/frontend/app/components/table/records/recordsTable.vue
+++ b/frontend/app/components/table/records/recordsTable.vue
@@ -3,7 +3,10 @@ import type { TableColumn } from "@nuxt/ui";
 import { h } from "vue";
 import { UBadge } from "#components";
 import { storeToRefs } from "pinia";
-import { useRecordsTableStore } from "~/stores/recordsTableStore";
+import {
+    useRecordsTableStore,
+    periodOptions,
+} from "~/stores/recordsTableStore";
 import RecordsFilterBar from "~/components/table/records/RecordsFilterBar.vue";
 
 const store = useRecordsTableStore();
@@ -11,6 +14,7 @@ const {
     page,
     pageSize,
     typeRecords,
+    periodSelection,
     pagedStations,
     filteredCount,
     pending,
@@ -67,6 +71,28 @@ const columns = computed<TableColumn<TableRow>[]>(() => [
 
 <template>
     <div class="flex flex-col gap-4">
+        <!-- Controls: Période + Chaud/Froid -->
+        <div class="flex items-end gap-4">
+            <div class="flex flex-col gap-1">
+                <p class="text-sm text-muted">Période</p>
+                <USelect v-model="periodSelection" :items="periodOptions" />
+            </div>
+            <UButtonGroup>
+                <UButton
+                    color="neutral"
+                    :variant="typeRecords === 'hot' ? 'subtle' : 'outline'"
+                    label="Chaud"
+                    @click="typeRecords = 'hot'"
+                />
+                <UButton
+                    color="neutral"
+                    :variant="typeRecords === 'cold' ? 'subtle' : 'outline'"
+                    label="Froid"
+                    @click="typeRecords = 'cold'"
+                />
+            </UButtonGroup>
+        </div>
+
         <!-- Filter bar -->
         <RecordsFilterBar />
 

--- a/frontend/app/stores/recordsTableStore.ts
+++ b/frontend/app/stores/recordsTableStore.ts
@@ -4,6 +4,8 @@ import { departements } from "~/data/records/departements";
 import { dateToStringYMD } from "~/utils/date";
 import type {
     TypeRecords,
+    PeriodType,
+    Season,
     TemperatureRecordsParams,
     TemperatureRecordFlatEntry,
 } from "~/types/api";
@@ -23,6 +25,26 @@ type RecordsFilters = {
 
 const debounceDuration = 300;
 
+export const periodOptions = [
+    { value: "all_time", label: "Toute l'année" },
+    { value: "season_spring", label: "Printemps" },
+    { value: "season_summer", label: "Été" },
+    { value: "season_autumn", label: "Automne" },
+    { value: "season_winter", label: "Hiver" },
+    { value: "month_1", label: "Janvier" },
+    { value: "month_2", label: "Février" },
+    { value: "month_3", label: "Mars" },
+    { value: "month_4", label: "Avril" },
+    { value: "month_5", label: "Mai" },
+    { value: "month_6", label: "Juin" },
+    { value: "month_7", label: "Juillet" },
+    { value: "month_8", label: "Août" },
+    { value: "month_9", label: "Septembre" },
+    { value: "month_10", label: "Octobre" },
+    { value: "month_11", label: "Novembre" },
+    { value: "month_12", label: "Décembre" },
+];
+
 export const useRecordsTableStore = defineStore("recordsTableStore", () => {
     // Pagination
     const page = ref(1);
@@ -30,6 +52,7 @@ export const useRecordsTableStore = defineStore("recordsTableStore", () => {
 
     // Query shape
     const typeRecords = ref<TypeRecords>("hot");
+    const periodSelection = ref("all_time");
 
     // Filters
     const stationIds = ref<string[]>([]);
@@ -118,10 +141,43 @@ export const useRecordsTableStore = defineStore("recordsTableStore", () => {
     const debouncedDateStart = refDebounced(dateStart, debounceDuration);
     const debouncedDateEnd = refDebounced(dateEnd, debounceDuration);
 
-    // The API only supports type_records — all other filtering is client-side
-    const params = computed<TemperatureRecordsParams>(() => ({
-        type_records: typeRecords.value,
-    }));
+    // Build API params from periodSelection
+    const params = computed<TemperatureRecordsParams>(() => {
+        const result: TemperatureRecordsParams = {
+            type_records: typeRecords.value,
+        };
+
+        if (periodSelection.value.startsWith("season_")) {
+            result.period_type = "season" as PeriodType;
+            result.season = periodSelection.value.replace(
+                "season_",
+                "",
+            ) as Season;
+        } else if (periodSelection.value.startsWith("month_")) {
+            result.period_type = "month" as PeriodType;
+            result.month = parseInt(
+                periodSelection.value.replace("month_", ""),
+            );
+        }
+
+        return result;
+    });
+
+    // Reset page when API params or client-side filters change
+    watch(
+        [
+            params,
+            debouncedStationIds,
+            debouncedDepartments,
+            debouncedTempMin,
+            debouncedTempMax,
+            debouncedDateStart,
+            debouncedDateEnd,
+        ],
+        () => {
+            page.value = 1;
+        },
+    );
 
     const { data: rawRecords, pending, error } = useTemperatureRecords(params);
 
@@ -181,6 +237,7 @@ export const useRecordsTableStore = defineStore("recordsTableStore", () => {
         page,
         pageSize,
         typeRecords,
+        periodSelection,
         filters,
         staticOptions,
         setFilter,

--- a/frontend/app/stores/recordsTableStore.ts
+++ b/frontend/app/stores/recordsTableStore.ts
@@ -3,9 +3,9 @@ import { useTemperatureRecords } from "~/composables/useTemperature";
 import { departements } from "~/data/records/departements";
 import { dateToStringYMD } from "~/utils/date";
 import type {
-    RecordKind,
     TypeRecords,
     TemperatureRecordsParams,
+    TemperatureRecordFlatEntry,
 } from "~/types/api";
 import type {
     StringFilterValue,
@@ -30,7 +30,6 @@ export const useRecordsTableStore = defineStore("recordsTableStore", () => {
 
     // Query shape
     const typeRecords = ref<TypeRecords>("hot");
-    const recordKind = ref<RecordKind>("absolute");
 
     // Filters
     const stationIds = ref<string[]>([]);
@@ -76,6 +75,7 @@ export const useRecordsTableStore = defineStore("recordsTableStore", () => {
     });
 
     function setFilter(id: string, value: FilterValue) {
+        page.value = 1;
         if (value.type === "string") {
             if (id === "name") {
                 stationIds.value = value.values;
@@ -96,6 +96,7 @@ export const useRecordsTableStore = defineStore("recordsTableStore", () => {
     }
 
     function clearFilter(id: string) {
+        page.value = 1;
         if (id === "name") {
             stationIds.value = [];
         } else if (id === "departement") {
@@ -109,7 +110,7 @@ export const useRecordsTableStore = defineStore("recordsTableStore", () => {
         }
     }
 
-    // Debounce text inputs before sending to the API
+    // Debounce filter inputs before applying client-side filters
     const debouncedStationIds = refDebounced(stationIds, debounceDuration);
     const debouncedDepartments = refDebounced(departments, debounceDuration);
     const debouncedTempMin = refDebounced(temperatureMin, debounceDuration);
@@ -117,48 +118,75 @@ export const useRecordsTableStore = defineStore("recordsTableStore", () => {
     const debouncedDateStart = refDebounced(dateStart, debounceDuration);
     const debouncedDateEnd = refDebounced(dateEnd, debounceDuration);
 
-    const params = computed<TemperatureRecordsParams>(() => {
-        const result: TemperatureRecordsParams = {
-            type_records: typeRecords.value,
-            record_kind: recordKind.value,
-            limit: pageSize.value,
-            offset: (page.value - 1) * pageSize.value,
-        };
+    // The API only supports type_records — all other filtering is client-side
+    const params = computed<TemperatureRecordsParams>(() => ({
+        type_records: typeRecords.value,
+    }));
 
-        if (debouncedStationIds.value.length >= 1) {
-            result.station_ids = debouncedStationIds.value.join(",");
+    const { data: rawRecords, pending, error } = useTemperatureRecords(params);
+
+    // Group flat list by station, keeping the last record per station (= absolute record)
+    const absoluteRecords = computed<TemperatureRecordFlatEntry[]>(() => {
+        const stationMap = new Map<string, TemperatureRecordFlatEntry>();
+        for (const record of rawRecords.value ?? []) {
+            stationMap.set(record.station_id, record);
         }
-        if (debouncedDepartments.value.length >= 1) {
-            result.departments = debouncedDepartments.value.join(",");
+        return Array.from(stationMap.values());
+    });
+
+    // Apply client-side filters
+    const filteredRecords = computed<TemperatureRecordFlatEntry[]>(() => {
+        let result = absoluteRecords.value;
+
+        if (debouncedStationIds.value.length > 0) {
+            result = result.filter((r) =>
+                debouncedStationIds.value.includes(r.station_id),
+            );
+        }
+        if (debouncedDepartments.value.length > 0) {
+            result = result.filter((r) =>
+                debouncedDepartments.value.includes(r.department),
+            );
         }
         if (debouncedTempMin.value) {
-            result.temperature_min = Number(debouncedTempMin.value);
+            result = result.filter(
+                (r) => r.record_value >= Number(debouncedTempMin.value),
+            );
         }
         if (debouncedTempMax.value) {
-            result.temperature_max = Number(debouncedTempMax.value);
+            result = result.filter(
+                (r) => r.record_value <= Number(debouncedTempMax.value),
+            );
         }
         if (debouncedDateStart.value) {
-            result.date_start = dateToStringYMD(debouncedDateStart.value);
+            const start = dateToStringYMD(debouncedDateStart.value);
+            result = result.filter((r) => r.record_date >= start);
         }
         if (debouncedDateEnd.value) {
-            result.date_end = dateToStringYMD(debouncedDateEnd.value);
+            const end = dateToStringYMD(debouncedDateEnd.value);
+            result = result.filter((r) => r.record_date <= end);
         }
 
         return result;
     });
 
-    const { data: recordsData, pending, error } = useTemperatureRecords(params);
+    const filteredCount = computed(() => filteredRecords.value.length);
+
+    const pagedStations = computed<TemperatureRecordFlatEntry[]>(() => {
+        const start = (page.value - 1) * pageSize.value;
+        return filteredRecords.value.slice(start, start + pageSize.value);
+    });
 
     return {
         page,
         pageSize,
         typeRecords,
-        recordKind,
         filters,
         staticOptions,
         setFilter,
         clearFilter,
-        recordsData,
+        pagedStations,
+        filteredCount,
         pending,
         error,
     };

--- a/frontend/app/types/api.ts
+++ b/frontend/app/types/api.ts
@@ -138,35 +138,15 @@ export interface TemperatureRecordsParams {
     offset?: number;
 }
 
-export interface TemperatureRecordEntry {
-    value: number;
-    date: string;
+export interface TemperatureRecordFlatEntry {
+    station_id: string;
+    station_name: string;
+    department: string;
+    record_value: number;
+    record_date: string;
 }
 
-export interface TemperatureRecordStation {
-    id: string;
-    name: string;
-    hot_records: TemperatureRecordEntry[];
-    cold_records: TemperatureRecordEntry[];
-}
-
-export interface TemperatureRecordsMetadata {
-    date_start: string | null;
-    date_end: string | null;
-    record_kind: RecordKind;
-    record_scope: RecordScope;
-    type_records: TypeRecords;
-    station_ids: string[];
-    departments: string[];
-    temperature_min: number | null;
-    temperature_max: number | null;
-}
-
-export interface TemperatureRecordsResponse {
-    count: number;
-    metadata: TemperatureRecordsMetadata;
-    stations: TemperatureRecordStation[];
-}
+export type TemperatureRecordsResponse = TemperatureRecordFlatEntry[];
 
 // ===== API Error type =====
 

--- a/frontend/app/types/api.ts
+++ b/frontend/app/types/api.ts
@@ -123,11 +123,16 @@ export interface DeviationResponse {
 export type RecordKind = "historical" | "absolute";
 export type RecordScope = "monthly" | "seasonal" | "all_time";
 export type TypeRecords = "hot" | "cold" | "all";
+export type PeriodType = "all_time" | "season" | "month";
+export type Season = "spring" | "summer" | "autumn" | "winter";
 
 export interface TemperatureRecordsParams {
     record_kind?: RecordKind;
     record_scope?: RecordScope;
     type_records?: TypeRecords;
+    period_type?: PeriodType;
+    season?: Season;
+    month?: number;
     date_start?: string;
     date_end?: string;
     station_ids?: string;


### PR DESCRIPTION
## Type de PR
- [ ] Bugfix
- [x] Feature
- [ ] Refactor
- [ ] Chore / Tech debt
- [ ] Documentation
- [ ] Autre (à préciser)

## Objectif
Utiliser le nouvel endpoint temperature/records pour alimenter le tableau des records absolus 

## Contexte
Il existait déjà un tableau avec des données mocké

## Changements
- connexion au endpoint
- Le record absolu est récupéré en prenant le dernier record battu de la liste
- ajoute sélecteur de période (season or month or all)

<img width="1099" height="522" alt="image" src="https://github.com/user-attachments/assets/27b58a86-1d56-455c-ac0a-02617449b178" />


## Décisions techniques

## Impacts
- [ ] API / contrat
- [ ] Modèle de données / DB
- [ ] Calculs métier
- [x] Performance
- [ ] Sécurité
- [ ] Infra / déploiement
- [ ] Aucun impact transverse identifié

## Tests
<!-- Décris ce qui a été fait dans cette PR pour vérifier le comportement introduit ou modifié. -->
- [ ] Tests unitaires
- [ ] Tests d’intégration
- [x] Tests manuels
- [ ] Non applicable (à justifier)

## Points d’attention pour la review
<!-- Parties sensibles du code, dette technique introduite, risques. -->

## Suivi
- [ ] Migration à prévoir
- [ ] Documentation à mettre à jour
- [ ] Tâche(s) de suivi à créer
