### PR TITLE
Feat/front/auto date interval threshold

### DIFF
--- a/frontend/app/components/table/deviation/DeviationTable.vue
+++ b/frontend/app/components/table/deviation/DeviationTable.vue
@@ -9,6 +9,10 @@ import DayPicker from "~/components/ui/commons/selectBar/dayPicker.vue";
 import { useCustomDate } from "~/composables/useCustomDate";
 import type { TemperatureDeviationResponse } from "~/types/api";
 import { buildDeviationCsv } from "~/utils/deviationCsv";
+const props = withDefaults(defineProps<{ showFilters?: boolean }>(), {
+    showFilters: true,
+});
+
 const store = useDeviationTableStore();
 
 const dates = useCustomDate();
@@ -198,6 +202,7 @@ const columns: TableColumn<TableRow>[] = [
     <div class="flex flex-col gap-4">
         <div class="flex items-end justify-between gap-4">
             <DayPicker
+                v-if="props.showFilters"
                 v-model:start-date="dateStart"
                 v-model:end-date="dateEnd"
                 :min-date="dates.absoluteMinDataDate.value"

--- a/frontend/app/components/ui/commons/selectBar/dayPicker.vue
+++ b/frontend/app/components/ui/commons/selectBar/dayPicker.vue
@@ -9,19 +9,22 @@ const localEndDate = defineModel<Date | undefined>("endDate");
 const adapter = inject<SelectBarAdapter>("selectBarAdapter");
 const dates = useCustomDate();
 
-const minStartDate = computed(() => {
-    if (!localEndDate.value) return dates.absoluteMinDataDate.value;
-    const d = new Date(localEndDate.value);
-    d.setFullYear(d.getFullYear() - 2);
-    return d;
+const maxEndDate = adapter?.maxDate?.value ?? dates.today.value;
+
+watch(localStartDate, (newStart) => {
+    if (!newStart || !localEndDate.value) return;
+    const limit = new Date(newStart);
+    limit.setFullYear(limit.getFullYear() + 2);
+    const ceiling = adapter?.maxDate?.value ?? dates.today.value;
+    const cap = limit < ceiling ? limit : ceiling;
+    if (localEndDate.value > cap) localEndDate.value = cap;
 });
 
-const maxEndDate = computed(() => {
-    const ceiling = adapter?.maxDate?.value ?? dates.yesterday.value;
-    if (!localStartDate.value) return ceiling;
-    const d = new Date(localStartDate.value);
-    d.setFullYear(d.getFullYear() + 2);
-    return d < ceiling ? d : ceiling;
+watch(localEndDate, (newEnd) => {
+    if (!newEnd || !localStartDate.value) return;
+    const limit = new Date(newEnd);
+    limit.setFullYear(limit.getFullYear() - 2);
+    if (localStartDate.value < limit) localStartDate.value = limit;
 });
 
 const pt = {
@@ -118,7 +121,6 @@ const pt = {
             <p class="text-sm text-default">Jour de début</p>
             <DatePicker
                 v-model="localStartDate"
-                :min-date="minStartDate"
                 :max-date="localEndDate"
                 date-format="dd/mm/yy"
                 :pt="pt"

--- a/frontend/app/components/ui/commons/selectBar/monthPicker.vue
+++ b/frontend/app/components/ui/commons/selectBar/monthPicker.vue
@@ -9,19 +9,22 @@ const localEndDate = defineModel<Date | undefined>("endDate");
 const adapter = inject<SelectBarAdapter>("selectBarAdapter")!;
 const dates = useCustomDate();
 
-const minStartDate = computed(() => {
-    if (!localEndDate.value) return dates.absoluteMinDataDate.value;
-    const d = new Date(localEndDate.value);
-    d.setFullYear(d.getFullYear() - 50);
-    return d;
+const maxEndDate = adapter?.maxDate?.value ?? dates.today.value;
+
+watch(localStartDate, (newStart) => {
+    if (!newStart || !localEndDate.value) return;
+    const limit = new Date(newStart);
+    limit.setFullYear(limit.getFullYear() + 50);
+    const ceiling = adapter?.maxDate?.value ?? dates.today.value;
+    const cap = limit < ceiling ? limit : ceiling;
+    if (localEndDate.value > cap) localEndDate.value = cap;
 });
 
-const maxEndDate = computed(() => {
-    if (!localStartDate.value) return dates.today.value;
-    const d = new Date(localStartDate.value);
-    d.setFullYear(d.getFullYear() + 50);
-    const max = adapter.maxDate?.value ?? dates.today.value;
-    return d < max ? d : max;
+watch(localEndDate, (newEnd) => {
+    if (!newEnd || !localStartDate.value) return;
+    const limit = new Date(newEnd);
+    limit.setFullYear(limit.getFullYear() - 50);
+    if (localStartDate.value < limit) localStartDate.value = limit;
 });
 
 const pt = {
@@ -94,7 +97,6 @@ const pt = {
             <p class="text-sm text-default">Mois de début</p>
             <DatePicker
                 v-model="localStartDate"
-                :min-date="minStartDate"
                 :max-date="localEndDate"
                 view="month"
                 date-format="mm/yy"

--- a/frontend/app/components/ui/commons/selectBar/selectBar.vue
+++ b/frontend/app/components/ui/commons/selectBar/selectBar.vue
@@ -71,7 +71,7 @@ const granularityValues = reactive([
                 v-model:end-date="localEndDate"
                 :min-date="dates.absoluteMinDataDate.value"
                 :max-date="dates.today.value"
-            />/>
+            />
             <SelectChartType v-if="adapter.features.hasChartTypeSelector" />
 
             <USeparator

--- a/frontend/app/pages/ecart-normale.vue
+++ b/frontend/app/pages/ecart-normale.vue
@@ -28,7 +28,7 @@ const mapDateEnd = computed(() => toISODate(dateEnd.value));
 const heroData = {
     title: "Écart à la normale",
     description:
-        "L'écart de température à la normale est définit comme la différence de la température moyenne sur une période donnéeet la température moyenne de référence calculée sur la période 1991–2020 pour une durée équivalente",
+        "L'écart de température à la normale est définit comme la différence de la température moyenne sur une période donnée et la température moyenne de référence calculée sur la période 1991–2020 pour une durée équivalente",
 };
 </script>
 

--- a/frontend/app/pages/ecart-normale.vue
+++ b/frontend/app/pages/ecart-normale.vue
@@ -28,7 +28,7 @@ const mapDateEnd = computed(() => toISODate(dateEnd.value));
 const heroData = {
     title: "Écart à la normale",
     description:
-        "L'écart de température à la normale est définit comme la différence de la température moyenne sur une période donnée et la température moyenne de référence calculée sur la période 1991–2020 pour une durée équivalente",
+        "L'écart de température à la normale est définit comme la différence de la température moyenne sur une période donnéeet la température moyenne de référence calculée sur la période 1991–2020 pour une durée équivalente",
 };
 </script>
 


### PR DESCRIPTION
## Type de PR
- [ ] Bugfix
- [x] Feature
- [ ] Refactor
- [ ] Chore / Tech debt
- [ ] Documentation
- [ ] Autre (à préciser)

## Objectif
Laisse la possibilité de choisir à l'utilisateur n'importe quelle date de début et de fin mais restreint juste la durée de l'intervall si granularité est jour ou mois

## Contexte
Amélioration UX de https://github.com/dataforgoodfr/14_ValorisationDonneeMeteo/pull/343

## Changements
ajout de 2 watch pour mettre à jour endDate ou startDate selon modifs de l'un ou l'autre

## Décisions techniques
<!-- Choix structurants, arbitrages, compromis. -->
<!-- Ce qui aurait pu être fait autrement. -->

## Impacts
- [ ] API / contrat
- [ ] Modèle de données / DB
- [ ] Calculs métier
- [ ] Performance
- [ ] Sécurité
- [ ] Infra / déploiement
- [ ] Aucun impact transverse identifié

## Tests
<!-- Décris ce qui a été fait dans cette PR pour vérifier le comportement introduit ou modifié. -->
- [ ] Tests unitaires
- [ ] Tests d’intégration
- [x] Tests manuels
- [ ] Non applicable (à justifier)

## Points d’attention pour la review
<!-- Parties sensibles du code, dette technique introduite, risques. -->

## Suivi
- [ ] Migration à prévoir
- [ ] Documentation à mettre à jour
- [ ] Tâche(s) de suivi à créer
