### PR TITLE
fix bug interval Xtick et restaure affichage données calendar

### DIFF
--- a/frontend/app/composables/useDeviationCalendarOption.ts
+++ b/frontend/app/composables/useDeviationCalendarOption.ts
@@ -196,7 +196,12 @@ export function useDeviationCalendarOption(
     const series: SeriesOption[] = [];
     const titles: TitleOption[] = [];
 
-    const labelInterval = granularity === "day" ? 1 : 0;
+    // Cible ~12 labels max pour éviter le chevauchement sur les longues périodes
+    const maxLabels = granularity === "year" ? 15 : 12;
+    const labelInterval = Math.max(
+        0,
+        Math.ceil(xCategories.length / maxLabels) - 1,
+    );
     const labelRotate = granularity === "year" ? 0 : 45;
     const xAxisName = granularity === "year" ? "Année" : "Mois";
     const yAxisName = granularity === "year" ? "Mois" : "Jour";

--- a/frontend/app/stores/deviationStore.ts
+++ b/frontend/app/stores/deviationStore.ts
@@ -58,7 +58,12 @@ export const useDeviationStore = defineStore("deviationStore", () => {
     const params = computed<TemperatureDeviationGraphParams>(() => ({
         date_start: dateToStringYMD(pickedDateStart.value),
         date_end: dateToStringYMD(pickedDateEnd.value),
-        granularity: granularity.value,
+        granularity:
+            chartType.value === "calendar"
+                ? granularity.value === "month"
+                    ? "day" // calendrier mois → données journalières (y-axis = jours)
+                    : "month" // calendrier année → données mensuelles (y-axis = mois)
+                : granularity.value,
         station_ids: stationIds.value.join(","),
         include_national: includeNational.value,
     }));


### PR DESCRIPTION
## Type de PR
- [x] Bugfix
- [ ] Feature
- [ ] Refactor
- [ ] Chore / Tech debt
- [ ] Documentation
- [ ] Autre (à préciser)

## Objectif
espacer les Xtick du graph calendar
corriger bug affichage données calendar après rebase

## Contexte
bug story: https://github.com/dataforgoodfr/14_ValorisationDonneeMeteo/issues/303

## Changements
- ajoute exception spécifique calendar sur axe X et Y

## Décisions techniques
<!-- Choix structurants, arbitrages, compromis. -->
<!-- Ce qui aurait pu être fait autrement. -->

## Impacts
- [ ] API / contrat
- [ ] Modèle de données / DB
- [ ] Calculs métier
- [ ] Performance
- [ ] Sécurité
- [ ] Infra / déploiement
- [ ] Aucun impact transverse identifié

## Tests
<!-- Décris ce qui a été fait dans cette PR pour vérifier le comportement introduit ou modifié. -->
- [ ] Tests unitaires
- [ ] Tests d’intégration
- [x] Tests manuels
- [ ] Non applicable (à justifier)

## Points d’attention pour la review
<!-- Parties sensibles du code, dette technique introduite, risques. -->

## Suivi
- [ ] Migration à prévoir
- [ ] Documentation à mettre à jour
- [ ] Tâche(s) de suivi à créer
