### PR TITLE
fix(records): add dynamic resize for yticks

### DIFF
--- a/frontend/app/components/charts/recordsCharts/recordsPyramidChart.vue
+++ b/frontend/app/components/charts/recordsCharts/recordsPyramidChart.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import * as echarts from "echarts/core";
 import langFR from "~/i18n/langFR.js";
+import { useResizeObserver } from "@vueuse/core";
 import type { SelectBarAdapter } from "~/components/ui/commons/selectBar/types";
 import type { TemperatureRecordsGraphResponse } from "~/types/api";
 import type { XAXisOption, YAXisOption } from "echarts/types/dist/shared";
@@ -22,6 +23,14 @@ interface Props {
 }
 
 const props = defineProps<Props>();
+
+const containerRef = ref<HTMLElement | null>(null);
+const INITIAL_CONTAINER_WIDTH = 900;
+const containerWidth = ref(INITIAL_CONTAINER_WIDTH);
+useResizeObserver(containerRef, (entries) => {
+    const width = entries[0]?.contentRect.width;
+    if (width !== undefined) containerWidth.value = width;
+});
 
 const renderer = ref<"svg" | "canvas">("canvas");
 const initOptions = computed(() => ({
@@ -76,10 +85,14 @@ const option = computed<ECOption>(() => {
         ),
     );
 
-    const rightOfLeftGrid = { year: "53%", month: "53.5%", day: "54%" }[
+    const rightOfLeftGridPercent = { year: 53, month: 53.5, day: 54 }[
         granularity
     ];
-    const labelMargin = { year: 27, month: 31, day: 35 }[granularity];
+    const rightOfLeftGrid = `${rightOfLeftGridPercent}%`;
+    // margin calibré pour centrer le label à 50% quelle que soit la largeur du container
+    const labelMargin = Math.round(
+        ((rightOfLeftGridPercent - 50) / 100) * containerWidth.value,
+    );
     const slotSize = 100 / N;
 
     // Positions verticales du subplot i dans le conteneur (en %)
@@ -137,6 +150,7 @@ const option = computed<ECOption>(() => {
                 gridIndex: 2 * i + 1,
                 axisLabel: {
                     margin: labelMargin,
+                    width: labelMargin * 2,
                     align: "center",
                     fontSize: 12,
                     fontWeight: "bold",
@@ -194,13 +208,15 @@ const option = computed<ECOption>(() => {
 </script>
 
 <template>
-    <VChart
-        :ref="adapter.chartRef"
-        :key="`${adapter.granularity.value}-${adapter.chartType?.value}`"
-        :option="option"
-        :init-options="initOptions"
-        :loading="adapter.pending.value"
-        :loading-options="{ text: 'Chargement…', color: '#3b82f6' }"
-        autoresize
-    />
+    <div ref="containerRef">
+        <VChart
+            :ref="adapter.chartRef"
+            :key="`${adapter.granularity.value}-${adapter.chartType?.value}`"
+            :option="option"
+            :init-options="initOptions"
+            :loading="adapter.pending.value"
+            :loading-options="{ text: 'Chargement…', color: '#3b82f6' }"
+            autoresize
+        />
+    </div>
 </template>


### PR DESCRIPTION
## Type de PR
- [x] Bugfix
- [ ] Feature
- [ ] Refactor
- [ ] Chore / Tech debt
- [ ] Documentation
- [ ] Autre (à préciser)

## Objectif
<!-- Problème résolu ou fonctionnalité apportée. Une phrase claire. -->

Les labels Y-axis (ticks entre les deux barres) du graphe pyramide se décalaient selon la largeur de la fenêtre. Le margin et la width des labels étaient des valeurs statiques calibrées à la main pour une largeur fixe, rendant le centrage incorrect sur d'autres résolutions.

## Contexte
<!-- Contexte fonctionnel ou technique nécessaire à la revue. -->
<!-- Lien(s) vers issue(s), discussion(s), doc(s). -->

## Changements

Le composant observe désormais la largeur réelle de son container via useResizeObserver (@vueuse/core). Le labelMargin est recalculé dynamiquement à chaque redimensionnement :

 labelMargin = ((rightOfLeftGridPercent - 50) / 100) * containerWidth

Cette formule dérive la distance en pixels entre le bord de la grille gauche et le centre (50%), garantissant que les labels restent centrés quelle que soit la largeur du container. La propriété width: labelMargin * 2 a également été ajoutée pour que les labels aient l'espace suffisant pour s'afficher.

 recordsPyramidChart.vue  

 - wrapping du <VChart> dans un <div ref="containerRef"> pour observer les  redimensionnements ;
 - calcul dynamique de labelMargin à partir de containerWidth ; 
 - extraction de rightOfLeftGridPercent pour réutilisation dans la formule 
 - extraction de 900 en constante nommée INITIAL_CONTAINER_WIDTH.

## Décisions techniques
<!-- Choix structurants, arbitrages, compromis. -->
<!-- Ce qui aurait pu être fait autrement. -->

## Impacts
- [ ] API / contrat
- [ ] Modèle de données / DB
- [ ] Calculs métier
- [ ] Performance
- [ ] Sécurité
- [ ] Infra / déploiement
- [ ] Aucun impact transverse identifié

## Tests
<!-- Décris ce qui a été fait dans cette PR pour vérifier le comportement introduit ou modifié. -->
- [ ] Tests unitaires
- [ ] Tests d’intégration
- [ ] Tests manuels
- [ ] Non applicable (à justifier)

## Points d’attention pour la review
<!-- Parties sensibles du code, dette technique introduite, risques. -->

## Suivi
- [ ] Migration à prévoir
- [ ] Documentation à mettre à jour
- [ ] Tâche(s) de suivi à créer

Close #373 