### PR TITLE
Feat/back/add itn mean and deviation kpi

### DIFF
--- a/backend/openapi/target-specs/openapi.yaml
+++ b/backend/openapi/target-specs/openapi.yaml
@@ -331,7 +331,7 @@ paths:
           required: false
           schema:
             type: string
-            enum: [ full, month_of_year, day_of_month ]
+            enum: [full, month_of_year, day_of_month]
             default: full
           description: >
             Filtre intra-période appliqué à chaque période (selon `granularity`).
@@ -863,11 +863,12 @@ paths:
     get:
       tags:
         - Temperature
-      summary: Pic de chaud/froid à partir de l'indicateur thermique national (ITN)
+      summary: KPI à partir de l'indicateur thermique national (ITN)
       description: >
-        Retourne une liste de jours de pic (chaud ou froid) ainsi que le nombre de pics (i.e jours) sur la période
-        Un pic de chaud correspond à une journée ou la température de l'itn >= mean_baseline + std_baseline
-      operationId: getNationalIndicatorKPI
+        Retourne des KPIs sur la période : moyenne ITN, écart à la normale, et optionnellement la liste des jours de pic (chaud ou froid).
+        Un pic de chaud correspond à une journée où la température de l'ITN >= mean_baseline + std_baseline.
+        Si `type` est absent, seuls `itn_mean` et `deviation_from_normal` sont calculés (count=0, days=[]).
+      operationId: getNationalIndicatorKpi
       parameters:
         - name: date_start
           in: query
@@ -886,13 +887,14 @@ paths:
             format: date
           description: Date de fin incluse (YYYY-MM-DD).
           example: "2024-12-31"
-        - name: type_records
+        - name: type
           in: query
-          required: true
+          required: false
           description: |
-            Type de pics à retourner :
-            - `hot` : pic de chauds (défaut)
-            - `cold` : records froids
+            Type de pics à retourner (facultatif) :
+            - `hot` : pics de chaud
+            - `cold` : pics de froid
+            Si absent, aucun pic n'est calculé.
           schema:
             type: string
             enum: [hot, cold]
@@ -903,7 +905,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/NationalIndicatorResponse"
+                $ref: "#/components/schemas/NationalIndicatorKpiResponse"
         "400":
           description: Paramètre invalide ou manquant.
           content:
@@ -1197,7 +1199,17 @@ components:
       properties:
         count:
           type: integer
-          description: "Nombre de jours de pic"
+          description: "Nombre de jours de pic (0 si `type` absent)"
+        itn_mean:
+          type: number
+          format: float
+          nullable: true
+          description: "Température ITN moyenne sur la période (null si aucune donnée)"
+        deviation_from_normal:
+          type: number
+          format: float
+          nullable: true
+          description: "Écart à la normale 1991-2020 (itn_mean - baseline_mean moyen, null si aucune donnée)"
         days:
           type: array
           description: "Liste des jours de pic"
@@ -1368,11 +1380,11 @@ components:
               example: "1991-2020"
             granularity:
               type: string
-              enum: [ year, month, day ]
+              enum: [year, month, day]
               description: "Granularité de la série (axe X)."
             slice_type:
               type: string
-              enum: [ full, month_of_year, day_of_month ]
+              enum: [full, month_of_year, day_of_month]
               description: "Filtre intra-période appliqué à chaque période."
               example: full
             month_of_year:

--- a/backend/weather/serializers.py
+++ b/backend/weather/serializers.py
@@ -610,6 +610,7 @@ class NationalIndicatorKpiDaySerializer(serializers.Serializer):
 class NationalIndicatorKpiResponseSerializer(serializers.Serializer):
     count = serializers.IntegerField()
     itn_mean = serializers.FloatField(allow_null=True)
+    deviation_from_normal = serializers.FloatField(allow_null=True)
     days = NationalIndicatorKpiDaySerializer(many=True)
 
 

--- a/backend/weather/serializers.py
+++ b/backend/weather/serializers.py
@@ -590,7 +590,9 @@ class TemperatureDeviationOverviewResponseSerializer(serializers.Serializer):
 class NationalIndicatorKpiQuerySerializer(serializers.Serializer):
     date_start = serializers.DateField(required=True)
     date_end = serializers.DateField(required=True)
-    type = serializers.ChoiceField(choices=["hot", "cold"], required=True)
+    type = serializers.ChoiceField(
+        choices=["hot", "cold"], required=False, allow_null=True, default=None
+    )
 
     def validate(self, attrs):
         if attrs["date_start"] > attrs["date_end"]:

--- a/backend/weather/serializers.py
+++ b/backend/weather/serializers.py
@@ -609,6 +609,7 @@ class NationalIndicatorKpiDaySerializer(serializers.Serializer):
 
 class NationalIndicatorKpiResponseSerializer(serializers.Serializer):
     count = serializers.IntegerField()
+    itn_mean = serializers.FloatField(allow_null=True)
     days = NationalIndicatorKpiDaySerializer(many=True)
 
 

--- a/backend/weather/services/national_indicator/kpi_use_case.py
+++ b/backend/weather/services/national_indicator/kpi_use_case.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import datetime as dt
 from dataclasses import dataclass
+from statistics import mean
 
 from weather.services.national_indicator.protocols import (
     NationalIndicatorBaselineDataSource,
@@ -64,8 +65,8 @@ def get_national_indicator_kpi(
             )
 
     if observed:
-        itn_mean = sum(p.temperature for p in observed) / len(observed)
-        baseline_period_mean = sum(baseline_means) / len(baseline_means)
+        itn_mean = mean(p.temperature for p in observed)
+        baseline_period_mean = mean(baseline_means)
         deviation_from_normal = itn_mean - baseline_period_mean
     else:
         itn_mean = None

--- a/backend/weather/services/national_indicator/kpi_use_case.py
+++ b/backend/weather/services/national_indicator/kpi_use_case.py
@@ -38,7 +38,7 @@ def get_national_indicator_kpi(
     baseline_data_source: NationalIndicatorBaselineDataSource,
     date_start: dt.date,
     date_end: dt.date,
-    peak_type: str,
+    peak_type: str | None,
 ) -> NationalIndicatorKpiResult:
     observed = observed_data_source.fetch_daily_series(
         DailySeriesQuery(date_start=date_start, date_end=date_end)
@@ -53,7 +53,7 @@ def get_national_indicator_kpi(
         std_dev = baseline.baseline_std_dev_upper - baseline.baseline_mean
         baseline_means.append(baseline.baseline_mean)
 
-        if is_peak(point.temperature, baseline, peak_type):
+        if peak_type is not None and is_peak(point.temperature, baseline, peak_type):
             peak_days.append(
                 KpiDay(
                     date=point.date,

--- a/backend/weather/services/national_indicator/kpi_use_case.py
+++ b/backend/weather/services/national_indicator/kpi_use_case.py
@@ -22,6 +22,7 @@ class KpiDay:
 class NationalIndicatorKpiResult:
     days: list[KpiDay]
     count: int
+    itn_mean: float | None
 
 
 def is_peak(temperature: float, baseline: BaselinePoint, peak_type: str) -> bool:
@@ -59,4 +60,10 @@ def get_national_indicator_kpi(
                 )
             )
 
-    return NationalIndicatorKpiResult(days=peak_days, count=len(peak_days))
+    itn_mean = (
+        sum(p.temperature for p in observed) / len(observed) if observed else None
+    )
+
+    return NationalIndicatorKpiResult(
+        days=peak_days, count=len(peak_days), itn_mean=itn_mean
+    )

--- a/backend/weather/services/national_indicator/kpi_use_case.py
+++ b/backend/weather/services/national_indicator/kpi_use_case.py
@@ -23,6 +23,7 @@ class NationalIndicatorKpiResult:
     days: list[KpiDay]
     count: int
     itn_mean: float | None
+    deviation_from_normal: float | None
 
 
 def is_peak(temperature: float, baseline: BaselinePoint, peak_type: str) -> bool:
@@ -44,11 +45,13 @@ def get_national_indicator_kpi(
     )
 
     peak_days: list[KpiDay] = []
+    baseline_means: list[float] = []
 
     for point in observed:
         baseline = baseline_data_source.fetch_daily_baseline(point.date)
 
         std_dev = baseline.baseline_std_dev_upper - baseline.baseline_mean
+        baseline_means.append(baseline.baseline_mean)
 
         if is_peak(point.temperature, baseline, peak_type):
             peak_days.append(
@@ -60,10 +63,17 @@ def get_national_indicator_kpi(
                 )
             )
 
-    itn_mean = (
-        sum(p.temperature for p in observed) / len(observed) if observed else None
-    )
+    if observed:
+        itn_mean = sum(p.temperature for p in observed) / len(observed)
+        baseline_period_mean = sum(baseline_means) / len(baseline_means)
+        deviation_from_normal = itn_mean - baseline_period_mean
+    else:
+        itn_mean = None
+        deviation_from_normal = None
 
     return NationalIndicatorKpiResult(
-        days=peak_days, count=len(peak_days), itn_mean=itn_mean
+        days=peak_days,
+        count=len(peak_days),
+        itn_mean=itn_mean,
+        deviation_from_normal=deviation_from_normal,
     )

--- a/backend/weather/tests/integration/test_national_indicator_kpi_endpoint.py
+++ b/backend/weather/tests/integration/test_national_indicator_kpi_endpoint.py
@@ -173,17 +173,6 @@ def test_kpi_response_contains_baseline_mean_and_std_dev(client: APIClient):
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.django_db
-def test_kpi_missing_type_returns_400(client: APIClient):
-    resp = client.get(
-        reverse("temperature-national-indicator-kpi"),
-        {"date_start": "2024-01-01", "date_end": "2024-01-31"},
-    )
-
-    assert resp.status_code == 400
-    assert resp.json()["error"]["code"] == "INVALID_PARAMETER"
-
-
 def test_kpi_missing_date_start_returns_400(client: APIClient):
     resp = client.get(
         reverse("temperature-national-indicator-kpi"),

--- a/backend/weather/tests/integration/test_national_indicator_kpi_endpoint.py
+++ b/backend/weather/tests/integration/test_national_indicator_kpi_endpoint.py
@@ -173,6 +173,7 @@ def test_kpi_response_contains_baseline_mean_and_std_dev(client: APIClient):
 # ---------------------------------------------------------------------------
 
 
+@pytest.mark.django_db
 def test_kpi_missing_type_returns_400(client: APIClient):
     resp = client.get(
         reverse("temperature-national-indicator-kpi"),

--- a/backend/weather/tests/integration/test_national_indicator_kpi_endpoint.py
+++ b/backend/weather/tests/integration/test_national_indicator_kpi_endpoint.py
@@ -251,6 +251,28 @@ def test_kpi_itn_mean_is_average_over_all_days_including_non_peaks(client: APICl
     assert data["itn_mean"] == pytest.approx((10.0 + 10.0 + 13.0) / 3)
 
 
+def test_kpi_deviation_from_normal_is_difference_between_itn_mean_and_baseline_mean(
+    client: APIClient,
+):
+    # baseline fixe mean=10.0 → baseline_period_mean=10.0
+    # temps observées : 10, 10, 13 → itn_mean = 11.0
+    # deviation = 11.0 - 10.0 = 1.0
+    temps = {
+        dt.date(2024, 1, 1): 10.0,
+        dt.date(2024, 1, 2): 10.0,
+        dt.date(2024, 1, 3): 13.0,
+    }
+    _register(temps)
+
+    resp = client.get(
+        reverse("temperature-national-indicator-kpi"),
+        {"date_start": "2024-01-01", "date_end": "2024-01-03", "type": "hot"},
+    )
+
+    assert resp.status_code == 200
+    assert resp.json()["deviation_from_normal"] == pytest.approx(1.0)
+
+
 def test_kpi_itn_mean_is_null_when_no_observed_data(client: APIClient):
     # InMemoryKpiDependency retourne une série vide si date_start == date_end + 1 jour
     # On surcharge fetch_daily_series pour retourner []
@@ -282,3 +304,4 @@ def test_kpi_itn_mean_is_null_when_no_observed_data(client: APIClient):
 
     assert resp.status_code == 200
     assert resp.json()["itn_mean"] is None
+    assert resp.json()["deviation_from_normal"] is None

--- a/backend/weather/tests/integration/test_national_indicator_kpi_endpoint.py
+++ b/backend/weather/tests/integration/test_national_indicator_kpi_endpoint.py
@@ -211,3 +211,74 @@ def test_kpi_invalid_type_returns_400(client: APIClient):
 
     assert resp.status_code == 400
     assert resp.json()["error"]["code"] == "INVALID_PARAMETER"
+
+
+# ---------------------------------------------------------------------------
+# itn_mean
+# ---------------------------------------------------------------------------
+
+
+def test_kpi_response_contains_itn_mean_field(client: APIClient):
+    _register({})
+
+    resp = client.get(
+        reverse("temperature-national-indicator-kpi"),
+        {"date_start": "2024-01-01", "date_end": "2024-01-03", "type": "hot"},
+    )
+
+    assert resp.status_code == 200
+    assert "itn_mean" in resp.json()
+
+
+def test_kpi_itn_mean_is_average_over_all_days_including_non_peaks(client: APIClient):
+    # mean=10, upper=12 → seul 13.0 est un pic
+    # itn_mean = (10.0 + 10.0 + 13.0) / 3
+    temps = {
+        dt.date(2024, 1, 1): 10.0,
+        dt.date(2024, 1, 2): 10.0,
+        dt.date(2024, 1, 3): 13.0,
+    }
+    _register(temps)
+
+    resp = client.get(
+        reverse("temperature-national-indicator-kpi"),
+        {"date_start": "2024-01-01", "date_end": "2024-01-03", "type": "hot"},
+    )
+
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["count"] == 1
+    assert data["itn_mean"] == pytest.approx((10.0 + 10.0 + 13.0) / 3)
+
+
+def test_kpi_itn_mean_is_null_when_no_observed_data(client: APIClient):
+    # InMemoryKpiDependency retourne une série vide si date_start == date_end + 1 jour
+    # On surcharge fetch_daily_series pour retourner []
+    class EmptyObservedDependency(
+        NationalIndicatorObservedDataSource,
+        NationalIndicatorBaselineDataSource,
+    ):
+        def fetch_daily_series(self, _query: DailySeriesQuery) -> list[ObservedPoint]:
+            return []
+
+        def fetch_daily_baseline(self, _day: dt.date) -> BaselinePoint:
+            return BaselinePoint(
+                baseline_mean=10.0,
+                baseline_std_dev_upper=12.0,
+                baseline_std_dev_lower=8.0,
+                baseline_max=15.0,
+                baseline_min=5.0,
+            )
+
+    dep = EmptyObservedDependency()
+    ITNDependencyProvider.set_builder(
+        lambda: ITNDependencies(observed_data_source=dep, baseline_data_source=dep)
+    )
+
+    resp = client.get(
+        reverse("temperature-national-indicator-kpi"),
+        {"date_start": "2024-01-01", "date_end": "2024-01-03", "type": "hot"},
+    )
+
+    assert resp.status_code == 200
+    assert resp.json()["itn_mean"] is None

--- a/backend/weather/tests/integration/test_national_indicator_kpi_endpoint.py
+++ b/backend/weather/tests/integration/test_national_indicator_kpi_endpoint.py
@@ -214,6 +214,40 @@ def test_kpi_invalid_type_returns_400(client: APIClient):
 
 
 # ---------------------------------------------------------------------------
+# peak_type facultatif
+# ---------------------------------------------------------------------------
+
+
+def test_kpi_without_type_returns_empty_peaks_and_zero_count(client: APIClient):
+    _register({dt.date(2024, 1, 1): 25.0})  # serait un pic chaud si type fourni
+
+    resp = client.get(
+        reverse("temperature-national-indicator-kpi"),
+        {"date_start": "2024-01-01", "date_end": "2024-01-01"},
+    )
+
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["count"] == 0
+    assert data["days"] == []
+
+
+def test_kpi_without_type_still_returns_itn_mean_and_deviation(client: APIClient):
+    # baseline mean=10.0, temp=20.0 → itn_mean=20.0, deviation=10.0
+    _register({dt.date(2024, 1, 1): 20.0})
+
+    resp = client.get(
+        reverse("temperature-national-indicator-kpi"),
+        {"date_start": "2024-01-01", "date_end": "2024-01-01"},
+    )
+
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["itn_mean"] == pytest.approx(20.0)
+    assert data["deviation_from_normal"] == pytest.approx(10.0)
+
+
+# ---------------------------------------------------------------------------
 # itn_mean
 # ---------------------------------------------------------------------------
 

--- a/backend/weather/tests/unit/test_national_indicator_kpi_business.py
+++ b/backend/weather/tests/unit/test_national_indicator_kpi_business.py
@@ -252,3 +252,82 @@ def test_itn_mean_with_single_day():
     )
 
     assert result.itn_mean == 15.5
+
+
+# ─── Tests : deviation_from_normal ────────────────────────────────────────────
+
+
+def test_deviation_from_normal_positive_when_warmer_than_baseline():
+    observed = [
+        ObservedPoint(date=dt.date(2024, 7, 1), temperature=22.0),
+        ObservedPoint(date=dt.date(2024, 7, 2), temperature=24.0),
+    ]
+    # baseline_mean = 20.0 pour les deux jours
+    baseline = _baseline(mean=20.0, std_dev=2.0)
+    baselines = {(7, 1): baseline, (7, 2): baseline}
+
+    result = get_national_indicator_kpi(
+        observed_data_source=StubObservedDataSource(observed),
+        baseline_data_source=StubBaselineDataSource(baselines),
+        date_start=dt.date(2024, 7, 1),
+        date_end=dt.date(2024, 7, 2),
+        peak_type="hot",
+    )
+
+    # itn_mean = 23.0, baseline_period_mean = 20.0
+    assert result.deviation_from_normal == pytest.approx(3.0)
+
+
+def test_deviation_from_normal_negative_when_colder_than_baseline():
+    observed = [
+        ObservedPoint(date=dt.date(2024, 1, 1), temperature=5.0),
+        ObservedPoint(date=dt.date(2024, 1, 2), temperature=7.0),
+    ]
+    baseline = _baseline(mean=10.0, std_dev=2.0)
+    baselines = {(1, 1): baseline, (1, 2): baseline}
+
+    result = get_national_indicator_kpi(
+        observed_data_source=StubObservedDataSource(observed),
+        baseline_data_source=StubBaselineDataSource(baselines),
+        date_start=dt.date(2024, 1, 1),
+        date_end=dt.date(2024, 1, 2),
+        peak_type="cold",
+    )
+
+    # itn_mean = 6.0, baseline_period_mean = 10.0
+    assert result.deviation_from_normal == pytest.approx(-4.0)
+
+
+def test_deviation_from_normal_uses_per_day_baseline_mean():
+    # Baselines différentes par jour pour vérifier que la moyenne porte sur tous les jours
+    observed = [
+        ObservedPoint(date=dt.date(2024, 7, 1), temperature=20.0),
+        ObservedPoint(date=dt.date(2024, 7, 2), temperature=20.0),
+    ]
+    baselines = {
+        (7, 1): _baseline(mean=10.0, std_dev=2.0),
+        (7, 2): _baseline(mean=30.0, std_dev=2.0),
+    }
+
+    result = get_national_indicator_kpi(
+        observed_data_source=StubObservedDataSource(observed),
+        baseline_data_source=StubBaselineDataSource(baselines),
+        date_start=dt.date(2024, 7, 1),
+        date_end=dt.date(2024, 7, 2),
+        peak_type="hot",
+    )
+
+    # itn_mean = 20.0, baseline_period_mean = (10 + 30) / 2 = 20.0
+    assert result.deviation_from_normal == pytest.approx(0.0)
+
+
+def test_deviation_from_normal_is_none_when_observed_series_is_empty():
+    result = get_national_indicator_kpi(
+        observed_data_source=StubObservedDataSource([]),
+        baseline_data_source=StubBaselineDataSource({}),
+        date_start=dt.date(2024, 7, 1),
+        date_end=dt.date(2024, 7, 3),
+        peak_type="hot",
+    )
+
+    assert result.deviation_from_normal is None

--- a/backend/weather/tests/unit/test_national_indicator_kpi_business.py
+++ b/backend/weather/tests/unit/test_national_indicator_kpi_business.py
@@ -331,3 +331,46 @@ def test_deviation_from_normal_is_none_when_observed_series_is_empty():
     )
 
     assert result.deviation_from_normal is None
+
+
+# ─── Tests : peak_type facultatif ─────────────────────────────────────────────
+
+
+def test_no_peak_type_returns_empty_days_and_zero_count():
+    observed = [
+        ObservedPoint(date=dt.date(2024, 7, 1), temperature=25.0),
+        ObservedPoint(date=dt.date(2024, 7, 2), temperature=5.0),
+    ]
+    baseline = _baseline(mean=15.0, std_dev=2.0)
+    baselines = {(7, 1): baseline, (7, 2): baseline}
+
+    result = get_national_indicator_kpi(
+        observed_data_source=StubObservedDataSource(observed),
+        baseline_data_source=StubBaselineDataSource(baselines),
+        date_start=dt.date(2024, 7, 1),
+        date_end=dt.date(2024, 7, 2),
+        peak_type=None,
+    )
+
+    assert result.count == 0
+    assert result.days == []
+
+
+def test_no_peak_type_still_computes_itn_mean_and_deviation():
+    observed = [
+        ObservedPoint(date=dt.date(2024, 7, 1), temperature=20.0),
+        ObservedPoint(date=dt.date(2024, 7, 2), temperature=30.0),
+    ]
+    baseline = _baseline(mean=10.0, std_dev=2.0)
+    baselines = {(7, 1): baseline, (7, 2): baseline}
+
+    result = get_national_indicator_kpi(
+        observed_data_source=StubObservedDataSource(observed),
+        baseline_data_source=StubBaselineDataSource(baselines),
+        date_start=dt.date(2024, 7, 1),
+        date_end=dt.date(2024, 7, 2),
+        peak_type=None,
+    )
+
+    assert result.itn_mean == 25.0
+    assert result.deviation_from_normal == pytest.approx(15.0)

--- a/backend/weather/tests/unit/test_national_indicator_kpi_business.py
+++ b/backend/weather/tests/unit/test_national_indicator_kpi_business.py
@@ -1,5 +1,7 @@
 import datetime as dt
 
+import pytest
+
 from weather.services.national_indicator.kpi_use_case import get_national_indicator_kpi
 from weather.services.national_indicator.protocols import (
     NationalIndicatorBaselineDataSource,
@@ -178,3 +180,75 @@ def test_hot_type_does_not_return_cold_days():
     )
 
     assert result.count == 0
+
+
+# ─── Tests : itn_mean ─────────────────────────────────────────────────────────
+
+
+def test_itn_mean_is_average_of_all_observed_days():
+    observed = [
+        ObservedPoint(date=dt.date(2024, 7, 1), temperature=10.0),
+        ObservedPoint(date=dt.date(2024, 7, 2), temperature=20.0),
+        ObservedPoint(date=dt.date(2024, 7, 3), temperature=30.0),
+    ]
+    baseline = _baseline(mean=20.0, std_dev=2.0)
+    baselines = {(7, 1): baseline, (7, 2): baseline, (7, 3): baseline}
+
+    result = get_national_indicator_kpi(
+        observed_data_source=StubObservedDataSource(observed),
+        baseline_data_source=StubBaselineDataSource(baselines),
+        date_start=dt.date(2024, 7, 1),
+        date_end=dt.date(2024, 7, 3),
+        peak_type="hot",
+    )
+
+    assert result.itn_mean == 20.0
+
+
+def test_itn_mean_includes_non_peak_days():
+    # Seul le 3 juillet est un pic, mais la moyenne porte sur les 3 jours
+    observed = [
+        ObservedPoint(date=dt.date(2024, 7, 1), temperature=10.0),
+        ObservedPoint(date=dt.date(2024, 7, 2), temperature=10.0),
+        ObservedPoint(date=dt.date(2024, 7, 3), temperature=25.0),  # pic
+    ]
+    baseline = _baseline(mean=20.0, std_dev=2.0)
+    baselines = {(7, 1): baseline, (7, 2): baseline, (7, 3): baseline}
+
+    result = get_national_indicator_kpi(
+        observed_data_source=StubObservedDataSource(observed),
+        baseline_data_source=StubBaselineDataSource(baselines),
+        date_start=dt.date(2024, 7, 1),
+        date_end=dt.date(2024, 7, 3),
+        peak_type="hot",
+    )
+
+    assert result.count == 1
+    assert result.itn_mean == pytest.approx((10.0 + 10.0 + 25.0) / 3)
+
+
+def test_itn_mean_is_none_when_observed_series_is_empty():
+    result = get_national_indicator_kpi(
+        observed_data_source=StubObservedDataSource([]),
+        baseline_data_source=StubBaselineDataSource({}),
+        date_start=dt.date(2024, 7, 1),
+        date_end=dt.date(2024, 7, 3),
+        peak_type="hot",
+    )
+
+    assert result.itn_mean is None
+
+
+def test_itn_mean_with_single_day():
+    observed = [ObservedPoint(date=dt.date(2024, 7, 1), temperature=15.5)]
+    baselines = {(7, 1): _baseline(mean=20.0, std_dev=2.0)}
+
+    result = get_national_indicator_kpi(
+        observed_data_source=StubObservedDataSource(observed),
+        baseline_data_source=StubBaselineDataSource(baselines),
+        date_start=dt.date(2024, 7, 1),
+        date_end=dt.date(2024, 7, 1),
+        peak_type="hot",
+    )
+
+    assert result.itn_mean == 15.5

--- a/backend/weather/tests/unit/test_national_indicator_kpi_query_serializer.py
+++ b/backend/weather/tests/unit/test_national_indicator_kpi_query_serializer.py
@@ -50,14 +50,13 @@ def test_type_rejects_invalid_values(invalid_type):
     assert "type" in s.errors
 
 
-def test_missing_type_is_invalid():
+def test_missing_type_is_valid_and_defaults_to_none():
     s = NationalIndicatorKpiQuerySerializer(
         data={"date_start": "2024-01-01", "date_end": "2024-01-31"}
     )
 
-    ok = s.is_valid()
-    assert not ok
-    assert "type" in s.errors
+    assert s.is_valid(), s.errors
+    assert s.validated_data["type"] is None
 
 
 def test_missing_date_start_is_invalid():

--- a/backend/weather/views.py
+++ b/backend/weather/views.py
@@ -345,6 +345,7 @@ class NationalIndicatorKpiAPIView(APIView):
 
         payload = {
             "count": result.count,
+            "itn_mean": result.itn_mean,
             "days": [
                 {
                     "date": d.date,

--- a/backend/weather/views.py
+++ b/backend/weather/views.py
@@ -340,7 +340,7 @@ class NationalIndicatorKpiAPIView(APIView):
             baseline_data_source=deps.baseline_data_source,
             date_start=params["date_start"],
             date_end=params["date_end"],
-            peak_type=params["type"],
+            peak_type=params.get("type"),
         )
 
         payload = {

--- a/backend/weather/views.py
+++ b/backend/weather/views.py
@@ -346,6 +346,7 @@ class NationalIndicatorKpiAPIView(APIView):
         payload = {
             "count": result.count,
             "itn_mean": result.itn_mean,
+            "deviation_from_normal": result.deviation_from_normal,
             "days": [
                 {
                     "date": d.date,


### PR DESCRIPTION
## Type de PR
- [ ] Bugfix
- [x] Feature
- [ ] Refactor
- [ ] Chore / Tech debt
- [ ] Documentation
- [ ] Autre (à préciser)

## Objectif
Enrichir le endpoint national-indicator/kpi pour requeter ITN moyen et ecart à la normale à partir d'un date_start et date_end

## Contexte
Ce endpoint sera utiliser pour les KPIs de page d'accueil et pour les KPIs du graphe itn. La liste des jours de pics ne sera probablement pas utiliser par le front end. Faut-il la laisser?

## Changements
- type de pic (chaud/froid) rendu falcultatif
- compute itn_mean et écart
- mie à jour openapi.yaml
- tests intégration, unitaire, business

## Décisions techniques
<!-- Choix structurants, arbitrages, compromis. -->
<!-- Ce qui aurait pu être fait autrement. -->

## Impacts
- [x] API / contrat
- [ ] Modèle de données / DB
- [ ] Calculs métier
- [ ] Performance
- [ ] Sécurité
- [ ] Infra / déploiement
- [ ] Aucun impact transverse identifié

## Tests
<!-- Décris ce qui a été fait dans cette PR pour vérifier le comportement introduit ou modifié. -->
- [x] Tests unitaires
- [x] Tests d’intégration
- [x] Tests manuels
- [ ] Non applicable (à justifier)

## Points d’attention pour la review
<!-- Parties sensibles du code, dette technique introduite, risques. -->

## Suivi
- [ ] Migration à prévoir
- [x] Documentation à mettre à jour
- [ ] Tâche(s) de suivi à créer
