### PR TITLE
Feat/back/deviation graph with analysis period

### DIFF
--- a/backend/openapi/target-specs/openapi.yaml
+++ b/backend/openapi/target-specs/openapi.yaml
@@ -250,6 +250,22 @@ paths:
         Récupère les données d'écart de température par rapport à la normale (baseline fixe 1991-2020).
         Permet de comparer l'écart à la normale moyen en France avec celui de stations spécifiques.
         La granularité temporelle est ajustable (jour, mois, année) pour s'adapter à l'axe des abscisses.
+        Un filtre intra-période optionnel est contrôlé par `slice_type` et paramètres associés.
+
+          Combinaisons valides (validation côté API) :
+
+          - granularity=year :
+            - slice_type=full (défaut) : agrégat sur l'année complète
+            - slice_type=month_of_year : agrégat sur un mois donné (month_of_year requis)
+            - slice_type=day_of_month : échantillon sur un jour précis de l'année (month_of_year + day_of_month requis)
+          - granularity=month :
+            - slice_type=full (défaut) : agrégat sur le mois complet
+            - slice_type=day_of_month : échantillon sur le N-ième jour de chaque mois (day_of_month requis)
+          - granularity=day :
+            - slice_type=full uniquement (slice_type doit être absent ou full)
+
+          Règle "jours inexistants" :
+          - si day_of_month n'existe pas dans un mois (ex: 30/02, 31/04), le dernier jour du mois est utilisé.
       operationId: getTemperatureDeviationGraph
       tags:
         - Temperature
@@ -310,6 +326,45 @@ paths:
             Si ce paramètre vaut 'true', la propriété `national` est présente dans la réponse.
             Si ce paramètre est défini à 'false', et que 'station_ids' est absent ou vide, l'API retourne une erreur 400.
 
+        - name: slice_type
+          in: query
+          required: false
+          schema:
+            type: string
+            enum: [ full, month_of_year, day_of_month ]
+            default: full
+          description: >
+            Filtre intra-période appliqué à chaque période (selon `granularity`).
+            - full : agrégat sur toute la période (défaut)
+            - month_of_year : agrégat sur un mois spécifique de l’année (month_of_year requis, granularity=year)
+            - day_of_month : échantillon sur un jour du mois (day_of_month requis, et si granularity=year alors month_of_year requis)
+
+        - name: month_of_year
+          in: query
+          required: false
+          schema:
+            type: integer
+            minimum: 1
+            maximum: 12
+          description: >
+            Mois concerné (1..12).
+            Requis si slice_type=month_of_year.
+            Requis aussi si slice_type=day_of_month ET granularity=year (pour exprimer un jour précis de l’année).
+          example: 1
+
+        - name: day_of_month
+          in: query
+          required: false
+          schema:
+            type: integer
+            minimum: 1
+            maximum: 31
+          description: >
+            Jour du mois concerné (1..31).
+            Requis si slice_type=day_of_month.
+            Si le jour n'existe pas dans un mois, le dernier jour du mois est utilisé.
+          example: 29
+
       responses:
         "200":
           description: Séries temporelles de l'écart à la normale pour la moyenne nationale (optionnelle) et les stations demandées.
@@ -326,6 +381,7 @@ paths:
                       date_end: "2025-02-02"
                       baseline: "1991-2020"
                       granularity: "day"
+                      slice_type: "full"
                     national:
                       data:
                         - date: "2025-02-01"
@@ -364,9 +420,10 @@ paths:
                   value:
                     metadata:
                       date_start: "2025-02-01"
-                      date_end: "2025-02-28"
+                      date_end: "2025-02-02"
                       baseline: "1991-2020"
                       granularity: "day"
+                      slice_type: "full"
                     stations:
                       - station_id: "07149"
                         station_name: "Orly"
@@ -375,6 +432,34 @@ paths:
                             deviation: 0.8
                             temperature: 7.9
                             baseline_mean: 7.1
+                yearly_february_slice:
+                  summary: Agrégation annuelle limitée au mois de février
+                  value:
+                    metadata:
+                      date_start: "2020-01-01"
+                      date_end: "2025-12-31"
+                      baseline: "1991-2020"
+                      granularity: "year"
+                      slice_type: "month_of_year"
+                      month_of_year: 2
+                    national:
+                      data:
+                        - date: "2020-02-01"
+                          deviation: 1.1
+                          temperature: 8.3
+                          baseline_mean: 7.2
+                        - date: "2021-02-01"
+                          deviation: 0.7
+                          temperature: 7.9
+                          baseline_mean: 7.2
+                    stations:
+                      - station_id: "07149"
+                        station_name: "Orly"
+                        data:
+                          - date: "2020-02-01"
+                            deviation: 0.9
+                            temperature: 7.8
+                            baseline_mean: 6.9
         "400":
           $ref: "#/components/responses/BadRequest"
 
@@ -993,6 +1078,14 @@ components:
         date:
           type: string
           format: date
+          description: |
+            Date du point de données.
+            - granularity=year, slice_type=full: premier jour de l'année (ex: "2024-01-01")
+            - granularity=year, slice_type=month_of_year: premier jour du mois sélectionné (ex: "2024-02-01")
+            - granularity=year, slice_type=day_of_month: date exacte du jour sélectionné (ex: "2024-02-29")
+            - granularity=month, slice_type=full: premier jour du mois
+            - granularity=month, slice_type=day_of_month: date exacte du jour sélectionné
+            - granularity=day: date exacte du jour
         deviation:
           type: number
           format: float
@@ -1000,11 +1093,11 @@ components:
         temperature:
           type: number
           format: float
-          description: "Température moyenne observée sur la période"
+          description: "Température observée (moyenne ou valeur selon slice_type)"
         baseline_mean:
           type: number
           format: float
-          description: "Température moyenne de référence 1991-2020 pour cette période"
+          description: "Température de référence 1991-2020 pour ce point (moyenne ou valeur selon slice_type)"
 
     NationalTemperatureDeviationSeries:
       type: object
@@ -1049,6 +1142,7 @@ components:
             - date_end
             - baseline
             - granularity
+            - slice_type
           properties:
             date_start:
               type: string
@@ -1062,8 +1156,25 @@ components:
               example: "1991-2020"
             granularity:
               type: string
-              enum: [year, month, day]
+              enum: [ year, month, day ]
               description: "Granularité de la série (axe X)."
+            slice_type:
+              type: string
+              enum: [ full, month_of_year, day_of_month ]
+              description: "Filtre intra-période appliqué à chaque période."
+              example: full
+            month_of_year:
+              type: integer
+              minimum: 1
+              maximum: 12
+              description: "Mois concerné si slice_type=month_of_year, ou si slice_type=day_of_month & granularity=year."
+            day_of_month:
+              type: integer
+              minimum: 1
+              maximum: 31
+              description: >
+                Jour du mois concerné si slice_type=day_of_month.
+                Si le jour n'existe pas dans un mois, le dernier jour du mois est utilisé.
         national:
           $ref: "#/components/schemas/NationalTemperatureDeviationSeries"
         stations:

--- a/backend/weather/data_sources/temperature_deviation_fake.py
+++ b/backend/weather/data_sources/temperature_deviation_fake.py
@@ -145,14 +145,20 @@ class FakeTemperatureDeviationDailyDataSource(TemperatureDeviationDailyDataSourc
         self, query: DailyDeviationSeriesQuery
     ) -> list[ObservedPoint]:
         rng = random.Random(self._seed)
-        days = tuple(iter_days_intersecting(query.date_start, query.date_end))
+        if query.target_dates is not None:
+            days = tuple(sorted(query.target_dates))
+        else:
+            days = tuple(iter_days_intersecting(query.date_start, query.date_end))
 
         return [_generate_national_observed_point(day=d, rng=rng) for d in days]
 
     def fetch_stations_daily_series(
         self, query: DailyDeviationSeriesQuery
     ) -> list[StationDailySeries]:
-        days = tuple(iter_days_intersecting(query.date_start, query.date_end))
+        if query.target_dates is not None:
+            days = tuple(sorted(query.target_dates))
+        else:
+            days = tuple(iter_days_intersecting(query.date_start, query.date_end))
         out: list[StationDailySeries] = []
 
         for station_id in query.station_ids:

--- a/backend/weather/data_sources/timescale.py
+++ b/backend/weather/data_sources/timescale.py
@@ -233,13 +233,17 @@ class TimescaleTemperatureDeviationDailyDataSource(
 
         baseline_sq = self._baseline_subquery()
 
+        qs = QuotidienneITN.objects.filter(
+            date__gte=query.date_start,
+            date__lte=query.date_end,
+            station_code__in=query.station_ids,
+        )
+
+        if query.target_dates is not None:
+            qs = qs.filter(date__in=query.target_dates)
+
         rows = (
-            QuotidienneITN.objects.filter(
-                date__gte=query.date_start,
-                date__lte=query.date_end,
-                station_code__in=query.station_ids,
-            )
-            .annotate(
+            qs.annotate(
                 month=ExtractMonth("date"),
                 day=ExtractDay("date"),
             )
@@ -287,7 +291,7 @@ class TimescaleTemperatureDeviationDailyDataSource(
                 DailySeriesQuery(
                     date_start=query.date_start,
                     date_end=query.date_end,
-                    target_dates=None,
+                    target_dates=query.target_dates,
                 )
             )
         )

--- a/backend/weather/serializers.py
+++ b/backend/weather/serializers.py
@@ -213,6 +213,87 @@ class TemperatureDeviationGraphQuerySerializer(serializers.Serializer):
     station_ids = CommaSeparatedStringListField(required=False)
     include_national = serializers.BooleanField(required=False, default=True)
 
+    def _validate_day_granularity_slice_constraints(
+        self,
+        *,
+        slice_type: str,
+        month_of_year: int | None,
+        day_of_month: int | None,
+    ) -> None:
+        if slice_type != "full":
+            raise serializers.ValidationError(
+                {"slice_type": "Interdit si granularity=day (doit être full)."}
+            )
+        if month_of_year is not None:
+            raise serializers.ValidationError(
+                {"month_of_year": "Interdit si granularity=day."}
+            )
+        if day_of_month is not None:
+            raise serializers.ValidationError(
+                {"day_of_month": "Interdit si granularity=day."}
+            )
+
+    def _validate_full_slice_constraints(
+        self,
+        *,
+        month_of_year: int | None,
+        day_of_month: int | None,
+    ) -> None:
+        if month_of_year is not None:
+            raise serializers.ValidationError(
+                {"month_of_year": "Interdit si slice_type=full."}
+            )
+        if day_of_month is not None:
+            raise serializers.ValidationError(
+                {"day_of_month": "Interdit si slice_type=full."}
+            )
+
+    def _validate_month_of_year_slice_constraints(
+        self,
+        *,
+        granularity: str,
+        month_of_year: int | None,
+        day_of_month: int | None,
+    ) -> None:
+        if granularity != "year":
+            raise serializers.ValidationError(
+                {"slice_type": "month_of_year n'est valide que si granularity=year."}
+            )
+        if month_of_year is None:
+            raise serializers.ValidationError(
+                {"month_of_year": "Requis si slice_type=month_of_year."}
+            )
+        if day_of_month is not None:
+            raise serializers.ValidationError(
+                {"day_of_month": "Interdit si slice_type=month_of_year."}
+            )
+
+    def _validate_day_of_month_slice_constraints(
+        self,
+        *,
+        granularity: str,
+        month_of_year: int | None,
+        day_of_month: int | None,
+    ) -> None:
+        if day_of_month is None:
+            raise serializers.ValidationError(
+                {"day_of_month": "Requis si slice_type=day_of_month."}
+            )
+
+        if granularity == "year":
+            if month_of_year is None:
+                raise serializers.ValidationError(
+                    {
+                        "month_of_year": "Requis si granularity=year et slice_type=day_of_month."
+                    }
+                )
+        else:
+            # granularity=month
+            if month_of_year is not None:
+                raise serializers.ValidationError(
+                    {"month_of_year": "Interdit si granularity=month."}
+                )
+
     def validate(self, attrs):
         date_start = attrs["date_start"]
         date_end = attrs["date_end"]
@@ -228,65 +309,32 @@ class TemperatureDeviationGraphQuerySerializer(serializers.Serializer):
 
         # granularity=day => slice_type doit être full + pas de month/day selectors
         if granularity == "day":
-            if slice_type != "full":
-                raise serializers.ValidationError(
-                    {"slice_type": "Interdit si granularity=day (doit être full)."}
-                )
-            if month_of_year is not None:
-                raise serializers.ValidationError(
-                    {"month_of_year": "Interdit si granularity=day."}
-                )
-            if day_of_month is not None:
-                raise serializers.ValidationError(
-                    {"day_of_month": "Interdit si granularity=day."}
-                )
+            self._validate_day_granularity_slice_constraints(
+                slice_type=slice_type,
+                month_of_year=month_of_year,
+                day_of_month=day_of_month,
+            )
 
         elif slice_type == "full":
-            if month_of_year is not None:
-                raise serializers.ValidationError(
-                    {"month_of_year": "Interdit si slice_type=full."}
-                )
-            if day_of_month is not None:
-                raise serializers.ValidationError(
-                    {"day_of_month": "Interdit si slice_type=full."}
-                )
+            self._validate_full_slice_constraints(
+                month_of_year=month_of_year,
+                day_of_month=day_of_month,
+            )
 
         elif slice_type == "month_of_year":
-            if granularity != "year":
-                raise serializers.ValidationError(
-                    {
-                        "slice_type": "month_of_year n'est valide que si granularity=year."
-                    }
-                )
-            if month_of_year is None:
-                raise serializers.ValidationError(
-                    {"month_of_year": "Requis si slice_type=month_of_year."}
-                )
-            if day_of_month is not None:
-                raise serializers.ValidationError(
-                    {"day_of_month": "Interdit si slice_type=month_of_year."}
-                )
+            self._validate_month_of_year_slice_constraints(
+                granularity=granularity,
+                month_of_year=month_of_year,
+                day_of_month=day_of_month,
+            )
 
         else:
             # slice_type == "day_of_month"
-            if day_of_month is None:
-                raise serializers.ValidationError(
-                    {"day_of_month": "Requis si slice_type=day_of_month."}
-                )
-
-            if granularity == "year":
-                if month_of_year is None:
-                    raise serializers.ValidationError(
-                        {
-                            "month_of_year": "Requis si granularity=year et slice_type=day_of_month."
-                        }
-                    )
-            else:
-                # granularity=month => month_of_year interdit
-                if month_of_year is not None:
-                    raise serializers.ValidationError(
-                        {"month_of_year": "Interdit si granularity=month."}
-                    )
+            self._validate_day_of_month_slice_constraints(
+                granularity=granularity,
+                month_of_year=month_of_year,
+                day_of_month=day_of_month,
+            )
 
         station_ids = attrs.get("station_ids", ())
         include_national = attrs.get("include_national", True)

--- a/backend/weather/serializers.py
+++ b/backend/weather/serializers.py
@@ -200,16 +200,93 @@ class TemperatureDeviationGraphQuerySerializer(serializers.Serializer):
     granularity = serializers.ChoiceField(
         choices=["year", "month", "day"], required=True
     )
+
+    slice_type = serializers.ChoiceField(
+        choices=["full", "month_of_year", "day_of_month"],
+        required=False,
+        default="full",
+    )
+
+    month_of_year = serializers.IntegerField(required=False, min_value=1, max_value=12)
+    day_of_month = serializers.IntegerField(required=False, min_value=1, max_value=31)
+
     station_ids = CommaSeparatedStringListField(required=False)
     include_national = serializers.BooleanField(required=False, default=True)
 
     def validate(self, attrs):
-        ds = attrs["date_start"]
-        de = attrs["date_end"]
-        if ds > de:
+        date_start = attrs["date_start"]
+        date_end = attrs["date_end"]
+        if date_start > date_end:
             raise serializers.ValidationError(
                 {"date_end": "date_end doit être >= date_start."}
             )
+
+        granularity = attrs["granularity"]
+        slice_type = attrs.get("slice_type", "full")
+        month_of_year = attrs.get("month_of_year")
+        day_of_month = attrs.get("day_of_month")
+
+        # granularity=day => slice_type doit être full + pas de month/day selectors
+        if granularity == "day":
+            if slice_type != "full":
+                raise serializers.ValidationError(
+                    {"slice_type": "Interdit si granularity=day (doit être full)."}
+                )
+            if month_of_year is not None:
+                raise serializers.ValidationError(
+                    {"month_of_year": "Interdit si granularity=day."}
+                )
+            if day_of_month is not None:
+                raise serializers.ValidationError(
+                    {"day_of_month": "Interdit si granularity=day."}
+                )
+
+        elif slice_type == "full":
+            if month_of_year is not None:
+                raise serializers.ValidationError(
+                    {"month_of_year": "Interdit si slice_type=full."}
+                )
+            if day_of_month is not None:
+                raise serializers.ValidationError(
+                    {"day_of_month": "Interdit si slice_type=full."}
+                )
+
+        elif slice_type == "month_of_year":
+            if granularity != "year":
+                raise serializers.ValidationError(
+                    {
+                        "slice_type": "month_of_year n'est valide que si granularity=year."
+                    }
+                )
+            if month_of_year is None:
+                raise serializers.ValidationError(
+                    {"month_of_year": "Requis si slice_type=month_of_year."}
+                )
+            if day_of_month is not None:
+                raise serializers.ValidationError(
+                    {"day_of_month": "Interdit si slice_type=month_of_year."}
+                )
+
+        else:
+            # slice_type == "day_of_month"
+            if day_of_month is None:
+                raise serializers.ValidationError(
+                    {"day_of_month": "Requis si slice_type=day_of_month."}
+                )
+
+            if granularity == "year":
+                if month_of_year is None:
+                    raise serializers.ValidationError(
+                        {
+                            "month_of_year": "Requis si granularity=year et slice_type=day_of_month."
+                        }
+                    )
+            else:
+                # granularity=month => month_of_year interdit
+                if month_of_year is not None:
+                    raise serializers.ValidationError(
+                        {"month_of_year": "Interdit si granularity=month."}
+                    )
 
         station_ids = attrs.get("station_ids", ())
         include_national = attrs.get("include_national", True)
@@ -245,6 +322,11 @@ class TemperatureDeviationMetadataSerializer(serializers.Serializer):
     date_end = serializers.DateField()
     baseline = serializers.CharField()
     granularity = serializers.ChoiceField(choices=["year", "month", "day"])
+    slice_type = serializers.ChoiceField(
+        choices=["full", "month_of_year", "day_of_month"]
+    )
+    month_of_year = serializers.IntegerField(required=False, min_value=1, max_value=12)
+    day_of_month = serializers.IntegerField(required=False, min_value=1, max_value=31)
 
 
 class TemperatureDeviationResponseSerializer(serializers.Serializer):

--- a/backend/weather/services/temperature_deviation/aggregation.py
+++ b/backend/weather/services/temperature_deviation/aggregation.py
@@ -1,0 +1,167 @@
+import datetime as dt
+
+from weather.utils.date_range import (
+    iter_month_starts_intersecting,
+    iter_year_starts_intersecting,
+)
+
+from .types import (
+    AggregatedDeviationPoint,
+    DailyDeviationPoint,
+    ObservedPoint,
+)
+
+
+def _mean(values: list[float]) -> float:
+    return sum(values) / len(values)
+
+
+def aggregate_observed(
+    points: list[ObservedPoint],
+    *,
+    date_start: dt.date,
+    date_end: dt.date,
+    granularity: str,
+    slice_type: str,
+    month_of_year: int | None = None,
+) -> list[ObservedPoint]:
+    """
+    Agrégation nationale (température seule).
+    """
+
+    if granularity == "day":
+        return points
+
+    # cas slicing déjà 1 point / bucket
+    if granularity == "month" and slice_type == "day_of_month":
+        return points
+
+    if granularity == "year" and slice_type == "day_of_month":
+        return points
+
+    if granularity == "month":
+        out: list[ObservedPoint] = []
+        for month_start in iter_month_starts_intersecting(date_start, date_end):
+            y, m = month_start.year, month_start.month
+            bucket = [p for p in points if p.date.year == y and p.date.month == m]
+            if not bucket:
+                continue
+
+            out.append(
+                ObservedPoint(
+                    date=dt.date(y, m, 1),
+                    temperature=_mean([p.temperature for p in bucket]),
+                )
+            )
+        return out
+
+    # year
+    out: list[ObservedPoint] = []
+    for year_start in iter_year_starts_intersecting(date_start, date_end):
+        y = year_start.year
+        bucket = [p for p in points if p.date.year == y]
+        if not bucket:
+            continue
+
+        if slice_type == "month_of_year":
+            if month_of_year is None:
+                raise ValueError("month_of_year ne doit pas être None")
+            anchor = dt.date(y, month_of_year, 1)
+        else:
+            anchor = dt.date(y, 1, 1)
+
+        out.append(
+            ObservedPoint(
+                date=anchor,
+                temperature=_mean([p.temperature for p in bucket]),
+            )
+        )
+
+    return out
+
+
+def aggregate_station_daily(
+    points: list[DailyDeviationPoint],
+    *,
+    date_start: dt.date,
+    date_end: dt.date,
+    granularity: str,
+    slice_type: str,
+    month_of_year: int | None = None,
+) -> list[AggregatedDeviationPoint]:
+    """
+    Agrégation station avec baseline.
+    """
+
+    if granularity == "day":
+        return [
+            AggregatedDeviationPoint(
+                date=p.date,
+                temperature=p.temperature,
+                baseline_mean=p.baseline_mean,
+            )
+            for p in points
+        ]
+
+    # slicing => déjà 1 point par bucket
+    if granularity == "month" and slice_type == "day_of_month":
+        return [
+            AggregatedDeviationPoint(
+                date=p.date,
+                temperature=p.temperature,
+                baseline_mean=p.baseline_mean,
+            )
+            for p in points
+        ]
+
+    if granularity == "year" and slice_type == "day_of_month":
+        return [
+            AggregatedDeviationPoint(
+                date=p.date,
+                temperature=p.temperature,
+                baseline_mean=p.baseline_mean,
+            )
+            for p in points
+        ]
+
+    if granularity == "month":
+        out: list[AggregatedDeviationPoint] = []
+        for month_start in iter_month_starts_intersecting(date_start, date_end):
+            y, m = month_start.year, month_start.month
+            bucket = [p for p in points if p.date.year == y and p.date.month == m]
+            if not bucket:
+                continue
+
+            out.append(
+                AggregatedDeviationPoint(
+                    date=dt.date(y, m, 1),
+                    temperature=_mean([p.temperature for p in bucket]),
+                    baseline_mean=_mean([p.baseline_mean for p in bucket]),
+                )
+            )
+        return out
+
+    # year
+    out: list[AggregatedDeviationPoint] = []
+    for year_start in iter_year_starts_intersecting(date_start, date_end):
+        y = year_start.year
+        bucket = [p for p in points if p.date.year == y]
+        if not bucket:
+            continue
+
+        if slice_type == "month_of_year":
+            if month_of_year is None:
+                raise ValueError("month_of_year ne doit pas être None")
+            anchor = dt.date(y, month_of_year, 1)
+        else:
+            anchor = dt.date(y, 1, 1)
+
+        out.append(
+            AggregatedDeviationPoint(
+                date=anchor,
+                temperature=_mean([p.temperature for p in bucket]),
+                baseline_mean=_mean([p.baseline_mean for p in bucket]),
+            )
+        )
+
+    return out

--- a/backend/weather/services/temperature_deviation/aggregation.py
+++ b/backend/weather/services/temperature_deviation/aggregation.py
@@ -16,6 +16,78 @@ def _mean(values: list[float]) -> float:
     return sum(values) / len(values)
 
 
+def _aggregate_monthly_observed(
+    points: list[ObservedPoint],
+    *,
+    date_start: dt.date,
+    date_end: dt.date,
+) -> list[ObservedPoint]:
+    out: list[ObservedPoint] = []
+
+    for month_start in iter_month_starts_intersecting(date_start, date_end):
+        year = month_start.year
+        month = month_start.month
+
+        bucket = [p for p in points if p.date.year == year and p.date.month == month]
+        if not bucket:
+            continue
+
+        out.append(
+            ObservedPoint(
+                date=dt.date(year, month, 1),
+                temperature=_mean([p.temperature for p in bucket]),
+            )
+        )
+
+    return out
+
+
+def _year_anchor_date(
+    *,
+    year: int,
+    slice_type: str,
+    month_of_year: int | None,
+) -> dt.date:
+    if slice_type == "month_of_year":
+        if month_of_year is None:
+            raise ValueError("month_of_year ne doit pas être None")
+        return dt.date(year, month_of_year, 1)
+
+    return dt.date(year, 1, 1)
+
+
+def _aggregate_yearly_observed(
+    points: list[ObservedPoint],
+    *,
+    date_start: dt.date,
+    date_end: dt.date,
+    slice_type: str,
+    month_of_year: int | None = None,
+) -> list[ObservedPoint]:
+    out: list[ObservedPoint] = []
+
+    for year_start in iter_year_starts_intersecting(date_start, date_end):
+        year = year_start.year
+        bucket = [p for p in points if p.date.year == year]
+        if not bucket:
+            continue
+
+        anchor = _year_anchor_date(
+            year=year,
+            slice_type=slice_type,
+            month_of_year=month_of_year,
+        )
+
+        out.append(
+            ObservedPoint(
+                date=anchor,
+                temperature=_mean([p.temperature for p in bucket]),
+            )
+        )
+
+    return out
+
+
 def aggregate_observed(
     points: list[ObservedPoint],
     *,
@@ -40,40 +112,76 @@ def aggregate_observed(
         return points
 
     if granularity == "month":
-        out: list[ObservedPoint] = []
-        for month_start in iter_month_starts_intersecting(date_start, date_end):
-            y, m = month_start.year, month_start.month
-            bucket = [p for p in points if p.date.year == y and p.date.month == m]
-            if not bucket:
-                continue
-
-            out.append(
-                ObservedPoint(
-                    date=dt.date(y, m, 1),
-                    temperature=_mean([p.temperature for p in bucket]),
-                )
-            )
-        return out
+        return _aggregate_monthly_observed(
+            points,
+            date_start=date_start,
+            date_end=date_end,
+        )
 
     # year
-    out: list[ObservedPoint] = []
-    for year_start in iter_year_starts_intersecting(date_start, date_end):
-        y = year_start.year
-        bucket = [p for p in points if p.date.year == y]
+    return _aggregate_yearly_observed(
+        points,
+        date_start=date_start,
+        date_end=date_end,
+        slice_type=slice_type,
+        month_of_year=month_of_year,
+    )
+
+
+def _aggregate_monthly_station(
+    points: list[DailyDeviationPoint],
+    *,
+    date_start: dt.date,
+    date_end: dt.date,
+) -> list[AggregatedDeviationPoint]:
+    out: list[AggregatedDeviationPoint] = []
+
+    for month_start in iter_month_starts_intersecting(date_start, date_end):
+        year = month_start.year
+        month = month_start.month
+
+        bucket = [p for p in points if p.date.year == year and p.date.month == month]
         if not bucket:
             continue
 
-        if slice_type == "month_of_year":
-            if month_of_year is None:
-                raise ValueError("month_of_year ne doit pas être None")
-            anchor = dt.date(y, month_of_year, 1)
-        else:
-            anchor = dt.date(y, 1, 1)
+        out.append(
+            AggregatedDeviationPoint(
+                date=dt.date(year, month, 1),
+                temperature=_mean([p.temperature for p in bucket]),
+                baseline_mean=_mean([p.baseline_mean for p in bucket]),
+            )
+        )
+
+    return out
+
+
+def _aggregate_yearly_station(
+    points: list[DailyDeviationPoint],
+    *,
+    date_start: dt.date,
+    date_end: dt.date,
+    slice_type: str,
+    month_of_year: int | None = None,
+) -> list[AggregatedDeviationPoint]:
+    out: list[AggregatedDeviationPoint] = []
+
+    for year_start in iter_year_starts_intersecting(date_start, date_end):
+        year = year_start.year
+        bucket = [p for p in points if p.date.year == year]
+        if not bucket:
+            continue
+
+        anchor = _year_anchor_date(
+            year=year,
+            slice_type=slice_type,
+            month_of_year=month_of_year,
+        )
 
         out.append(
-            ObservedPoint(
+            AggregatedDeviationPoint(
                 date=anchor,
                 temperature=_mean([p.temperature for p in bucket]),
+                baseline_mean=_mean([p.baseline_mean for p in bucket]),
             )
         )
 
@@ -125,43 +233,17 @@ def aggregate_station_daily(
         ]
 
     if granularity == "month":
-        out: list[AggregatedDeviationPoint] = []
-        for month_start in iter_month_starts_intersecting(date_start, date_end):
-            y, m = month_start.year, month_start.month
-            bucket = [p for p in points if p.date.year == y and p.date.month == m]
-            if not bucket:
-                continue
-
-            out.append(
-                AggregatedDeviationPoint(
-                    date=dt.date(y, m, 1),
-                    temperature=_mean([p.temperature for p in bucket]),
-                    baseline_mean=_mean([p.baseline_mean for p in bucket]),
-                )
-            )
-        return out
-
-    # year
-    out: list[AggregatedDeviationPoint] = []
-    for year_start in iter_year_starts_intersecting(date_start, date_end):
-        y = year_start.year
-        bucket = [p for p in points if p.date.year == y]
-        if not bucket:
-            continue
-
-        if slice_type == "month_of_year":
-            if month_of_year is None:
-                raise ValueError("month_of_year ne doit pas être None")
-            anchor = dt.date(y, month_of_year, 1)
-        else:
-            anchor = dt.date(y, 1, 1)
-
-        out.append(
-            AggregatedDeviationPoint(
-                date=anchor,
-                temperature=_mean([p.temperature for p in bucket]),
-                baseline_mean=_mean([p.baseline_mean for p in bucket]),
-            )
+        return _aggregate_monthly_station(
+            points,
+            date_start=date_start,
+            date_end=date_end,
         )
 
-    return out
+    # year
+    return _aggregate_yearly_station(
+        points,
+        date_start=date_start,
+        date_end=date_end,
+        slice_type=slice_type,
+        month_of_year=month_of_year,
+    )

--- a/backend/weather/services/temperature_deviation/service.py
+++ b/backend/weather/services/temperature_deviation/service.py
@@ -4,16 +4,28 @@ import datetime as dt
 from collections import defaultdict
 
 from weather.utils.date_range import (
+    days_in_month_in_range,
     iter_days_intersecting,
     iter_month_starts_intersecting,
     iter_year_starts_intersecting,
+    monthly_points_in_range,
     period_start,
+    yearly_points_in_range,
 )
 
+from .aggregation import (
+    aggregate_observed,
+    aggregate_station_daily,
+)
 from .protocols import (
     TemperatureDeviationDailyDataSource,
     TemperatureDeviationOverviewDataSource,
 )
+from .slicing import (
+    apply_slice_to_observed,
+    apply_slice_to_station_daily,
+)
+from .source_window import compute_source_window
 from .types import (
     AggregatedDeviationPoint,
     DailyDeviationPoint,
@@ -291,19 +303,87 @@ def serialize_temperature_deviation_result(
     return payload
 
 
+def compute_target_dates(
+    *,
+    date_start: dt.date,
+    date_end: dt.date,
+    granularity: str,
+    slice_type: str,
+    month_of_year: int | None,
+    day_of_month: int | None,
+) -> tuple[dt.date, ...] | None:
+    if slice_type == "full":
+        return None
+
+    if slice_type == "month_of_year":
+        if month_of_year is None:
+            raise ValueError("month_of_year ne doit pas être None")
+
+        return tuple(
+            days_in_month_in_range(
+                date_start=date_start,
+                date_end=date_end,
+                month=month_of_year,
+            )
+        )
+
+    if day_of_month is None:
+        raise ValueError("day_of_month ne doit pas être None")
+
+    if granularity == "month":
+        return tuple(
+            monthly_points_in_range(
+                date_start=date_start,
+                date_end=date_end,
+                day_of_month=day_of_month,
+            )
+        )
+
+    if granularity == "year":
+        if month_of_year is None:
+            raise ValueError("month_of_year ne doit pas être None")
+
+        return tuple(
+            yearly_points_in_range(
+                date_start=date_start,
+                date_end=date_end,
+                month=month_of_year,
+                day_of_month=day_of_month,
+            )
+        )
+
+    raise ValueError(
+        f"Combinaison invalide granularity={granularity}, slice_type={slice_type}"
+    )
+
+
 def compute_temperature_deviation_series(
     *,
     data_source: TemperatureDeviationDailyDataSource,
     date_start: dt.date,
     date_end: dt.date,
     granularity: str,
+    slice_type: str = "full",
+    month_of_year: int | None = None,
+    day_of_month: int | None = None,
     station_ids: tuple[str, ...] = (),
     include_national: bool = True,
 ) -> TemperatureDeviationResult:
-    src_start, src_end = _compute_source_window(
+    src_start, src_end = compute_source_window(
         date_start=date_start,
         date_end=date_end,
         granularity=granularity,
+        slice_type=slice_type,
+        month_of_year=month_of_year,
+    )
+
+    target_dates = compute_target_dates(
+        date_start=src_start,
+        date_end=src_end,
+        granularity=granularity,
+        slice_type=slice_type,
+        month_of_year=month_of_year,
+        day_of_month=day_of_month,
     )
 
     query = DailyDeviationSeriesQuery(
@@ -311,35 +391,95 @@ def compute_temperature_deviation_series(
         date_end=src_end,
         station_ids=station_ids,
         include_national=include_national,
+        target_dates=target_dates,
     )
 
     national = None
+
     if include_national:
-        national_observed_daily = data_source.fetch_national_observed_series(query)
-        national_aggregated_observed = _aggregate_observed(
-            national_observed_daily,
+        observed_daily = data_source.fetch_national_observed_series(query)
+
+        sliced = apply_slice_to_observed(
+            observed_daily,
+            granularity=granularity,
+            slice_type=slice_type,
+            month_of_year=month_of_year,
+            day_of_month=day_of_month,
+        )
+
+        aggregated = aggregate_observed(
+            sliced,
             date_start=date_start,
             date_end=date_end,
             granularity=granularity,
+            slice_type=slice_type,
+            month_of_year=month_of_year,
         )
-        nat_points = _inject_national_baseline(
-            national_observed_daily,
-            national_aggregated_observed,
-            granularity=granularity,
-            data_source=data_source,
-        )
+
+        # baseline journalière
+        daily_baseline = {
+            (p.month, p.day_of_month): p.mean
+            for p in data_source.fetch_national_daily_baseline()
+        }
+
+        monthly_baseline = {
+            p.month: p.mean for p in data_source.fetch_national_monthly_baseline()
+        }
+
+        yearly_baseline = data_source.fetch_national_yearly_baseline()
+
+        nat_points = []
+
+        for p in aggregated:
+            if granularity == "day":
+                baseline_mean = daily_baseline[(p.date.month, p.date.day)]
+
+            elif granularity == "month":
+                if slice_type == "full":
+                    baseline_mean = monthly_baseline[p.date.month]
+                else:
+                    baseline_mean = daily_baseline[(p.date.month, p.date.day)]
+
+            elif granularity == "year":
+                if slice_type == "full":
+                    baseline_mean = yearly_baseline.mean
+                elif slice_type == "month_of_year":
+                    baseline_mean = monthly_baseline[p.date.month]
+                else:
+                    baseline_mean = daily_baseline[(p.date.month, p.date.day)]
+
+            else:
+                continue
+
+            nat_points.append(
+                AggregatedDeviationPoint(
+                    date=p.date,
+                    temperature=p.temperature,
+                    baseline_mean=baseline_mean,
+                )
+            )
+
         national = NationalDeviationSeries(data=nat_points)
 
     station_daily_series = data_source.fetch_stations_daily_series(query)
+
     stations = [
         StationDeviationSeries(
             station_id=station_series.station_id,
             station_name=station_series.station_name,
-            data=_aggregate(
-                station_series.points,
+            data=aggregate_station_daily(
+                apply_slice_to_station_daily(
+                    station_series.points,
+                    granularity=granularity,
+                    slice_type=slice_type,
+                    month_of_year=month_of_year,
+                    day_of_month=day_of_month,
+                ),
                 date_start=date_start,
                 date_end=date_end,
                 granularity=granularity,
+                slice_type=slice_type,
+                month_of_year=month_of_year,
             ),
         )
         for station_series in station_daily_series
@@ -357,6 +497,9 @@ def compute_temperature_deviation(
     date_start: dt.date,
     date_end: dt.date,
     granularity: str,
+    slice_type: str = "full",
+    month_of_year: int | None = None,
+    day_of_month: int | None = None,
     station_ids: tuple[str, ...] = (),
     include_national: bool = True,
 ) -> dict:
@@ -365,6 +508,9 @@ def compute_temperature_deviation(
         date_start=date_start,
         date_end=date_end,
         granularity=granularity,
+        slice_type=slice_type,
+        month_of_year=month_of_year,
+        day_of_month=day_of_month,
         station_ids=station_ids,
         include_national=include_national,
     )

--- a/backend/weather/services/temperature_deviation/service.py
+++ b/backend/weather/services/temperature_deviation/service.py
@@ -282,6 +282,134 @@ def _point_to_payload(p: AggregatedDeviationPoint) -> dict:
     }
 
 
+def _daily_baseline_map(
+    data_source: TemperatureDeviationDailyDataSource,
+) -> dict[tuple[int, int], float]:
+    return {
+        (point.month, point.day_of_month): point.mean
+        for point in data_source.fetch_national_daily_baseline()
+    }
+
+
+def _monthly_baseline_map(
+    data_source: TemperatureDeviationDailyDataSource,
+) -> dict[int, float]:
+    return {
+        point.month: point.mean
+        for point in data_source.fetch_national_monthly_baseline()
+    }
+
+
+def _is_complete_month_bucket(
+    observed_daily: list[ObservedPoint],
+    *,
+    year: int,
+    month: int,
+) -> bool:
+    month_points = [
+        point
+        for point in observed_daily
+        if point.date.year == year and point.date.month == month
+    ]
+    expected_days = clamp_day_to_month_end(year, month, 31)
+    return len(month_points) == expected_days
+
+
+def _mean_daily_baseline_for_month_bucket(
+    observed_daily: list[ObservedPoint],
+    *,
+    year: int,
+    month: int,
+    daily_baseline: dict[tuple[int, int], float],
+) -> float:
+    month_points = [
+        point
+        for point in observed_daily
+        if point.date.year == year and point.date.month == month
+    ]
+    return sum(
+        daily_baseline[(point.date.month, point.date.day)] for point in month_points
+    ) / len(month_points)
+
+
+def _national_baseline_mean_for_point(
+    *,
+    point: ObservedPoint,
+    observed_daily: list[ObservedPoint],
+    granularity: str,
+    slice_type: str,
+    daily_baseline: dict[tuple[int, int], float],
+    monthly_baseline: dict[int, float],
+    yearly_baseline_mean: float | None,
+) -> float:
+    if granularity == "day":
+        return daily_baseline[(point.date.month, point.date.day)]
+
+    if granularity == "month":
+        if slice_type == "full":
+            if _is_complete_month_bucket(
+                observed_daily,
+                year=point.date.year,
+                month=point.date.month,
+            ):
+                return monthly_baseline[point.date.month]
+
+            return _mean_daily_baseline_for_month_bucket(
+                observed_daily,
+                year=point.date.year,
+                month=point.date.month,
+                daily_baseline=daily_baseline,
+            )
+
+        return daily_baseline[(point.date.month, point.date.day)]
+
+    if granularity == "year":
+        if slice_type == "full":
+            if yearly_baseline_mean is None:
+                raise ValueError("Baseline annuelle nationale introuvable")
+
+            if _is_complete_year_bucket(
+                observed_daily,
+                year=point.date.year,
+            ):
+                return yearly_baseline_mean
+
+            return _mean_daily_baseline_for_year_bucket(
+                observed_daily,
+                year=point.date.year,
+                daily_baseline=daily_baseline,
+            )
+
+        if slice_type == "month_of_year":
+            return monthly_baseline[point.date.month]
+
+        return daily_baseline[(point.date.month, point.date.day)]
+
+    raise ValueError(f"Granularité non supportée : {granularity}")
+
+
+def _mean_daily_baseline_for_year_bucket(
+    observed_daily: list[ObservedPoint],
+    *,
+    year: int,
+    daily_baseline: dict[tuple[int, int], float],
+) -> float:
+    year_points = [point for point in observed_daily if point.date.year == year]
+    return sum(
+        daily_baseline[(point.date.month, point.date.day)] for point in year_points
+    ) / len(year_points)
+
+
+def _is_complete_year_bucket(
+    observed_daily: list[ObservedPoint],
+    *,
+    year: int,
+) -> bool:
+    year_points = [point for point in observed_daily if point.date.year == year]
+    expected_days = 366 if dt.date(year, 12, 31).timetuple().tm_yday == 366 else 365
+    return len(year_points) == expected_days
+
+
 def serialize_temperature_deviation_result(
     result: TemperatureDeviationResult,
 ) -> dict:
@@ -302,6 +430,102 @@ def serialize_temperature_deviation_result(
         }
 
     return payload
+
+
+def _compute_national_series(
+    *,
+    data_source: TemperatureDeviationDailyDataSource,
+    query: DailyDeviationSeriesQuery,
+    date_start: dt.date,
+    date_end: dt.date,
+    granularity: str,
+    slice_type: str,
+    month_of_year: int | None,
+    day_of_month: int | None,
+    include_national: bool,
+) -> NationalDeviationSeries | None:
+    if not include_national:
+        return None
+
+    observed_daily = data_source.fetch_national_observed_series(query)
+
+    sliced = apply_slice_to_observed(
+        observed_daily,
+        granularity=granularity,
+        slice_type=slice_type,
+        month_of_year=month_of_year,
+        day_of_month=day_of_month,
+    )
+
+    aggregated = aggregate_observed(
+        sliced,
+        date_start=date_start,
+        date_end=date_end,
+        granularity=granularity,
+        slice_type=slice_type,
+        month_of_year=month_of_year,
+    )
+
+    daily_baseline = _daily_baseline_map(data_source)
+    monthly_baseline = _monthly_baseline_map(data_source)
+
+    yearly_baseline = data_source.fetch_national_yearly_baseline()
+    yearly_baseline_mean = yearly_baseline.mean if yearly_baseline is not None else None
+
+    points = [
+        AggregatedDeviationPoint(
+            date=point.date,
+            temperature=point.temperature,
+            baseline_mean=_national_baseline_mean_for_point(
+                point=point,
+                observed_daily=observed_daily,
+                granularity=granularity,
+                slice_type=slice_type,
+                daily_baseline=daily_baseline,
+                monthly_baseline=monthly_baseline,
+                yearly_baseline_mean=yearly_baseline_mean,
+            ),
+        )
+        for point in aggregated
+    ]
+
+    return NationalDeviationSeries(data=points)
+
+
+def _compute_station_series(
+    *,
+    data_source: TemperatureDeviationDailyDataSource,
+    query: DailyDeviationSeriesQuery,
+    date_start: dt.date,
+    date_end: dt.date,
+    granularity: str,
+    slice_type: str,
+    month_of_year: int | None,
+    day_of_month: int | None,
+) -> list[StationDeviationSeries]:
+    station_daily_series = data_source.fetch_stations_daily_series(query)
+
+    return [
+        StationDeviationSeries(
+            station_id=station_series.station_id,
+            station_name=station_series.station_name,
+            data=aggregate_station_daily(
+                apply_slice_to_station_daily(
+                    station_series.points,
+                    granularity=granularity,
+                    slice_type=slice_type,
+                    month_of_year=month_of_year,
+                    day_of_month=day_of_month,
+                ),
+                date_start=date_start,
+                date_end=date_end,
+                granularity=granularity,
+                slice_type=slice_type,
+                month_of_year=month_of_year,
+            ),
+        )
+        for station_series in station_daily_series
+    ]
 
 
 def compute_target_dates(
@@ -395,135 +619,28 @@ def compute_temperature_deviation_series(
         target_dates=target_dates,
     )
 
-    national = None
+    national = _compute_national_series(
+        data_source=data_source,
+        query=query,
+        date_start=date_start,
+        date_end=date_end,
+        granularity=granularity,
+        slice_type=slice_type,
+        month_of_year=month_of_year,
+        day_of_month=day_of_month,
+        include_national=include_national,
+    )
 
-    if include_national:
-        observed_daily = data_source.fetch_national_observed_series(query)
-
-        sliced = apply_slice_to_observed(
-            observed_daily,
-            granularity=granularity,
-            slice_type=slice_type,
-            month_of_year=month_of_year,
-            day_of_month=day_of_month,
-        )
-
-        aggregated = aggregate_observed(
-            sliced,
-            date_start=date_start,
-            date_end=date_end,
-            granularity=granularity,
-            slice_type=slice_type,
-            month_of_year=month_of_year,
-        )
-
-        # baseline journalière
-        daily_baseline = {
-            (p.month, p.day_of_month): p.mean
-            for p in data_source.fetch_national_daily_baseline()
-        }
-
-        monthly_baseline = {
-            p.month: p.mean for p in data_source.fetch_national_monthly_baseline()
-        }
-
-        yearly_baseline = data_source.fetch_national_yearly_baseline()
-
-        nat_points = []
-
-        for p in aggregated:
-            if granularity == "day":
-                baseline_mean = daily_baseline[(p.date.month, p.date.day)]
-
-            elif granularity == "month":
-                if slice_type == "full":
-                    # logique historique : bucket complet ou non
-                    month_points = [
-                        x
-                        for x in observed_daily
-                        if x.date.year == p.date.year and x.date.month == p.date.month
-                    ]
-
-                    expected_days = clamp_day_to_month_end(
-                        p.date.year, p.date.month, 31
-                    )
-
-                    if len(month_points) == expected_days:
-                        baseline_mean = monthly_baseline[p.date.month]
-                    else:
-                        baseline_mean = sum(
-                            daily_baseline[(x.date.month, x.date.day)]
-                            for x in month_points
-                        ) / len(month_points)
-
-                else:
-                    # slicing
-                    baseline_mean = daily_baseline[(p.date.month, p.date.day)]
-
-            elif granularity == "year":
-                if slice_type == "full":
-                    year_points = [
-                        x for x in observed_daily if x.date.year == p.date.year
-                    ]
-
-                    # 365 ou 366
-                    expected_days = (
-                        366
-                        if dt.date(p.date.year, 12, 31).toordinal()
-                        - dt.date(p.date.year, 1, 1).toordinal()
-                        + 1
-                        == 366
-                        else 365
-                    )
-
-                    if len(year_points) == expected_days:
-                        baseline_mean = yearly_baseline.mean
-                    else:
-                        baseline_mean = sum(
-                            daily_baseline[(x.date.month, x.date.day)]
-                            for x in year_points
-                        ) / len(year_points)
-
-                elif slice_type == "month_of_year":
-                    baseline_mean = monthly_baseline[p.date.month]
-
-                else:
-                    # day_of_month
-                    baseline_mean = daily_baseline[(p.date.month, p.date.day)]
-
-            nat_points.append(
-                AggregatedDeviationPoint(
-                    date=p.date,
-                    temperature=p.temperature,
-                    baseline_mean=baseline_mean,
-                )
-            )
-
-        national = NationalDeviationSeries(data=nat_points)
-
-    station_daily_series = data_source.fetch_stations_daily_series(query)
-
-    stations = [
-        StationDeviationSeries(
-            station_id=station_series.station_id,
-            station_name=station_series.station_name,
-            data=aggregate_station_daily(
-                apply_slice_to_station_daily(
-                    station_series.points,
-                    granularity=granularity,
-                    slice_type=slice_type,
-                    month_of_year=month_of_year,
-                    day_of_month=day_of_month,
-                ),
-                date_start=date_start,
-                date_end=date_end,
-                granularity=granularity,
-                slice_type=slice_type,
-                month_of_year=month_of_year,
-            ),
-        )
-        for station_series in station_daily_series
-    ]
+    stations = _compute_station_series(
+        data_source=data_source,
+        query=query,
+        date_start=date_start,
+        date_end=date_end,
+        granularity=granularity,
+        slice_type=slice_type,
+        month_of_year=month_of_year,
+        day_of_month=day_of_month,
+    )
 
     return TemperatureDeviationResult(
         stations=stations,

--- a/backend/weather/services/temperature_deviation/service.py
+++ b/backend/weather/services/temperature_deviation/service.py
@@ -4,6 +4,7 @@ import datetime as dt
 from collections import defaultdict
 
 from weather.utils.date_range import (
+    clamp_day_to_month_end,
     days_in_month_in_range,
     iter_days_intersecting,
     iter_month_starts_intersecting,
@@ -436,20 +437,59 @@ def compute_temperature_deviation_series(
 
             elif granularity == "month":
                 if slice_type == "full":
-                    baseline_mean = monthly_baseline[p.date.month]
+                    # logique historique : bucket complet ou non
+                    month_points = [
+                        x
+                        for x in observed_daily
+                        if x.date.year == p.date.year and x.date.month == p.date.month
+                    ]
+
+                    expected_days = clamp_day_to_month_end(
+                        p.date.year, p.date.month, 31
+                    )
+
+                    if len(month_points) == expected_days:
+                        baseline_mean = monthly_baseline[p.date.month]
+                    else:
+                        baseline_mean = sum(
+                            daily_baseline[(x.date.month, x.date.day)]
+                            for x in month_points
+                        ) / len(month_points)
+
                 else:
+                    # slicing
                     baseline_mean = daily_baseline[(p.date.month, p.date.day)]
 
             elif granularity == "year":
                 if slice_type == "full":
-                    baseline_mean = yearly_baseline.mean
+                    year_points = [
+                        x for x in observed_daily if x.date.year == p.date.year
+                    ]
+
+                    # 365 ou 366
+                    expected_days = (
+                        366
+                        if dt.date(p.date.year, 12, 31).toordinal()
+                        - dt.date(p.date.year, 1, 1).toordinal()
+                        + 1
+                        == 366
+                        else 365
+                    )
+
+                    if len(year_points) == expected_days:
+                        baseline_mean = yearly_baseline.mean
+                    else:
+                        baseline_mean = sum(
+                            daily_baseline[(x.date.month, x.date.day)]
+                            for x in year_points
+                        ) / len(year_points)
+
                 elif slice_type == "month_of_year":
                     baseline_mean = monthly_baseline[p.date.month]
-                else:
-                    baseline_mean = daily_baseline[(p.date.month, p.date.day)]
 
-            else:
-                continue
+                else:
+                    # day_of_month
+                    baseline_mean = daily_baseline[(p.date.month, p.date.day)]
 
             nat_points.append(
                 AggregatedDeviationPoint(

--- a/backend/weather/services/temperature_deviation/slicing.py
+++ b/backend/weather/services/temperature_deviation/slicing.py
@@ -5,6 +5,102 @@ from weather.utils.date_range import clamp_day_to_month_end
 from .types import DailyDeviationPoint, ObservedPoint
 
 
+def _select_monthly_observed_points(
+    daily: list[ObservedPoint],
+    *,
+    day_of_month: int,
+) -> list[ObservedPoint]:
+    by_month: dict[tuple[int, int], list[ObservedPoint]] = defaultdict(list)
+    for point in daily:
+        by_month[(point.date.year, point.date.month)].append(point)
+
+    selected: list[ObservedPoint] = []
+    for (year, month), points in sorted(by_month.items()):
+        target_day = clamp_day_to_month_end(year, month, day_of_month)
+        chosen = next((point for point in points if point.date.day == target_day), None)
+        if chosen is None:
+            continue
+        selected.append(chosen)
+
+    return selected
+
+
+def _select_yearly_observed_points(
+    daily: list[ObservedPoint],
+    *,
+    month_of_year: int,
+    day_of_month: int,
+) -> list[ObservedPoint]:
+    by_year: dict[int, list[ObservedPoint]] = defaultdict(list)
+    for point in daily:
+        by_year[point.date.year].append(point)
+
+    selected: list[ObservedPoint] = []
+    for year, points in sorted(by_year.items()):
+        target_day = clamp_day_to_month_end(year, month_of_year, day_of_month)
+        chosen = next(
+            (
+                point
+                for point in points
+                if point.date.month == month_of_year and point.date.day == target_day
+            ),
+            None,
+        )
+        if chosen is None:
+            continue
+        selected.append(chosen)
+
+    return selected
+
+
+def _select_monthly_station_points(
+    daily: list[DailyDeviationPoint],
+    *,
+    day_of_month: int,
+) -> list[DailyDeviationPoint]:
+    by_month: dict[tuple[int, int], list[DailyDeviationPoint]] = defaultdict(list)
+    for point in daily:
+        by_month[(point.date.year, point.date.month)].append(point)
+
+    selected: list[DailyDeviationPoint] = []
+    for (year, month), points in sorted(by_month.items()):
+        target_day = clamp_day_to_month_end(year, month, day_of_month)
+        chosen = next((point for point in points if point.date.day == target_day), None)
+        if chosen is None:
+            continue
+        selected.append(chosen)
+
+    return selected
+
+
+def _select_yearly_station_points(
+    daily: list[DailyDeviationPoint],
+    *,
+    month_of_year: int,
+    day_of_month: int,
+) -> list[DailyDeviationPoint]:
+    by_year: dict[int, list[DailyDeviationPoint]] = defaultdict(list)
+    for point in daily:
+        by_year[point.date.year].append(point)
+
+    selected: list[DailyDeviationPoint] = []
+    for year, points in sorted(by_year.items()):
+        target_day = clamp_day_to_month_end(year, month_of_year, day_of_month)
+        chosen = next(
+            (
+                point
+                for point in points
+                if point.date.month == month_of_year and point.date.day == target_day
+            ),
+            None,
+        )
+        if chosen is None:
+            continue
+        selected.append(chosen)
+
+    return selected
+
+
 def apply_slice_to_observed(
     daily: list[ObservedPoint],
     *,
@@ -28,44 +124,20 @@ def apply_slice_to_observed(
         raise ValueError("day_of_month ne doit pas être None")
 
     if granularity == "month":
-        by_month: dict[tuple[int, int], list[ObservedPoint]] = defaultdict(list)
-        for p in daily:
-            by_month[(p.date.year, p.date.month)].append(p)
-
-        selected: list[ObservedPoint] = []
-        for (y, m), pts in sorted(by_month.items()):
-            target_day = clamp_day_to_month_end(y, m, day_of_month)
-            chosen = next((pp for pp in pts if pp.date.day == target_day), None)
-            if chosen is None:
-                continue
-            selected.append(chosen)
-
-        return selected
+        return _select_monthly_observed_points(
+            daily,
+            day_of_month=day_of_month,
+        )
 
     if granularity == "year":
         if month_of_year is None:
             raise ValueError("month_of_year ne doit pas être None")
 
-        by_year: dict[int, list[ObservedPoint]] = defaultdict(list)
-        for p in daily:
-            by_year[p.date.year].append(p)
-
-        selected: list[ObservedPoint] = []
-        for y, pts in sorted(by_year.items()):
-            target_day = clamp_day_to_month_end(y, month_of_year, day_of_month)
-            chosen = next(
-                (
-                    pp
-                    for pp in pts
-                    if pp.date.month == month_of_year and pp.date.day == target_day
-                ),
-                None,
-            )
-            if chosen is None:
-                continue
-            selected.append(chosen)
-
-        return selected
+        return _select_yearly_observed_points(
+            daily,
+            month_of_year=month_of_year,
+            day_of_month=day_of_month,
+        )
 
     raise ValueError(
         f"Combinaison invalide granularity={granularity}, slice_type={slice_type}"
@@ -98,44 +170,20 @@ def apply_slice_to_station_daily(
         raise ValueError("day_of_month ne doit pas être None")
 
     if granularity == "month":
-        by_month: dict[tuple[int, int], list[DailyDeviationPoint]] = defaultdict(list)
-        for p in daily:
-            by_month[(p.date.year, p.date.month)].append(p)
-
-        selected: list[DailyDeviationPoint] = []
-        for (y, m), pts in sorted(by_month.items()):
-            target_day = clamp_day_to_month_end(y, m, day_of_month)
-            chosen = next((pp for pp in pts if pp.date.day == target_day), None)
-            if chosen is None:
-                continue
-            selected.append(chosen)
-
-        return selected
+        return _select_monthly_station_points(
+            daily,
+            day_of_month=day_of_month,
+        )
 
     if granularity == "year":
         if month_of_year is None:
             raise ValueError("month_of_year ne doit pas être None")
 
-        by_year: dict[int, list[DailyDeviationPoint]] = defaultdict(list)
-        for p in daily:
-            by_year[p.date.year].append(p)
-
-        selected: list[DailyDeviationPoint] = []
-        for y, pts in sorted(by_year.items()):
-            target_day = clamp_day_to_month_end(y, month_of_year, day_of_month)
-            chosen = next(
-                (
-                    pp
-                    for pp in pts
-                    if pp.date.month == month_of_year and pp.date.day == target_day
-                ),
-                None,
-            )
-            if chosen is None:
-                continue
-            selected.append(chosen)
-
-        return selected
+        return _select_yearly_station_points(
+            daily,
+            month_of_year=month_of_year,
+            day_of_month=day_of_month,
+        )
 
     raise ValueError(
         f"Combinaison invalide granularity={granularity}, slice_type={slice_type}"

--- a/backend/weather/services/temperature_deviation/slicing.py
+++ b/backend/weather/services/temperature_deviation/slicing.py
@@ -1,0 +1,142 @@
+from collections import defaultdict
+
+from weather.utils.date_range import clamp_day_to_month_end
+
+from .types import DailyDeviationPoint, ObservedPoint
+
+
+def apply_slice_to_observed(
+    daily: list[ObservedPoint],
+    *,
+    granularity: str,
+    slice_type: str,
+    month_of_year: int | None = None,
+    day_of_month: int | None = None,
+) -> list[ObservedPoint]:
+    if slice_type == "full":
+        return daily
+
+    if slice_type == "month_of_year":
+        if month_of_year is None:
+            raise ValueError("month_of_year ne doit pas être None")
+        return [p for p in daily if p.date.month == month_of_year]
+
+    if slice_type != "day_of_month":
+        raise ValueError(f"slice_type non supporté: {slice_type}")
+
+    if day_of_month is None:
+        raise ValueError("day_of_month ne doit pas être None")
+
+    if granularity == "month":
+        by_month: dict[tuple[int, int], list[ObservedPoint]] = defaultdict(list)
+        for p in daily:
+            by_month[(p.date.year, p.date.month)].append(p)
+
+        selected: list[ObservedPoint] = []
+        for (y, m), pts in sorted(by_month.items()):
+            target_day = clamp_day_to_month_end(y, m, day_of_month)
+            chosen = next((pp for pp in pts if pp.date.day == target_day), None)
+            if chosen is None:
+                continue
+            selected.append(chosen)
+
+        return selected
+
+    if granularity == "year":
+        if month_of_year is None:
+            raise ValueError("month_of_year ne doit pas être None")
+
+        by_year: dict[int, list[ObservedPoint]] = defaultdict(list)
+        for p in daily:
+            by_year[p.date.year].append(p)
+
+        selected: list[ObservedPoint] = []
+        for y, pts in sorted(by_year.items()):
+            target_day = clamp_day_to_month_end(y, month_of_year, day_of_month)
+            chosen = next(
+                (
+                    pp
+                    for pp in pts
+                    if pp.date.month == month_of_year and pp.date.day == target_day
+                ),
+                None,
+            )
+            if chosen is None:
+                continue
+            selected.append(chosen)
+
+        return selected
+
+    raise ValueError(
+        f"Combinaison invalide granularity={granularity}, slice_type={slice_type}"
+    )
+
+
+def apply_slice_to_station_daily(
+    daily: list[DailyDeviationPoint],
+    *,
+    granularity: str,
+    slice_type: str,
+    month_of_year: int | None = None,
+    day_of_month: int | None = None,
+) -> list[DailyDeviationPoint]:
+    """
+    Identique à apply_slice_to_observed mais sur DailyDeviationPoint.
+    """
+    if slice_type == "full":
+        return daily
+
+    if slice_type == "month_of_year":
+        if month_of_year is None:
+            raise ValueError("month_of_year ne doit pas être None")
+        return [p for p in daily if p.date.month == month_of_year]
+
+    if slice_type != "day_of_month":
+        raise ValueError(f"slice_type non supporté: {slice_type}")
+
+    if day_of_month is None:
+        raise ValueError("day_of_month ne doit pas être None")
+
+    if granularity == "month":
+        by_month: dict[tuple[int, int], list[DailyDeviationPoint]] = defaultdict(list)
+        for p in daily:
+            by_month[(p.date.year, p.date.month)].append(p)
+
+        selected: list[DailyDeviationPoint] = []
+        for (y, m), pts in sorted(by_month.items()):
+            target_day = clamp_day_to_month_end(y, m, day_of_month)
+            chosen = next((pp for pp in pts if pp.date.day == target_day), None)
+            if chosen is None:
+                continue
+            selected.append(chosen)
+
+        return selected
+
+    if granularity == "year":
+        if month_of_year is None:
+            raise ValueError("month_of_year ne doit pas être None")
+
+        by_year: dict[int, list[DailyDeviationPoint]] = defaultdict(list)
+        for p in daily:
+            by_year[p.date.year].append(p)
+
+        selected: list[DailyDeviationPoint] = []
+        for y, pts in sorted(by_year.items()):
+            target_day = clamp_day_to_month_end(y, month_of_year, day_of_month)
+            chosen = next(
+                (
+                    pp
+                    for pp in pts
+                    if pp.date.month == month_of_year and pp.date.day == target_day
+                ),
+                None,
+            )
+            if chosen is None:
+                continue
+            selected.append(chosen)
+
+        return selected
+
+    raise ValueError(
+        f"Combinaison invalide granularity={granularity}, slice_type={slice_type}"
+    )

--- a/backend/weather/services/temperature_deviation/source_window.py
+++ b/backend/weather/services/temperature_deviation/source_window.py
@@ -1,0 +1,36 @@
+import datetime as dt
+
+from weather.utils.date_range import (
+    clamp_day_to_month_end,
+    iter_year_starts_intersecting,
+)
+
+
+def compute_source_window(
+    *,
+    date_start: dt.date,
+    date_end: dt.date,
+    granularity: str,
+    slice_type: str,
+    month_of_year: int | None,
+) -> tuple[dt.date, dt.date]:
+    """
+    Détermine la fenêtre réelle utilisée pour générer la série journalière.
+
+    Cas particulier :
+    - granularity="year" avec slice_type="month_of_year" ou "day_of_month"
+      -> on veut un point par année d'intersection, même si le mois ciblé
+         est hors [date_start, date_end].
+      -> on couvre donc le mois ciblé sur toutes les années intersectantes.
+    """
+    if granularity == "year" and slice_type in ("month_of_year", "day_of_month"):
+        if month_of_year is None:
+            raise ValueError("month_of_year ne doit pas être None")
+
+        years = [d.year for d in iter_year_starts_intersecting(date_start, date_end)]
+        start = dt.date(years[0], month_of_year, 1)
+        last_day = clamp_day_to_month_end(years[-1], month_of_year, 31)
+        end = dt.date(years[-1], month_of_year, last_day)
+        return start, end
+
+    return date_start, date_end

--- a/backend/weather/services/temperature_deviation/source_window.py
+++ b/backend/weather/services/temperature_deviation/source_window.py
@@ -14,23 +14,34 @@ def compute_source_window(
     slice_type: str,
     month_of_year: int | None,
 ) -> tuple[dt.date, dt.date]:
-    """
-    Détermine la fenêtre réelle utilisée pour générer la série journalière.
+    # --- CAS HISTORIQUE deviation ---
 
-    Cas particulier :
-    - granularity="year" avec slice_type="month_of_year" ou "day_of_month"
-      -> on veut un point par année d'intersection, même si le mois ciblé
-         est hors [date_start, date_end].
-      -> on couvre donc le mois ciblé sur toutes les années intersectantes.
-    """
+    # Mois → élargir au mois complet
+    if granularity == "month" and slice_type == "full":
+        start = dt.date(date_start.year, date_start.month, 1)
+        last_day = clamp_day_to_month_end(date_end.year, date_end.month, 31)
+        end = dt.date(date_end.year, date_end.month, last_day)
+        return start, end
+
+    # Année → élargir à l'année complète
+    if granularity == "year" and slice_type == "full":
+        start = dt.date(date_start.year, 1, 1)
+        end = dt.date(date_end.year, 12, 31)
+        return start, end
+
+    # --- CAS SLICING (nouveau) ---
+
     if granularity == "year" and slice_type in ("month_of_year", "day_of_month"):
         if month_of_year is None:
             raise ValueError("month_of_year ne doit pas être None")
 
         years = [d.year for d in iter_year_starts_intersecting(date_start, date_end)]
+
         start = dt.date(years[0], month_of_year, 1)
         last_day = clamp_day_to_month_end(years[-1], month_of_year, 31)
         end = dt.date(years[-1], month_of_year, last_day)
+
         return start, end
 
+    # --- fallback ---
     return date_start, date_end

--- a/backend/weather/services/temperature_deviation/source_window.py
+++ b/backend/weather/services/temperature_deviation/source_window.py
@@ -6,6 +6,42 @@ from weather.utils.date_range import (
 )
 
 
+def _full_month_source_window(
+    *,
+    date_start: dt.date,
+    date_end: dt.date,
+) -> tuple[dt.date, dt.date]:
+    start = dt.date(date_start.year, date_start.month, 1)
+    last_day = clamp_day_to_month_end(date_end.year, date_end.month, 31)
+    end = dt.date(date_end.year, date_end.month, last_day)
+    return start, end
+
+
+def _full_year_source_window(
+    *,
+    date_start: dt.date,
+    date_end: dt.date,
+) -> tuple[dt.date, dt.date]:
+    start = dt.date(date_start.year, 1, 1)
+    end = dt.date(date_end.year, 12, 31)
+    return start, end
+
+
+def _year_slice_source_window(
+    *,
+    date_start: dt.date,
+    date_end: dt.date,
+    month_of_year: int,
+) -> tuple[dt.date, dt.date]:
+    years = [d.year for d in iter_year_starts_intersecting(date_start, date_end)]
+
+    start = dt.date(years[0], month_of_year, 1)
+    last_day = clamp_day_to_month_end(years[-1], month_of_year, 31)
+    end = dt.date(years[-1], month_of_year, last_day)
+
+    return start, end
+
+
 def compute_source_window(
     *,
     date_start: dt.date,
@@ -18,16 +54,17 @@ def compute_source_window(
 
     # Mois → élargir au mois complet
     if granularity == "month" and slice_type == "full":
-        start = dt.date(date_start.year, date_start.month, 1)
-        last_day = clamp_day_to_month_end(date_end.year, date_end.month, 31)
-        end = dt.date(date_end.year, date_end.month, last_day)
-        return start, end
+        return _full_month_source_window(
+            date_start=date_start,
+            date_end=date_end,
+        )
 
     # Année → élargir à l'année complète
     if granularity == "year" and slice_type == "full":
-        start = dt.date(date_start.year, 1, 1)
-        end = dt.date(date_end.year, 12, 31)
-        return start, end
+        return _full_year_source_window(
+            date_start=date_start,
+            date_end=date_end,
+        )
 
     # --- CAS SLICING (nouveau) ---
 
@@ -35,13 +72,11 @@ def compute_source_window(
         if month_of_year is None:
             raise ValueError("month_of_year ne doit pas être None")
 
-        years = [d.year for d in iter_year_starts_intersecting(date_start, date_end)]
-
-        start = dt.date(years[0], month_of_year, 1)
-        last_day = clamp_day_to_month_end(years[-1], month_of_year, 31)
-        end = dt.date(years[-1], month_of_year, last_day)
-
-        return start, end
+        return _year_slice_source_window(
+            date_start=date_start,
+            date_end=date_end,
+            month_of_year=month_of_year,
+        )
 
     # --- fallback ---
     return date_start, date_end

--- a/backend/weather/services/temperature_deviation/types.py
+++ b/backend/weather/services/temperature_deviation/types.py
@@ -16,6 +16,7 @@ class DailyDeviationSeriesQuery:
     date_end: dt.date
     station_ids: tuple[str, ...]
     include_national: bool = True
+    target_dates: tuple[dt.date, ...] | None = None
 
 
 @dataclass(frozen=True)

--- a/backend/weather/services/temperature_deviation/use_case.py
+++ b/backend/weather/services/temperature_deviation/use_case.py
@@ -18,6 +18,9 @@ def get_temperature_deviation(
     date_start: dt.date,
     date_end: dt.date,
     granularity: str,
+    slice_type: str = "full",
+    month_of_year: int | None = None,
+    day_of_month: int | None = None,
     station_ids: tuple[str, ...] = (),
     include_national: bool = True,
 ) -> dict:
@@ -26,6 +29,9 @@ def get_temperature_deviation(
         date_start=date_start,
         date_end=date_end,
         granularity=granularity,
+        slice_type=slice_type,
+        month_of_year=month_of_year,
+        day_of_month=day_of_month,
         station_ids=station_ids,
         include_national=include_national,
     )

--- a/backend/weather/tests/integration/test_temperature_deviation_graph_endpoint.py
+++ b/backend/weather/tests/integration/test_temperature_deviation_graph_endpoint.py
@@ -42,6 +42,7 @@ def test_get_temperature_deviation_graph_day_happy_path(
         "date_end": "2024-01-03",
         "baseline": "1991-2020",
         "granularity": "day",
+        "slice_type": "full",
     }
 
     assert "national" in body
@@ -142,3 +143,167 @@ def test_get_temperature_deviation_graph_endpoint_uses_dependency_provider(
     body = resp.json()
     assert body["stations"][0]["station_id"] == "07149"
     assert "national" not in body
+
+
+@pytest.mark.usefixtures("fake_temperature_deviation_dep")
+def test_get_temperature_deviation_graph_year_month_of_year_slice_happy_path(
+    client: APIClient,
+):
+    resp = client.get(
+        "/api/v1/temperature/deviation/graph",
+        {
+            "date_start": "2020-01-01",
+            "date_end": "2024-12-31",
+            "granularity": "year",
+            "slice_type": "month_of_year",
+            "month_of_year": 2,
+            "station_ids": "07149",
+        },
+    )
+
+    assert resp.status_code == 200
+    body = resp.json()
+
+    assert body["metadata"] == {
+        "date_start": "2020-01-01",
+        "date_end": "2024-12-31",
+        "baseline": "1991-2020",
+        "granularity": "year",
+        "slice_type": "month_of_year",
+        "month_of_year": 2,
+    }
+
+    assert "national" in body
+    assert "stations" in body
+    assert len(body["stations"]) == 1
+    assert body["stations"][0]["station_id"] == "07149"
+
+
+@pytest.mark.usefixtures("fake_temperature_deviation_dep")
+def test_get_temperature_deviation_graph_month_day_of_month_slice_happy_path(
+    client: APIClient,
+):
+    resp = client.get(
+        "/api/v1/temperature/deviation/graph",
+        {
+            "date_start": "2024-01-01",
+            "date_end": "2024-06-30",
+            "granularity": "month",
+            "slice_type": "day_of_month",
+            "day_of_month": 31,
+            "station_ids": "07149",
+        },
+    )
+
+    assert resp.status_code == 200
+    body = resp.json()
+
+    assert body["metadata"] == {
+        "date_start": "2024-01-01",
+        "date_end": "2024-06-30",
+        "baseline": "1991-2020",
+        "granularity": "month",
+        "slice_type": "day_of_month",
+        "day_of_month": 31,
+    }
+
+    assert "national" in body
+    assert "stations" in body
+    assert len(body["stations"]) == 1
+
+
+@pytest.mark.usefixtures("fake_temperature_deviation_dep")
+def test_get_temperature_deviation_graph_year_day_of_month_slice_happy_path(
+    client: APIClient,
+):
+    resp = client.get(
+        "/api/v1/temperature/deviation/graph",
+        {
+            "date_start": "2020-01-01",
+            "date_end": "2024-12-31",
+            "granularity": "year",
+            "slice_type": "day_of_month",
+            "month_of_year": 2,
+            "day_of_month": 29,
+            "station_ids": "07149",
+        },
+    )
+
+    assert resp.status_code == 200
+    body = resp.json()
+
+    assert body["metadata"] == {
+        "date_start": "2020-01-01",
+        "date_end": "2024-12-31",
+        "baseline": "1991-2020",
+        "granularity": "year",
+        "slice_type": "day_of_month",
+        "month_of_year": 2,
+        "day_of_month": 29,
+    }
+
+    assert "national" in body
+    assert "stations" in body
+    assert len(body["stations"]) == 1
+
+
+def test_get_temperature_deviation_graph_returns_400_for_day_granularity_with_day_of_month_slice(
+    client: APIClient,
+):
+    resp = client.get(
+        "/api/v1/temperature/deviation/graph",
+        {
+            "date_start": "2024-01-01",
+            "date_end": "2024-01-31",
+            "granularity": "day",
+            "slice_type": "day_of_month",
+            "day_of_month": 15,
+        },
+    )
+
+    assert resp.status_code == 400
+    body = resp.json()
+
+    assert body["error"]["code"] == "INVALID_PARAMETER"
+    assert "slice_type" in body["error"]["details"]
+
+
+def test_get_temperature_deviation_graph_returns_400_for_month_of_year_slice_without_month_of_year(
+    client: APIClient,
+):
+    resp = client.get(
+        "/api/v1/temperature/deviation/graph",
+        {
+            "date_start": "2020-01-01",
+            "date_end": "2024-12-31",
+            "granularity": "year",
+            "slice_type": "month_of_year",
+        },
+    )
+
+    assert resp.status_code == 400
+    body = resp.json()
+
+    assert body["error"]["code"] == "INVALID_PARAMETER"
+    assert "month_of_year" in body["error"]["details"]
+
+
+def test_get_temperature_deviation_graph_returns_400_for_year_day_of_month_slice_without_month_of_year(
+    client: APIClient,
+):
+    resp = client.get(
+        "/api/v1/temperature/deviation/graph",
+        {
+            "date_start": "2020-01-01",
+            "date_end": "2024-12-31",
+            "granularity": "year",
+            "slice_type": "day_of_month",
+            "day_of_month": 15,
+        },
+    )
+
+    assert resp.status_code == 400
+    body = resp.json()
+
+    assert body["error"]["code"] == "INVALID_PARAMETER"
+    assert "month_of_year" in body["error"]["details"]

--- a/backend/weather/tests/integration/test_temperature_deviation_timescale_datasource.py
+++ b/backend/weather/tests/integration/test_temperature_deviation_timescale_datasource.py
@@ -7,6 +7,7 @@ import pytest
 from weather.data_sources.timescale import (
     TimescaleTemperatureDeviationDailyDataSource,
 )
+from weather.services.national_indicator.stations import ITN_STATION_CODES_FOR_QUERY
 from weather.services.temperature_deviation.types import (
     DailyDeviationSeriesQuery,
     TemperatureDeviationOverviewQuery,
@@ -438,3 +439,96 @@ def test_fetch_station_overview_orders_by_region():
         "Provence-Alpes-Côte d'Azur",
         "Île-de-France",
     ]
+
+
+@pytest.mark.django_db
+def test_fetch_stations_daily_series_respects_target_dates():
+    station_code = "01269001"
+
+    insert_station(station_code, "Station 01269001")
+
+    # baseline (>= 24 années requises)
+    insert_station_daily_baseline(station_code, 1, 1, 10.0)
+    insert_station_daily_baseline(station_code, 1, 2, 11.0)
+    insert_station_daily_baseline(station_code, 1, 3, 12.0)
+
+    # observations
+    insert_quotidienne(dt.date(2024, 1, 1), station_code, 14.0)
+    insert_quotidienne(dt.date(2024, 1, 2), station_code, 15.0)
+    insert_quotidienne(dt.date(2024, 1, 3), station_code, 16.0)
+
+    ds = TimescaleTemperatureDeviationDailyDataSource()
+
+    target_dates = (
+        dt.date(2024, 1, 1),
+        dt.date(2024, 1, 3),
+    )
+
+    query = DailyDeviationSeriesQuery(
+        date_start=dt.date(2024, 1, 1),
+        date_end=dt.date(2024, 1, 3),
+        station_ids=(station_code,),
+        include_national=False,
+        target_dates=target_dates,
+    )
+
+    result = ds.fetch_stations_daily_series(query)
+
+    assert len(result) == 1
+
+    points = result[0].points
+
+    assert [p.date for p in points] == list(target_dates)
+
+
+@pytest.mark.django_db
+def test_fetch_national_observed_series_respects_target_dates():
+    day1 = dt.date(2024, 1, 1)
+    day2 = dt.date(2024, 1, 2)
+    day3 = dt.date(2024, 1, 3)
+
+    insert_complete_itn_day(day1, 10.0)
+
+    for code in ITN_STATION_CODES_FOR_QUERY:
+        insert_quotidienne(day2, code, 11.0)
+        insert_quotidienne(day3, code, 12.0)
+
+    ds = TimescaleTemperatureDeviationDailyDataSource()
+
+    target_dates = (day1, day3)
+
+    query = DailyDeviationSeriesQuery(
+        date_start=day1,
+        date_end=day3,
+        station_ids=(),
+        include_national=True,
+        target_dates=target_dates,
+    )
+
+    result = ds.fetch_national_observed_series(query)
+
+    assert [p.date for p in result] == list(target_dates)
+
+
+@pytest.mark.django_db
+def test_fetch_stations_daily_series_target_dates_outside_range_returns_empty():
+    station_code = "01269001"
+
+    insert_station(station_code, "Station 01269001")
+    insert_station_daily_baseline(station_code, 1, 1, 10.0)
+
+    insert_quotidienne(dt.date(2024, 1, 1), station_code, 14.0)
+
+    ds = TimescaleTemperatureDeviationDailyDataSource()
+
+    query = DailyDeviationSeriesQuery(
+        date_start=dt.date(2024, 1, 1),
+        date_end=dt.date(2024, 1, 1),
+        station_ids=(station_code,),
+        include_national=False,
+        target_dates=(dt.date(2024, 1, 2),),
+    )
+
+    result = ds.fetch_stations_daily_series(query)
+
+    assert result == []

--- a/backend/weather/tests/unit/test_temperature_deviation_graph_acceptance.py
+++ b/backend/weather/tests/unit/test_temperature_deviation_graph_acceptance.py
@@ -53,7 +53,7 @@ class FakeTemperatureDeviationAcceptanceDataSource:
         ]
 
 
-def test_temperature_deviation_acceptance_month_uses_monthly_baseline_for_national():
+def test_temperature_deviation_acceptance_month_partial_uses_daily_baseline_for_national():
     ds = FakeTemperatureDeviationAcceptanceDataSource()
 
     out = get_temperature_deviation(
@@ -88,3 +88,126 @@ def test_temperature_deviation_acceptance_month_uses_monthly_baseline_for_nation
     assert station_point["temperature"] == 8.0
     assert station_point["baseline_mean"] == 7.0
     assert station_point["deviation"] == 1.0
+
+
+def test_temperature_deviation_acceptance_year_month_of_year_slice():
+    class DS:
+        def fetch_national_observed_series(self, query):
+            return [
+                ObservedPoint(dt.date(2023, 2, 1), 10),
+                ObservedPoint(dt.date(2023, 2, 2), 20),
+                ObservedPoint(dt.date(2024, 2, 1), 30),
+                ObservedPoint(dt.date(2024, 2, 2), 40),
+            ]
+
+        def fetch_national_daily_baseline(self):
+            return []
+
+        def fetch_national_monthly_baseline(self):
+            return [MonthlyBaselinePoint(2, 5)]
+
+        def fetch_national_yearly_baseline(self):
+            return YearlyBaselinePoint(100)
+
+        def fetch_stations_daily_series(self, query):
+            return []
+
+    ds = DS()
+
+    out = get_temperature_deviation(
+        data_source=ds,
+        date_start=dt.date(2023, 1, 1),
+        date_end=dt.date(2024, 12, 31),
+        granularity="year",
+        slice_type="month_of_year",
+        month_of_year=2,
+    )
+
+    pts = out["national"]["data"]
+
+    assert len(pts) == 2
+    assert pts[0]["date"] == dt.date(2023, 2, 1)
+    assert pts[1]["date"] == dt.date(2024, 2, 1)
+    assert pts[0]["baseline_mean"] == 5
+
+
+def test_temperature_deviation_acceptance_month_day_of_month_slice():
+    class DS:
+        def fetch_national_observed_series(self, query):
+            return [
+                ObservedPoint(dt.date(2024, 1, 31), 10),
+                ObservedPoint(dt.date(2024, 2, 29), 20),
+            ]
+
+        def fetch_national_daily_baseline(self):
+            return [
+                DailyBaselinePoint(1, 31, 1),
+                DailyBaselinePoint(2, 29, 2),
+            ]
+
+        def fetch_national_monthly_baseline(self):
+            return []
+
+        def fetch_national_yearly_baseline(self):
+            return None
+
+        def fetch_stations_daily_series(self, query):
+            return []
+
+    ds = DS()
+
+    out = get_temperature_deviation(
+        data_source=ds,
+        date_start=dt.date(2024, 1, 1),
+        date_end=dt.date(2024, 2, 29),
+        granularity="month",
+        slice_type="day_of_month",
+        day_of_month=31,
+    )
+
+    pts = out["national"]["data"]
+
+    assert len(pts) == 2
+    assert pts[0]["date"] == dt.date(2024, 1, 31)
+    assert pts[1]["date"] == dt.date(2024, 2, 29)
+
+
+def test_temperature_deviation_acceptance_year_day_of_month_slice_clamp():
+    class DS:
+        def fetch_national_observed_series(self, query):
+            return [
+                ObservedPoint(dt.date(2020, 2, 29), 10),
+                ObservedPoint(dt.date(2021, 2, 28), 20),
+            ]
+
+        def fetch_national_daily_baseline(self):
+            return [
+                DailyBaselinePoint(2, 29, 1),
+                DailyBaselinePoint(2, 28, 2),
+            ]
+
+        def fetch_national_monthly_baseline(self):
+            return []
+
+        def fetch_national_yearly_baseline(self):
+            return None
+
+        def fetch_stations_daily_series(self, query):
+            return []
+
+    ds = DS()
+
+    out = get_temperature_deviation(
+        data_source=ds,
+        date_start=dt.date(2020, 1, 1),
+        date_end=dt.date(2021, 12, 31),
+        granularity="year",
+        slice_type="day_of_month",
+        month_of_year=2,
+        day_of_month=29,
+    )
+
+    pts = out["national"]["data"]
+
+    assert pts[0]["date"] == dt.date(2020, 2, 29)
+    assert pts[1]["date"] == dt.date(2021, 2, 28)

--- a/backend/weather/tests/unit/test_temperature_deviation_graph_business.py
+++ b/backend/weather/tests/unit/test_temperature_deviation_graph_business.py
@@ -5,10 +5,8 @@ from weather.data_sources.temperature_deviation_fake import (
 )
 from weather.services.temperature_deviation.types import (
     DailyBaselinePoint,
-    DailyDeviationPoint,
     MonthlyBaselinePoint,
     ObservedPoint,
-    StationDailySeries,
     YearlyBaselinePoint,
 )
 from weather.services.temperature_deviation.use_case import get_temperature_deviation
@@ -101,55 +99,6 @@ def test_temperature_deviation_graph__business_deviation_equals_temperature_minu
         point = station["data"][0]
         expected = round(point["temperature"] - point["baseline_mean"], 2)
         assert point["deviation"] == expected
-
-
-def test_temperature_deviation_graph__business_returns_expected_payload_on_simple_input():
-    class DeterministicTemperatureDeviationDataSource:
-        def fetch_national_observed_series(self, query):
-            return [
-                ObservedPoint(
-                    date=dt.date(2024, 1, 1),
-                    temperature=10.0,
-                ),
-                ObservedPoint(
-                    date=dt.date(2024, 1, 2),
-                    temperature=12.0,
-                ),
-            ]
-
-        def fetch_national_daily_baseline(self):
-            return [
-                DailyBaselinePoint(month=1, day_of_month=1, mean=8.0),
-                DailyBaselinePoint(month=1, day_of_month=2, mean=9.0),
-            ]
-
-        def fetch_national_monthly_baseline(self):
-            return [
-                MonthlyBaselinePoint(month=1, mean=8.5),
-            ]
-
-        def fetch_national_yearly_baseline(self):
-            return YearlyBaselinePoint(mean=8.5)
-
-        def fetch_stations_daily_series(self, query):
-            return [
-                StationDailySeries(
-                    station_id="07149",
-                    station_name="Station 07149",
-                    points=[
-                        DailyDeviationPoint(
-                            date=dt.date(2024, 1, 1),
-                            temperature=7.0,
-                            baseline_mean=6.0,
-                        ),
-                        DailyDeviationPoint(
-                            date=dt.date(2024, 1, 2),
-                            temperature=9.0,
-                            baseline_mean=8.5,
-                        ),
-                    ],
-                )
-            ]
 
 
 def test_temperature_deviation_graph_business_national_month_partial_uses_daily_baseline():
@@ -442,3 +391,200 @@ def test_temperature_deviation_graph_business_year_extends_source_window_to_full
 
     assert point["date"] == dt.date(2024, 1, 1)
     assert point["temperature"] == 12.0
+
+
+def test_temperature_deviation_graph_business_full_slice_keeps_target_dates_none():
+    class CaptureDS:
+        def __init__(self):
+            self.last_query = None
+
+        def fetch_national_observed_series(self, query):
+            self.last_query = query
+            return []
+
+        def fetch_stations_daily_series(self, query):
+            self.last_query = query
+            return []
+
+        def fetch_national_daily_baseline(self):
+            return []
+
+        def fetch_national_monthly_baseline(self):
+            return []
+
+        def fetch_national_yearly_baseline(self):
+            return None
+
+    ds = CaptureDS()
+
+    get_temperature_deviation(
+        data_source=ds,
+        date_start=dt.date(2024, 1, 1),
+        date_end=dt.date(2024, 1, 10),
+        granularity="day",
+    )
+
+    assert ds.last_query.target_dates is None
+
+
+def test_temperature_deviation_graph_business_month_day_of_month_sets_target_dates():
+    class CaptureDS:
+        def __init__(self):
+            self.last_query = None
+
+        def fetch_national_observed_series(self, query):
+            self.last_query = query
+            return []
+
+        def fetch_stations_daily_series(self, query):
+            self.last_query = query
+            return []
+
+        def fetch_national_daily_baseline(self):
+            return []
+
+        def fetch_national_monthly_baseline(self):
+            return []
+
+        def fetch_national_yearly_baseline(self):
+            return None
+
+    ds = CaptureDS()
+
+    get_temperature_deviation(
+        data_source=ds,
+        date_start=dt.date(2024, 1, 1),
+        date_end=dt.date(2024, 3, 31),
+        granularity="month",
+        slice_type="day_of_month",
+        day_of_month=31,
+    )
+
+    assert ds.last_query.target_dates is not None
+    assert len(ds.last_query.target_dates) == 3
+
+
+def test_temperature_deviation_graph_business_year_month_of_year_anchors_points():
+    class DS:
+        def fetch_national_observed_series(self, query):
+            return [
+                ObservedPoint(dt.date(2023, 2, 1), 10),
+                ObservedPoint(dt.date(2023, 2, 2), 20),
+                ObservedPoint(dt.date(2024, 2, 1), 30),
+                ObservedPoint(dt.date(2024, 2, 2), 40),
+            ]
+
+        def fetch_national_daily_baseline(self):
+            return [
+                DailyBaselinePoint(2, 1, 0),
+                DailyBaselinePoint(2, 2, 0),
+            ]
+
+        def fetch_national_monthly_baseline(self):
+            return [MonthlyBaselinePoint(2, 5)]
+
+        def fetch_national_yearly_baseline(self):
+            return YearlyBaselinePoint(100)
+
+        def fetch_stations_daily_series(self, query):
+            return []
+
+    ds = DS()
+
+    out = get_temperature_deviation(
+        data_source=ds,
+        date_start=dt.date(2023, 1, 1),
+        date_end=dt.date(2024, 12, 31),
+        granularity="year",
+        slice_type="month_of_year",
+        month_of_year=2,
+    )
+
+    dates = [p["date"] for p in out["national"]["data"]]
+
+    assert dates == [dt.date(2023, 2, 1), dt.date(2024, 2, 1)]
+
+
+def test_temperature_deviation_graph_business_month_day_of_month_returns_exact_day():
+    class DS:
+        def fetch_national_observed_series(self, query):
+            return [
+                ObservedPoint(dt.date(2024, 1, 31), 10),
+                ObservedPoint(dt.date(2024, 2, 29), 20),
+                ObservedPoint(dt.date(2024, 3, 31), 30),
+            ]
+
+        def fetch_national_daily_baseline(self):
+            return [
+                DailyBaselinePoint(1, 31, 1),
+                DailyBaselinePoint(2, 29, 1),
+                DailyBaselinePoint(3, 31, 1),
+            ]
+
+        def fetch_national_monthly_baseline(self):
+            return []
+
+        def fetch_national_yearly_baseline(self):
+            return None
+
+        def fetch_stations_daily_series(self, query):
+            return []
+
+    ds = DS()
+
+    out = get_temperature_deviation(
+        data_source=ds,
+        date_start=dt.date(2024, 1, 1),
+        date_end=dt.date(2024, 3, 31),
+        granularity="month",
+        slice_type="day_of_month",
+        day_of_month=31,
+    )
+
+    dates = [p["date"] for p in out["national"]["data"]]
+
+    assert dates == [
+        dt.date(2024, 1, 31),
+        dt.date(2024, 2, 29),
+        dt.date(2024, 3, 31),
+    ]
+
+
+def test_temperature_deviation_graph_business_year_day_of_month_clamps():
+    class DS:
+        def fetch_national_observed_series(self, query):
+            return [
+                ObservedPoint(dt.date(2020, 2, 29), 10),
+                ObservedPoint(dt.date(2021, 2, 28), 20),
+            ]
+
+        def fetch_national_daily_baseline(self):
+            return [
+                DailyBaselinePoint(2, 29, 1),
+                DailyBaselinePoint(2, 28, 1),
+            ]
+
+        def fetch_national_monthly_baseline(self):
+            return []
+
+        def fetch_national_yearly_baseline(self):
+            return None
+
+        def fetch_stations_daily_series(self, query):
+            return []
+
+    ds = DS()
+
+    out = get_temperature_deviation(
+        data_source=ds,
+        date_start=dt.date(2020, 1, 1),
+        date_end=dt.date(2021, 12, 31),
+        granularity="year",
+        slice_type="day_of_month",
+        month_of_year=2,
+        day_of_month=29,
+    )
+
+    dates = [p["date"] for p in out["national"]["data"]]
+
+    assert dates == [dt.date(2020, 2, 29), dt.date(2021, 2, 28)]

--- a/backend/weather/tests/unit/test_temperature_deviation_graph_fake.py
+++ b/backend/weather/tests/unit/test_temperature_deviation_graph_fake.py
@@ -87,3 +87,74 @@ def test_fake_temperature_deviation_yearly_baseline_returns_value():
 
     assert out is not None
     assert isinstance(out.mean, float)
+
+
+def test_fake_temperature_deviation_national_respects_target_dates():
+    ds = FakeTemperatureDeviationDailyDataSource()
+
+    target_dates = (
+        dt.date(2024, 1, 2),
+        dt.date(2024, 1, 5),
+        dt.date(2024, 1, 9),
+    )
+
+    query = DailyDeviationSeriesQuery(
+        date_start=dt.date(2024, 1, 1),
+        date_end=dt.date(2024, 1, 10),
+        station_ids=(),
+        include_national=True,
+        target_dates=target_dates,
+    )
+
+    result = ds.fetch_national_observed_series(query)
+
+    assert [p.date for p in result] == sorted(target_dates)
+
+
+def test_fake_temperature_deviation_station_respects_target_dates():
+    ds = FakeTemperatureDeviationDailyDataSource()
+
+    target_dates = (
+        dt.date(2024, 1, 3),
+        dt.date(2024, 1, 7),
+    )
+
+    query = DailyDeviationSeriesQuery(
+        date_start=dt.date(2024, 1, 1),
+        date_end=dt.date(2024, 1, 10),
+        station_ids=("07149",),
+        include_national=False,
+        target_dates=target_dates,
+    )
+
+    result = ds.fetch_stations_daily_series(query)
+
+    assert len(result) == 1
+
+    series = result[0]
+
+    assert [p.date for p in series.points] == sorted(target_dates)
+
+
+def test_fake_temperature_deviation_target_dates_are_sorted():
+    ds = FakeTemperatureDeviationDailyDataSource()
+
+    target_dates = (
+        dt.date(2024, 1, 10),
+        dt.date(2024, 1, 2),
+        dt.date(2024, 1, 5),
+    )
+
+    query = DailyDeviationSeriesQuery(
+        date_start=dt.date(2024, 1, 1),
+        date_end=dt.date(2024, 1, 10),
+        station_ids=("07149",),
+        include_national=False,
+        target_dates=target_dates,
+    )
+
+    result = ds.fetch_stations_daily_series(query)
+
+    dates = [p.date for p in result[0].points]
+
+    assert dates == sorted(target_dates)

--- a/backend/weather/tests/unit/test_temperature_deviation_graph_query_serializer.py
+++ b/backend/weather/tests/unit/test_temperature_deviation_graph_query_serializer.py
@@ -19,6 +19,7 @@ def test_temperature_deviation_query_serializer_happy_path():
     assert s.validated_data["granularity"] == "day"
     assert s.validated_data["station_ids"] == ("07149", "07222")
     assert s.validated_data["include_national"] is True
+    assert s.validated_data["slice_type"] == "full"
 
 
 def test_temperature_deviation_query_serializer_include_national_defaults_true():
@@ -33,6 +34,7 @@ def test_temperature_deviation_query_serializer_include_national_defaults_true()
     assert s.is_valid(), s.errors
     assert s.validated_data["include_national"] is True
     assert s.validated_data.get("station_ids", ()) == ()
+    assert s.validated_data["slice_type"] == "full"
 
 
 def test_temperature_deviation_query_serializer_rejects_date_start_gt_date_end():
@@ -74,3 +76,212 @@ def test_temperature_deviation_query_serializer_empty_station_ids_are_empty_tupl
 
     assert s.is_valid(), s.errors
     assert s.validated_data["station_ids"] == ()
+
+
+def test_temperature_deviation_query_serializer_accepts_year_month_of_year_slice():
+    s = TemperatureDeviationGraphQuerySerializer(
+        data={
+            "date_start": "2024-01-01",
+            "date_end": "2024-12-31",
+            "granularity": "year",
+            "slice_type": "month_of_year",
+            "month_of_year": 2,
+        }
+    )
+
+    assert s.is_valid(), s.errors
+    assert s.validated_data["slice_type"] == "month_of_year"
+    assert s.validated_data["month_of_year"] == 2
+
+
+def test_temperature_deviation_query_serializer_accepts_year_day_of_month_slice():
+    s = TemperatureDeviationGraphQuerySerializer(
+        data={
+            "date_start": "2024-01-01",
+            "date_end": "2024-12-31",
+            "granularity": "year",
+            "slice_type": "day_of_month",
+            "month_of_year": 2,
+            "day_of_month": 29,
+        }
+    )
+
+    assert s.is_valid(), s.errors
+
+
+def test_temperature_deviation_query_serializer_accepts_month_day_of_month_slice():
+    s = TemperatureDeviationGraphQuerySerializer(
+        data={
+            "date_start": "2024-01-01",
+            "date_end": "2024-06-30",
+            "granularity": "month",
+            "slice_type": "day_of_month",
+            "day_of_month": 31,
+        }
+    )
+
+    assert s.is_valid(), s.errors
+
+
+def test_temperature_deviation_query_serializer_rejects_day_granularity_with_month_of_year_slice():
+    s = TemperatureDeviationGraphQuerySerializer(
+        data={
+            "date_start": "2024-01-01",
+            "date_end": "2024-01-10",
+            "granularity": "day",
+            "slice_type": "month_of_year",
+            "month_of_year": 2,
+        }
+    )
+
+    assert not s.is_valid()
+    assert "slice_type" in s.errors
+
+
+def test_temperature_deviation_query_serializer_rejects_day_granularity_with_day_of_month_slice():
+    s = TemperatureDeviationGraphQuerySerializer(
+        data={
+            "date_start": "2024-01-01",
+            "date_end": "2024-01-10",
+            "granularity": "day",
+            "slice_type": "day_of_month",
+            "day_of_month": 15,
+        }
+    )
+
+    assert not s.is_valid()
+    assert "slice_type" in s.errors
+
+
+def test_temperature_deviation_query_serializer_rejects_day_granularity_with_month_of_year_param():
+    s = TemperatureDeviationGraphQuerySerializer(
+        data={
+            "date_start": "2024-01-01",
+            "date_end": "2024-01-10",
+            "granularity": "day",
+            "month_of_year": 2,
+        }
+    )
+
+    assert not s.is_valid()
+    assert "month_of_year" in s.errors
+
+
+def test_temperature_deviation_query_serializer_rejects_day_granularity_with_day_of_month_param():
+    s = TemperatureDeviationGraphQuerySerializer(
+        data={
+            "date_start": "2024-01-01",
+            "date_end": "2024-01-10",
+            "granularity": "day",
+            "day_of_month": 15,
+        }
+    )
+
+    assert not s.is_valid()
+    assert "day_of_month" in s.errors
+
+
+def test_temperature_deviation_query_serializer_rejects_month_of_year_when_slice_type_full():
+    s = TemperatureDeviationGraphQuerySerializer(
+        data={
+            "date_start": "2024-01-01",
+            "date_end": "2024-12-31",
+            "granularity": "year",
+            "slice_type": "full",
+            "month_of_year": 2,
+        }
+    )
+
+    assert not s.is_valid()
+    assert "month_of_year" in s.errors
+
+
+def test_temperature_deviation_query_serializer_rejects_day_of_month_when_slice_type_full():
+    s = TemperatureDeviationGraphQuerySerializer(
+        data={
+            "date_start": "2024-01-01",
+            "date_end": "2024-12-31",
+            "granularity": "year",
+            "slice_type": "full",
+            "day_of_month": 15,
+        }
+    )
+
+    assert not s.is_valid()
+    assert "day_of_month" in s.errors
+
+
+def test_temperature_deviation_query_serializer_rejects_month_of_year_slice_for_month_granularity():
+    s = TemperatureDeviationGraphQuerySerializer(
+        data={
+            "date_start": "2024-01-01",
+            "date_end": "2024-12-31",
+            "granularity": "month",
+            "slice_type": "month_of_year",
+            "month_of_year": 2,
+        }
+    )
+
+    assert not s.is_valid()
+    assert "slice_type" in s.errors
+
+
+def test_temperature_deviation_query_serializer_rejects_month_of_year_slice_without_month_of_year():
+    s = TemperatureDeviationGraphQuerySerializer(
+        data={
+            "date_start": "2024-01-01",
+            "date_end": "2024-12-31",
+            "granularity": "year",
+            "slice_type": "month_of_year",
+        }
+    )
+
+    assert not s.is_valid()
+    assert "month_of_year" in s.errors
+
+
+def test_temperature_deviation_query_serializer_rejects_day_of_month_with_month_of_year_slice():
+    s = TemperatureDeviationGraphQuerySerializer(
+        data={
+            "date_start": "2024-01-01",
+            "date_end": "2024-12-31",
+            "granularity": "year",
+            "slice_type": "month_of_year",
+            "month_of_year": 2,
+            "day_of_month": 15,
+        }
+    )
+
+    assert not s.is_valid()
+    assert "day_of_month" in s.errors
+
+
+def test_temperature_deviation_query_serializer_rejects_year_day_of_month_slice_without_month_of_year():
+    s = TemperatureDeviationGraphQuerySerializer(
+        data={
+            "date_start": "2024-01-01",
+            "date_end": "2024-12-31",
+            "granularity": "year",
+            "slice_type": "day_of_month",
+            "day_of_month": 15,
+        }
+    )
+
+    assert not s.is_valid()
+    assert "month_of_year" in s.errors
+
+
+def test_temperature_deviation_query_serializer_rejects_month_day_of_month_slice_with_month_of_year():
+    s = TemperatureDeviationGraphQuerySerializer(
+        data={
+            "date_start": "2024-01-01",
+            "date_end": "2024-06-30",
+            "granularity": "month",
+            "slice_type": "day_of_month",
+            "day_of_month": 15,
+            "month_of_year": 2,
+        }
+    )
+
+    assert not s.is_valid()
+    assert "month_of_year" in s.errors

--- a/backend/weather/views.py
+++ b/backend/weather/views.py
@@ -157,13 +157,22 @@ class TemperatureDeviationGraphAPIView(APIView):
                 ),
                 status=status.HTTP_501_NOT_IMPLEMENTED,
             )
+        metadata = {
+            "date_start": params["date_start"],
+            "date_end": params["date_end"],
+            "baseline": "1991-2020",
+            "granularity": params["granularity"],
+            "slice_type": params.get("slice_type", "full"),
+        }
+
+        if "month_of_year" in params:
+            metadata["month_of_year"] = params["month_of_year"]
+
+        if "day_of_month" in params:
+            metadata["day_of_month"] = params["day_of_month"]
+
         full_payload = {
-            "metadata": {
-                "date_start": params["date_start"],
-                "date_end": params["date_end"],
-                "baseline": "1991-2020",
-                "granularity": params["granularity"],
-            },
+            "metadata": metadata,
             **data,
         }
 


### PR DESCRIPTION
## Type de PR
- [ ] Bugfix
- [X] Feature
- [ ] Refactor
- [ ] Chore / Tech debt
- [ ] Documentation
- [ ] Autre (à préciser)

## Objectif
Ajouter des mécanismes de sélection de période (slice_type) sur l’endpoint /temperature/deviation/graph

## Contexte
Complète #275 

## Changements
- Extension du contrat OpenAPI :
   - ajout de slice_type, month_of_year, day_of_month
- Mise à jour des serializers 
- Propagation des nouveaux paramètres (view, use_case, service)
- Refactor du service :
   - ajout de source_window, slicing, aggregation
   - introduction de target_dates pour limiter les requêtes
   - correction de l’ancrage des dates en sortie
- Implémentation du slicing côté national et stations
- Adaptation des data sources (Timescale + fake) pour supporter target_dates
- Ajout de tests :
   - validation serializer
   - endpoint HTTP
   - logique métier (slicing, baseline, ancrage)
   - data sources (target_dates)
   
## Décisions techniques
- Alignement partiel avec ITN :
   - même mécanique de slicing
   - même logique de target_dates pour la volumétrie
- Conservation du comportement historique pour slice_type=full :
   - bucket complet → baseline agrégée (mensuelle / annuelle)
   - bucket partiel → fallback sur moyenne des baselines journalières
=> évite un biais sur les périodes tronquées
- Séparation claire des responsabilités :
   - slicing
   - agrégation
   - fenêtre source
=> évite la complexité monolithique du service initial


## Impacts
- [X] API / contrat
- [ ] Modèle de données / DB
- [X] Calculs métier
- [ ] Performance
- [ ] Sécurité
- [ ] Infra / déploiement
- [ ] Aucun impact transverse identifié

## Tests
- [X] Tests unitaires
- [X] Tests d’intégration
- [X] Tests manuels
- [ ] Non applicable (à justifier)

## Points d’attention pour la review
<!-- Parties sensibles du code, dette technique introduite, risques. -->

## Suivi
- [ ] Migration à prévoir
- [ ] Documentation à mettre à jour
- [ ] Tâche(s) de suivi à créer
