### PR TITLE
ajoute option moyenner par dans graphe deviation

### DIFF
--- a/frontend/app/adapters/deviationSelectBarAdapter.ts
+++ b/frontend/app/adapters/deviationSelectBarAdapter.ts
@@ -38,7 +38,7 @@ export const useDeviationSelectBarAdapter =
             chartTypeSwitchEnabled,
             setChartType: store.setChartType,
             features: {
-                hasSliceType: false,
+                hasSliceType: true,
                 hasRecordsPeriodSlice: false,
                 hasChartTypeSelector: true,
                 hasExport: true,

--- a/frontend/app/adapters/deviationSelectBarAdapter.ts
+++ b/frontend/app/adapters/deviationSelectBarAdapter.ts
@@ -12,9 +12,9 @@ export const useDeviationSelectBarAdapter =
             pickedDateStart,
             pickedDateEnd,
             maxDate,
-            sliceTypeSwitchEnabled, // Will be enabled in futur version
-            sliceType, // Will be enabled in futur version
-            sliceDatepickerDate, // Will be enabled in futur version
+            sliceTypeSwitchEnabled,
+            sliceType,
+            sliceDatepickerDate,
             deviationData,
             pending,
             chartTypeSwitchEnabled,
@@ -26,13 +26,14 @@ export const useDeviationSelectBarAdapter =
             pickedDateStart,
             pickedDateEnd,
             maxDate,
-            sliceTypeSwitchEnabled, // Will be enabled in futur version
-            sliceType, // Will be enabled in futur version
-            sliceDatepickerDate, // Will be enabled in futur version
+            sliceTypeSwitchEnabled,
+            sliceType,
+            sliceDatepickerDate,
             chartRef: deviationChartRef,
             data: deviationData,
             pending,
             setGranularity: store.setGranularity,
+            turnOffSliceType: store.turnOffSliceType,
             chartType,
             chartTypeSwitchEnabled,
             setChartType: store.setChartType,

--- a/frontend/app/components/ui/commons/selectBar/selectBar.vue
+++ b/frontend/app/components/ui/commons/selectBar/selectBar.vue
@@ -85,7 +85,8 @@ const granularityValues = reactive([
         <div id="right-side" class="flex md:flex-1 gap-6 items-center">
             <template
                 v-if="
-                    adapter.features.hasSliceType ||
+                    (adapter.features.hasSliceType &&
+                        adapter.chartType?.value !== 'calendar') ||
                     adapter.features.hasRecordsPeriodSlice
                 "
             >

--- a/frontend/app/components/ui/commons/selectBar/types.ts
+++ b/frontend/app/components/ui/commons/selectBar/types.ts
@@ -8,8 +8,8 @@ import type {
     TemperatureRecordsGraphResponse,
 } from "~/types/api";
 
-export type granularity = "year" | "month" | "day";
-export type slice_type = "full" | "month_of_year" | "day_of_month";
+export type GranularityType = "year" | "month" | "day";
+export type SliceType = "full" | "month_of_year" | "day_of_month";
 export type ChartType = "line" | "bar" | "scatter" | "pyramid" | "calendar";
 
 export interface SelectBarAdapter<

--- a/frontend/app/components/ui/commons/selectBar/types.ts
+++ b/frontend/app/components/ui/commons/selectBar/types.ts
@@ -1,6 +1,5 @@
 import type { ShallowRef } from "vue";
 import type {
-    GranularityType,
     NationalIndicatorDataPoint,
     NationalIndicatorResponse,
     PeriodType,

--- a/frontend/app/components/ui/commons/selectBar/types.ts
+++ b/frontend/app/components/ui/commons/selectBar/types.ts
@@ -1,5 +1,6 @@
 import type { ShallowRef } from "vue";
 import type {
+    GranularityType,
     NationalIndicatorDataPoint,
     NationalIndicatorResponse,
     PeriodType,
@@ -8,10 +9,8 @@ import type {
     TemperatureRecordsGraphResponse,
 } from "~/types/api";
 
-export type GranularityType = "year" | "month" | "day";
-
-export type SliceType = "full" | "month_of_year" | "day_of_month";
-
+export type granularity = "year" | "month" | "day";
+export type slice_type = "full" | "month_of_year" | "day_of_month";
 export type ChartType = "line" | "bar" | "scatter" | "pyramid" | "calendar";
 
 export interface SelectBarAdapter<

--- a/frontend/app/stores/deviationStore.ts
+++ b/frontend/app/stores/deviationStore.ts
@@ -38,6 +38,18 @@ export const useDeviationStore = defineStore("deviationStore", () => {
         () => granularity.value === "year",
     );
 
+    const month_of_year = computed<undefined | number>(() =>
+        granularity.value === "year" && sliceType.value !== "full"
+            ? sliceDatepickerDate.value.getMonth() + 1
+            : undefined,
+    );
+
+    const day_of_month = computed<undefined | number>(() =>
+        sliceType.value === "day_of_month"
+            ? sliceDatepickerDate.value.getDate()
+            : undefined,
+    );
+
     const selectedStationsAndNational = computed<DeviationStationIdAndName[]>(
         () => {
             const stations = selectedStations.value.map((station) => {
@@ -72,6 +84,9 @@ export const useDeviationStore = defineStore("deviationStore", () => {
                 : granularity.value,
         station_ids: stationIds.value.join(","),
         include_national: includeNational.value,
+        slice_type: sliceType.value,
+        month_of_year: month_of_year.value,
+        day_of_month: day_of_month.value,
     }));
 
     const {
@@ -94,6 +109,12 @@ export const useDeviationStore = defineStore("deviationStore", () => {
         }
         if (value === "year") {
             pickedDateStart.value = dates.absoluteMinDataDate.value;
+        }
+    };
+
+    const turnOffSliceType = (value: boolean) => {
+        if (!value) {
+            sliceType.value = "full";
         }
     };
 
@@ -146,6 +167,7 @@ export const useDeviationStore = defineStore("deviationStore", () => {
         chartTypeSwitchEnabled,
         chartType,
         setGranularity,
+        turnOffSliceType,
         setIncludeNational,
         setChartType,
         setStations,

--- a/frontend/app/types/api.ts
+++ b/frontend/app/types/api.ts
@@ -1,5 +1,10 @@
 // ===== Generic pagination wrapper (Django REST LimitOffsetPagination) =====
 
+import type {
+    GranularityType,
+    SliceType,
+} from "~/components/ui/commons/selectBar/types";
+
 export interface PaginatedResponse<T> {
     count: number;
     next: string | null;
@@ -207,10 +212,6 @@ export interface DeviationMapResponse {
     pagination: DeviationMapPagination;
     stations: DeviationMapStation[];
 }
-
-export type GranularityType = "year" | "month" | "day";
-
-export type SliceType = "full" | "month_of_year" | "day_of_month";
 
 export interface TemperatureDeviationGraphParams {
     date_start: string;

--- a/frontend/app/types/api.ts
+++ b/frontend/app/types/api.ts
@@ -219,6 +219,9 @@ export interface TemperatureDeviationGraphParams {
     deviation_max?: number;
     limit?: number;
     offset?: number;
+    slice_type?: "full" | "month_of_year" | "day_of_month";
+    month_of_year?: number;
+    day_of_month?: number;
 }
 
 export interface TemperatureDeviationGraphMetadata {

--- a/frontend/app/types/api.ts
+++ b/frontend/app/types/api.ts
@@ -43,8 +43,8 @@ export interface StationFilters {
 export interface NationalIndicatorParams {
     date_start: string;
     date_end: string;
-    granularity: "year" | "month" | "day";
-    slice_type?: "full" | "month_of_year" | "day_of_month";
+    granularity: GranularityType;
+    slice_type?: SliceType;
     month_of_year?: number;
     day_of_month?: number;
 }
@@ -53,8 +53,8 @@ export interface NationalIndicatorMetadata {
     date_start: string;
     date_end: string;
     baseline: string;
-    granularity: "year" | "month" | "day";
-    slice_type: "full" | "month_of_year" | "day_of_month";
+    granularity: GranularityType;
+    slice_type: SliceType;
     month_of_year?: number;
     day_of_month?: number;
 }
@@ -208,10 +208,14 @@ export interface DeviationMapResponse {
     stations: DeviationMapStation[];
 }
 
+export type GranularityType = "year" | "month" | "day";
+
+export type SliceType = "full" | "month_of_year" | "day_of_month";
+
 export interface TemperatureDeviationGraphParams {
     date_start: string;
     date_end: string;
-    granularity: "year" | "month" | "day";
+    granularity: GranularityType;
     station_ids?: string;
     departments?: string;
     include_national: boolean;
@@ -219,7 +223,7 @@ export interface TemperatureDeviationGraphParams {
     deviation_max?: number;
     limit?: number;
     offset?: number;
-    slice_type?: "full" | "month_of_year" | "day_of_month";
+    slice_type?: SliceType;
     month_of_year?: number;
     day_of_month?: number;
 }
@@ -228,7 +232,7 @@ export interface TemperatureDeviationGraphMetadata {
     date_start: string;
     date_end: string;
     baseline: string;
-    granularity: "year" | "month" | "day";
+    granularity: GranularityType;
 }
 
 export interface TemperatureDeviationGraphNational {


### PR DESCRIPTION
## Type de PR
- [ ] Bugfix
- [x] Feature
- [ ] Refactor
- [ ] Chore / Tech debt
- [ ] Documentation
- [ ] Autre (à préciser)

## Objectif
Possibilité de moyenner par mois ou jour spécifique pour le graphe pyramide d'écart à, la normale

## Contexte
- US: https://github.com/dataforgoodfr/14_ValorisationDonneeMeteo/issues/246
- enrichissement du endpoint deviation graph

## Changements
Enable l'option slice type pour le graphe deviation
Masque l'option pour le format calendrier car ça n'a pas de sens pour ce graph
<img width="1138" height="223" alt="image" src="https://github.com/user-attachments/assets/d3cc0fe2-4ec4-4e39-a8ff-c486ab673350" />

-

## Décisions techniques
<!-- Choix structurants, arbitrages, compromis. -->
<!-- Ce qui aurait pu être fait autrement. -->

## Impacts
- [ ] API / contrat
- [ ] Modèle de données / DB
- [ ] Calculs métier
- [ ] Performance
- [ ] Sécurité
- [ ] Infra / déploiement
- [ ] Aucun impact transverse identifié

## Tests
<!-- Décris ce qui a été fait dans cette PR pour vérifier le comportement introduit ou modifié. -->
- [ ] Tests unitaires
- [ ] Tests d’intégration
- [x] Tests manuels
- [ ] Non applicable (à justifier)

## Points d’attention pour la review
<!-- Parties sensibles du code, dette technique introduite, risques. -->

## Suivi
- [ ] Migration à prévoir
- [ ] Documentation à mettre à jour
- [ ] Tâche(s) de suivi à créer
