### PR TITLE
Feat/front/kpi graph itn

### DIFF
--- a/frontend/app/app.config.ts
+++ b/frontend/app/app.config.ts
@@ -1,5 +1,8 @@
 export default defineAppConfig({
     ui: {
+        container: {
+            base: "px-2 sm:px-4",
+        },
         card: {
             slots: {
                 root: "rounded-lg overflow-hidden",

--- a/frontend/app/app.config.ts
+++ b/frontend/app/app.config.ts
@@ -1,7 +1,8 @@
 export default defineAppConfig({
     ui: {
         container: {
-            base: "px-2 sm:px-4",
+            base: "w-full max-w-screen-xl mx-auto",
+            padding: "px-2 sm:px-4",
         },
         card: {
             slots: {

--- a/frontend/app/components/charts/ItnKpiPanel.vue
+++ b/frontend/app/components/charts/ItnKpiPanel.vue
@@ -102,6 +102,7 @@
 import Card from "~/components/home/Card.vue";
 import { useItnStore } from "~/stores/itnStore";
 import { dateToStringYMD } from "#imports";
+import type { NationalIndicatorKpiParams } from "~/types/api";
 
 const store = useItnStore();
 const { pickedDateStart, pickedDateEnd } = storeToRefs(store);
@@ -120,25 +121,25 @@ const prevPeriod = computed(() => {
     };
 });
 
-const hotParams = computed(() => ({
+const hotParams = computed<NationalIndicatorKpiParams>(() => ({
     date_start: dateToStringYMD(new Date(pickedDateStart.value)),
     date_end: dateToStringYMD(new Date(pickedDateEnd.value)),
-    type: "hot" as const,
+    type: "hot",
 }));
 
-const coldParams = computed(() => ({
+const coldParams = computed<NationalIndicatorKpiParams>(() => ({
     date_start: dateToStringYMD(new Date(pickedDateStart.value)),
     date_end: dateToStringYMD(new Date(pickedDateEnd.value)),
-    type: "cold" as const,
+    type: "cold",
 }));
 
-const prevHotParams = computed(() => ({
+const prevHotParams = computed<NationalIndicatorKpiParams>(() => ({
     ...prevPeriod.value,
-    type: "hot" as const,
+    type: "hot",
 }));
-const prevColdParams = computed(() => ({
+const prevColdParams = computed<NationalIndicatorKpiParams>(() => ({
     ...prevPeriod.value,
-    type: "cold" as const,
+    type: "cold",
 }));
 
 const { data: hotKpi } = useNationalIndicatorKpi(hotParams);

--- a/frontend/app/components/charts/ItnKpiPanel.vue
+++ b/frontend/app/components/charts/ItnKpiPanel.vue
@@ -50,6 +50,22 @@
                     <span v-else class="text-muted">—</span>
                 </p>
             </template>
+            <template v-if="hotDiff != null" #variation>
+                <span class="text-sm">
+                    {{ hotDiff >= 0 ? "+" : "" }}{{ hotDiff }}
+                </span>
+                <UIcon
+                    v-if="hotDiff < 0"
+                    name="i-lucide-arrow-down-right"
+                    class="text-blue-400"
+                />
+                <UIcon
+                    v-if="hotDiff > 0"
+                    name="i-lucide-arrow-up-right"
+                    class="text-red-400"
+                />
+                vs période précédente
+            </template>
         </Card>
 
         <Card
@@ -61,6 +77,22 @@
                     <span v-if="coldKpi != null">{{ coldKpi.count }}</span>
                     <span v-else class="text-muted">—</span>
                 </p>
+            </template>
+            <template v-if="coldDiff != null" #variation>
+                <span class="text-sm">
+                    {{ coldDiff >= 0 ? "+" : "" }}{{ coldDiff }}
+                </span>
+                <UIcon
+                    v-if="coldDiff < 0"
+                    name="i-lucide-arrow-down-right"
+                    class="text-red-400"
+                />
+                <UIcon
+                    v-if="coldDiff > 0"
+                    name="i-lucide-arrow-up-right"
+                    class="text-blue-400"
+                />
+                vs période précédente
             </template>
         </Card>
     </div>
@@ -74,6 +106,20 @@ import { dateToStringYMD } from "#imports";
 const store = useItnStore();
 const { pickedDateStart, pickedDateEnd } = storeToRefs(store);
 
+const prevPeriod = computed(() => {
+    const start = new Date(pickedDateStart.value);
+    const end = new Date(pickedDateEnd.value);
+    const durationMs = end.getTime() - start.getTime();
+    const prevEnd = new Date(start.getTime() - 24 * 60 * 60 * 1000);
+    const prevStart = new Date(
+        start.getTime() - durationMs - 24 * 60 * 60 * 1000,
+    );
+    return {
+        date_start: dateToStringYMD(prevStart),
+        date_end: dateToStringYMD(prevEnd),
+    };
+});
+
 const hotParams = computed(() => ({
     date_start: dateToStringYMD(new Date(pickedDateStart.value)),
     date_end: dateToStringYMD(new Date(pickedDateEnd.value)),
@@ -86,6 +132,27 @@ const coldParams = computed(() => ({
     type: "cold" as const,
 }));
 
+const prevHotParams = computed(() => ({
+    ...prevPeriod.value,
+    type: "hot" as const,
+}));
+const prevColdParams = computed(() => ({
+    ...prevPeriod.value,
+    type: "cold" as const,
+}));
+
 const { data: hotKpi } = useNationalIndicatorKpi(hotParams);
 const { data: coldKpi } = useNationalIndicatorKpi(coldParams);
+const { data: prevHotKpi } = useNationalIndicatorKpi(prevHotParams);
+const { data: prevColdKpi } = useNationalIndicatorKpi(prevColdParams);
+
+const hotDiff = computed(() => {
+    if (hotKpi.value == null || prevHotKpi.value == null) return null;
+    return hotKpi.value.count - prevHotKpi.value.count;
+});
+
+const coldDiff = computed(() => {
+    if (coldKpi.value == null || prevColdKpi.value == null) return null;
+    return coldKpi.value.count - prevColdKpi.value.count;
+});
 </script>

--- a/frontend/app/components/charts/ItnKpiPanel.vue
+++ b/frontend/app/components/charts/ItnKpiPanel.vue
@@ -1,8 +1,6 @@
 <template>
     <div class="flex flex-col gap-3 w-52 shrink-0 py-2">
-        <Card
-            v-for="i in 3"
-            :key="i"
+        <!-- <Card // à ajouter une fois le endpoint enrichi
             title="ITN moyen"
             tooltip-text="Moyenne de l'Indicateur Thermique National sur la période sélectionnée."
         >
@@ -10,33 +8,59 @@
                 <p
                     class="font-semibold text-4xl mb-1"
                     :class="
-                        (currentMean ?? 0) >= 0
+                        (hotKpi?.itn_mean ?? 0) >= 0
                             ? 'text-red-400'
                             : 'text-blue-400'
                     "
                 >
-                    <span v-if="currentMean != null">
-                        {{ currentMean >= 0 ? "+" : ""
-                        }}{{ currentMean.toFixed(1) }} °C
+                    <span v-if="hotKpi?.itn_mean != null">
+                        {{ hotKpi.itn_mean >= 0 ? "+" : ""
+                        }}{{ hotKpi.itn_mean.toFixed(1) }} °C
                     </span>
                     <span v-else class="text-muted">—</span>
                 </p>
             </template>
-            <template v-if="diff != null" #variation>
+            <template v-if="hotKpi?.deviation_from_normal != null" #variation>
                 <span class="text-sm">
-                    {{ diff >= 0 ? "+" : "" }}{{ diff.toFixed(1) }}°C
+                    {{
+                        hotKpi.deviation_from_normal >= 0 ? "+" : ""
+                    }}{{ hotKpi.deviation_from_normal.toFixed(1) }}°C
                 </span>
                 <UIcon
-                    v-if="diff < 0"
+                    v-if="hotKpi.deviation_from_normal < 0"
                     name="i-lucide-arrow-down-right"
                     class="text-blue-400"
                 />
                 <UIcon
-                    v-if="diff > 0"
+                    v-if="hotKpi.deviation_from_normal > 0"
                     name="i-lucide-arrow-up-right"
                     class="text-red-400"
                 />
-                vs période précédente
+                vs normale
+            </template>
+        </Card> -->
+
+        <Card
+            title="Pics chauds"
+            tooltip-text="Nombre de jours où l'ITN dépasse la normale d'un écart-type sur la période sélectionnée."
+        >
+            <template #kpi>
+                <p class="font-semibold text-4xl mb-1 text-red-400">
+                    <span v-if="hotKpi != null">{{ hotKpi.count }}</span>
+                    <span v-else class="text-muted">—</span>
+                </p>
+            </template>
+        </Card>
+
+        <Card
+            title="Pics froids"
+            tooltip-text="Nombre de jours où l'ITN est inférieur à la normale d'un écart-type sur la période sélectionnée."
+        >
+            <template #kpi>
+                <p class="font-semibold text-4xl mb-1 text-blue-400">
+                    <span v-if="coldKpi != null">{{ coldKpi.count }}</span>
+                    <span v-else class="text-muted">—</span>
+                </p>
             </template>
         </Card>
     </div>
@@ -46,53 +70,22 @@
 import Card from "~/components/home/Card.vue";
 import { useItnStore } from "~/stores/itnStore";
 import { dateToStringYMD } from "#imports";
-import type { NationalIndicatorParams } from "~/types/api";
 
 const store = useItnStore();
-const {
-    itnData,
-    pickedDateStart,
-    pickedDateEnd,
-    granularity,
-    sliceType,
-    month_of_year,
-    day_of_month,
-} = storeToRefs(store);
+const { pickedDateStart, pickedDateEnd } = storeToRefs(store);
 
-const prevYearParams = computed<NationalIndicatorParams>(() => {
-    const start = new Date(pickedDateStart.value);
-    const end = new Date(pickedDateEnd.value);
-    start.setFullYear(start.getFullYear() - 1);
-    end.setFullYear(end.getFullYear() - 1);
-    return {
-        date_start: dateToStringYMD(start),
-        date_end: dateToStringYMD(end),
-        granularity: granularity.value,
-        slice_type: sliceType.value,
-        month_of_year: month_of_year.value,
-        day_of_month: day_of_month.value,
-    };
-});
+const hotParams = computed(() => ({
+    date_start: dateToStringYMD(new Date(pickedDateStart.value)),
+    date_end: dateToStringYMD(new Date(pickedDateEnd.value)),
+    type: "hot" as const,
+}));
 
-const { data: prevYearData } = useNationalIndicator(prevYearParams);
+const coldParams = computed(() => ({
+    date_start: dateToStringYMD(new Date(pickedDateStart.value)),
+    date_end: dateToStringYMD(new Date(pickedDateEnd.value)),
+    type: "cold" as const,
+}));
 
-function meanTemperature(
-    timeSeries: { temperature: number }[] | undefined,
-): number | null {
-    if (!timeSeries?.length) return null;
-    return (
-        timeSeries.reduce((sum, p) => sum + p.temperature, 0) /
-        timeSeries.length
-    );
-}
-
-const currentMean = computed(() => meanTemperature(itnData.value?.time_series));
-const prevMean = computed(() =>
-    meanTemperature(prevYearData.value?.time_series),
-);
-
-const diff = computed(() => {
-    if (currentMean.value == null || prevMean.value == null) return null;
-    return currentMean.value - prevMean.value;
-});
+const { data: hotKpi } = useNationalIndicatorKpi(hotParams);
+const { data: coldKpi } = useNationalIndicatorKpi(coldParams);
 </script>

--- a/frontend/app/components/charts/ItnKpiPanel.vue
+++ b/frontend/app/components/charts/ItnKpiPanel.vue
@@ -1,0 +1,98 @@
+<template>
+    <div class="flex flex-col gap-3 w-52 shrink-0 py-2">
+        <Card
+            v-for="i in 3"
+            :key="i"
+            title="ITN moyen"
+            tooltip-text="Moyenne de l'Indicateur Thermique National sur la période sélectionnée."
+        >
+            <template #kpi>
+                <p
+                    class="font-semibold text-4xl mb-1"
+                    :class="
+                        (currentMean ?? 0) >= 0
+                            ? 'text-red-400'
+                            : 'text-blue-400'
+                    "
+                >
+                    <span v-if="currentMean != null">
+                        {{ currentMean >= 0 ? "+" : ""
+                        }}{{ currentMean.toFixed(1) }} °C
+                    </span>
+                    <span v-else class="text-muted">—</span>
+                </p>
+            </template>
+            <template v-if="diff != null" #variation>
+                <span class="text-sm">
+                    {{ diff >= 0 ? "+" : "" }}{{ diff.toFixed(1) }}°C
+                </span>
+                <UIcon
+                    v-if="diff < 0"
+                    name="i-lucide-arrow-down-right"
+                    class="text-blue-400"
+                />
+                <UIcon
+                    v-if="diff > 0"
+                    name="i-lucide-arrow-up-right"
+                    class="text-red-400"
+                />
+                vs période précédente
+            </template>
+        </Card>
+    </div>
+</template>
+
+<script setup lang="ts">
+import Card from "~/components/home/Card.vue";
+import { useItnStore } from "~/stores/itnStore";
+import { dateToStringYMD } from "#imports";
+import type { NationalIndicatorParams } from "~/types/api";
+
+const store = useItnStore();
+const {
+    itnData,
+    pickedDateStart,
+    pickedDateEnd,
+    granularity,
+    sliceType,
+    month_of_year,
+    day_of_month,
+} = storeToRefs(store);
+
+const prevYearParams = computed<NationalIndicatorParams>(() => {
+    const start = new Date(pickedDateStart.value);
+    const end = new Date(pickedDateEnd.value);
+    start.setFullYear(start.getFullYear() - 1);
+    end.setFullYear(end.getFullYear() - 1);
+    return {
+        date_start: dateToStringYMD(start),
+        date_end: dateToStringYMD(end),
+        granularity: granularity.value,
+        slice_type: sliceType.value,
+        month_of_year: month_of_year.value,
+        day_of_month: day_of_month.value,
+    };
+});
+
+const { data: prevYearData } = useNationalIndicator(prevYearParams);
+
+function meanTemperature(
+    timeSeries: { temperature: number }[] | undefined,
+): number | null {
+    if (!timeSeries?.length) return null;
+    return (
+        timeSeries.reduce((sum, p) => sum + p.temperature, 0) /
+        timeSeries.length
+    );
+}
+
+const currentMean = computed(() => meanTemperature(itnData.value?.time_series));
+const prevMean = computed(() =>
+    meanTemperature(prevYearData.value?.time_series),
+);
+
+const diff = computed(() => {
+    if (currentMean.value == null || prevMean.value == null) return null;
+    return currentMean.value - prevMean.value;
+});
+</script>

--- a/frontend/app/components/charts/ItnKpiPanel.vue
+++ b/frontend/app/components/charts/ItnKpiPanel.vue
@@ -41,8 +41,8 @@
         </Card> -->
 
         <Card
-            title="Pics chauds"
-            tooltip-text="Nombre de jours où l'ITN dépasse la normale d'un écart-type sur la période sélectionnée."
+            title="Jours de chaleur"
+            tooltip-text="Nombre de jours avec excédent de chaleur sur la période sélectionnée."
         >
             <template #kpi>
                 <p class="font-semibold text-4xl mb-1 text-red-400">
@@ -69,8 +69,8 @@
         </Card>
 
         <Card
-            title="Pics froids"
-            tooltip-text="Nombre de jours où l'ITN est inférieur à la normale d'un écart-type sur la période sélectionnée."
+            title="Jours de froid"
+            tooltip-text="Nombre de jours avec excédent de froid sur la période sélectionnée."
         >
             <template #kpi>
                 <p class="font-semibold text-4xl mb-1 text-blue-400">

--- a/frontend/app/components/layout/ChartLayout.vue
+++ b/frontend/app/components/layout/ChartLayout.vue
@@ -12,7 +12,7 @@ const sidebarOpen = ref(false);
 
 <template>
     <div
-        class="flex flex-col w-full divide-y divide-gray-200 border border-gray-200 rounded-lg"
+        class="flex w-full flex-col divide-y divide-gray-200 border border-gray-200 rounded-lg overflow-hidden"
     >
         <slot name="select-bar" />
 

--- a/frontend/app/composables/useNationalIndicatorKpi.ts
+++ b/frontend/app/composables/useNationalIndicatorKpi.ts
@@ -1,0 +1,15 @@
+import type {
+    NationalIndicatorKpiParams,
+    NationalIndicatorKpiResponse,
+} from "~/types/api";
+
+export function useNationalIndicatorKpi(
+    params: MaybeRef<NationalIndicatorKpiParams>,
+) {
+    const { useApiFetch } = useApiClient();
+
+    return useApiFetch<NationalIndicatorKpiResponse>(
+        "/temperature/national-indicator/kpi",
+        { query: params },
+    );
+}

--- a/frontend/app/pages/itn.vue
+++ b/frontend/app/pages/itn.vue
@@ -25,7 +25,12 @@ const heroData = {
                 <SelectBar :adapter="selectBarAdapter" />
             </template>
             <template #chart>
-                <ItnChart :adapter="selectBarAdapter" class="px-3 py-2" />
+                <div class="flex gap-4 px-3 py-2">
+                    <div class="flex-1 min-w-0">
+                        <ItnChart :adapter="selectBarAdapter" />
+                    </div>
+                    <ItnKpiPanel />
+                </div>
             </template>
         </ChartLayout>
     </UContainer>

--- a/frontend/app/pages/itn.vue
+++ b/frontend/app/pages/itn.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import ItnChart from "~/components/charts/ItnChart.vue";
+import ItnKpiPanel from "~/components/charts/ItnKpiPanel.vue";
 import PagesHero from "~/components/layout/PagesHero.vue";
 import SelectBar from "~/components/ui/commons/selectBar/selectBar.vue";
 import ChartLayout from "~/components/layout/ChartLayout.vue";

--- a/frontend/app/types/api.ts
+++ b/frontend/app/types/api.ts
@@ -78,6 +78,26 @@ export interface NationalIndicatorResponse {
     time_series: NationalIndicatorDataPoint[];
 }
 
+export interface NationalIndicatorKpiParams {
+    date_start: string;
+    date_end: string;
+    type: "hot" | "cold";
+}
+
+export interface NationalIndicatorKpiDay {
+    date: string;
+    temperature: number;
+    baseline_mean: number;
+    baseline_std_dev: number;
+}
+
+export interface NationalIndicatorKpiResponse {
+    count: number;
+    itn_mean: number | null;
+    deviation_from_normal: number | null;
+    days: NationalIndicatorKpiDay[];
+}
+
 // ===== Écart à la normale (Temperature Deviation) types =====
 
 export interface TemperatureDeviationParams {


### PR DESCRIPTION
## Type de PR
- [ ] Bugfix
- [x] Feature
- [ ] Refactor
- [ ] Chore / Tech debt
- [ ] Documentation
- [ ] Autre (à préciser)

## Objectif
Ajouter des kpis (ITN moyen, nombre de pic de chaud/froids) à côté du graphe ITN

## Contexte
Après le merge du composant card  (pour la home page) notammeent et celui de la route national-indicator/kpi on peut ajouter des kpis à droite du graphe.
Une fois le endpoint national-indicator/kpi  enrichit avec ITN moyen et ecart à la normale on pourra ajouter un KPI d'ITN moyen (actuellement commenté dans le code)

## Changements
- création d'un fichier itnKpiPanel (avec une partie commenté en attente de l'enrichissement du endpoint)

<img width="1131" height="504" alt="image" src="https://github.com/user-attachments/assets/2397a399-7437-4ac9-9c4b-3a0b55aa1254" />

## Décisions techniques
<!-- Choix structurants, arbitrages, compromis. -->
<!-- Ce qui aurait pu être fait autrement. -->

## Impacts
- [ ] API / contrat
- [ ] Modèle de données / DB
- [ ] Calculs métier
- [ ] Performance
- [ ] Sécurité
- [ ] Infra / déploiement
- [ ] Aucun impact transverse identifié

## Tests
<!-- Décris ce qui a été fait dans cette PR pour vérifier le comportement introduit ou modifié. -->
- [ ] Tests unitaires
- [ ] Tests d’intégration
- [x] Tests manuels
- [ ] Non applicable (à justifier)

## Points d’attention pour la review
<!-- Parties sensibles du code, dette technique introduite, risques. -->

## Suivi
- [ ] Migration à prévoir
- [ ] Documentation à mettre à jour
- [ ] Tâche(s) de suivi à créer
