### PR TITLE
extend limit de 500 à 5000 pour envoyer données

### DIFF
--- a/backend/weather/serializers.py
+++ b/backend/weather/serializers.py
@@ -336,7 +336,7 @@ class TemperatureDeviationOverviewQuerySerializer(serializers.Serializer):
     limit = serializers.IntegerField(
         required=False,
         min_value=1,
-        max_value=500,
+        max_value=5000,
         default=50,
     )
     offset = serializers.IntegerField(required=False, min_value=0, default=0)

--- a/backend/weather/serializers.py
+++ b/backend/weather/serializers.py
@@ -336,7 +336,6 @@ class TemperatureDeviationOverviewQuerySerializer(serializers.Serializer):
     limit = serializers.IntegerField(
         required=False,
         min_value=1,
-        max_value=5000,
         default=50,
     )
     offset = serializers.IntegerField(required=False, min_value=0, default=0)

--- a/frontend/app/components/charts/MapD3.vue
+++ b/frontend/app/components/charts/MapD3.vue
@@ -101,7 +101,6 @@ const props = defineProps<{
 const params = computed<DeviationMapParams>(() => ({
     date_start: props.dateStart,
     date_end: props.dateEnd,
-    limit: 5000,
 }));
 
 const { data: stationsData, execute: fetchStations } =

--- a/frontend/app/components/charts/MapD3.vue
+++ b/frontend/app/components/charts/MapD3.vue
@@ -101,6 +101,7 @@ const props = defineProps<{
 const params = computed<DeviationMapParams>(() => ({
     date_start: props.dateStart,
     date_end: props.dateEnd,
+    limit: 99999,
 }));
 
 const { data: stationsData, execute: fetchStations } =

--- a/frontend/app/components/charts/MapD3.vue
+++ b/frontend/app/components/charts/MapD3.vue
@@ -101,7 +101,7 @@ const props = defineProps<{
 const params = computed<DeviationMapParams>(() => ({
     date_start: props.dateStart,
     date_end: props.dateEnd,
-    limit: 500,
+    limit: 5000,
 }));
 
 const { data: stationsData, execute: fetchStations } =


### PR DESCRIPTION
## Type de PR
- [x] Bugfix
- [ ] Feature
- [ ] Refactor
- [ ] Chore / Tech debt
- [ ] Documentation
- [ ] Autre (à préciser)

## Objectif
Afficher toutes les stations sur la carte

## Contexte
Les stations affichées sur la carte changent selon période sélectionnée

## Changements
- passage de la limite à renvoyer par le back de 500 à 5000
- mis à jour de mapD3.vue pour mettre à jour limite
<img width="410" height="403" alt="image" src="https://github.com/user-attachments/assets/f70a8284-d52e-423e-80d0-52987efa50bc" />


## Décisions techniques
<!-- Choix structurants, arbitrages, compromis. -->
<!-- Ce qui aurait pu être fait autrement. -->

## Impacts
- [ ] API / contrat
- [ ] Modèle de données / DB
- [ ] Calculs métier
- [ ] Performance
- [ ] Sécurité
- [ ] Infra / déploiement
- [ ] Aucun impact transverse identifié

## Tests
<!-- Décris ce qui a été fait dans cette PR pour vérifier le comportement introduit ou modifié. -->
- [ ] Tests unitaires
- [ ] Tests d’intégration
- [ ] Tests manuels
- [ ] Non applicable (à justifier)

## Points d’attention pour la review
<!-- Parties sensibles du code, dette technique introduite, risques. -->

## Suivi
- [ ] Migration à prévoir
- [ ] Documentation à mettre à jour
- [ ] Tâche(s) de suivi à créer
