### PR TITLE
Feat/front/itn tune dark restart

### DIFF
--- a/frontend/app/components/charts/DeviationChart.vue
+++ b/frontend/app/components/charts/DeviationChart.vue
@@ -98,7 +98,7 @@ const barOption = computed<ECOption>(() => {
             nameLocation: "middle",
             nameGap: 25,
             nameTextStyle: {
-                fontSize: FONT_CHARTS.fontSize,
+                fontSize: FONT_CHARTS.axisName,
                 fontWeight: "bold",
             },
             axisPointer: { type: "line", label: { show: false } },
@@ -112,11 +112,13 @@ const barOption = computed<ECOption>(() => {
             nameLocation: "middle",
             nameGap: 40,
             nameTextStyle: {
-                fontSize: FONT_CHARTS.fontSize,
+                fontSize: FONT_CHARTS.axisName,
                 fontWeight: "bold",
             },
-            axisLabel: { fontSize: FONT_CHARTS.fontSize },
-            splitLine: { lineStyle: { type: "dashed" } },
+            axisLabel: { fontSize: FONT_CHARTS.axis },
+            splitLine: {
+                lineStyle: { type: "dashed", color: mapColors.value.splitLine },
+            },
         })),
         series: stationsAndNational.flatMap((_, index) => [
             {

--- a/frontend/app/components/charts/ItnChart.vue
+++ b/frontend/app/components/charts/ItnChart.vue
@@ -446,16 +446,6 @@ const option = computed<ECOption>(() => {
                     props.adapter.granularity.value,
                 ),
         },
-        dataZoom: [
-            {
-                type: "slider",
-                minSpan: 20,
-            },
-            {
-                type: "inside",
-                minSpan: 20,
-            },
-        ],
         emphasis: {
             focus: "none",
             disabled: true, // disables all emphasis state changes on hover

--- a/frontend/app/components/charts/ItnChart.vue
+++ b/frontend/app/components/charts/ItnChart.vue
@@ -7,7 +7,9 @@ import type {
     NationalIndicatorResponse,
 } from "~/types/api";
 import { CHART_ATTRIBUTION_GRAPHIC } from "~/constants/chartAttribution";
-import { ITN_SERIES, ITN_COLORS } from "~/constants/itn";
+import { ITN_SERIES, useItnColors } from "~/constants/itn";
+import { useMapColors } from "~/constants/colors";
+import { FONT_CHARTS } from "~/constants/fonts";
 import { itnChartTooltipFormatter } from "./tooltipFormatters/itnChartTooltipFormatter";
 import {
     itnStackedTooltipFormatter,
@@ -56,8 +58,8 @@ const initOptions = computed(() => ({
 }));
 provide(INIT_OPTIONS_KEY, initOptions);
 
-const colorEcartType = ITN_COLORS.ECART_TYPE;
-const colorExtremes = ITN_COLORS.EXTREMES;
+const itnColors = useItnColors();
+const mapColors = useMapColors();
 
 function buildStackedOption(
     timeSeries: NationalIndicatorDataPoint[],
@@ -122,9 +124,9 @@ function buildStackedOption(
             stack: "extreme",
             stackStrategy: "all",
             symbol: "none",
-            color: colorExtremes,
+            color: itnColors.value.extremes,
             lineStyle: { opacity: 0 },
-            areaStyle: { color: colorExtremes },
+            areaStyle: { color: itnColors.value.extremes },
         },
         {
             type: "line",
@@ -143,16 +145,16 @@ function buildStackedOption(
             stack: "std",
             stackStrategy: "all",
             symbol: "none",
-            color: colorEcartType,
+            color: itnColors.value.ecartType,
             lineStyle: { opacity: 0 },
-            areaStyle: { color: colorEcartType },
+            areaStyle: { color: itnColors.value.ecartType },
         },
         {
             name: ITN_SERIES.temperature,
             type: "line",
             encode: { x: "position", y: "baseline_mean" },
             symbol: "none",
-            lineStyle: { width: 2, color: "#333" },
+            lineStyle: { width: 2, color: itnColors.value.baselineLine },
             z: 5,
         },
     ];
@@ -187,6 +189,7 @@ function buildStackedOption(
             type: "category",
             data: allPositions,
             axisLabel: {
+                fontSize: FONT_CHARTS.axis,
                 interval:
                     granularity === "day"
                         ? (_index: number, value: string) =>
@@ -202,6 +205,11 @@ function buildStackedOption(
             nameRotate: 90,
             nameLocation: "middle",
             nameGap: 40,
+            nameTextStyle: { fontSize: FONT_CHARTS.axisName },
+            axisLabel: { fontSize: FONT_CHARTS.axis },
+            splitLine: {
+                lineStyle: { type: "dashed", color: mapColors.value.splitLine },
+            },
         },
         series: [...baselineSeries, ...yearSeries],
         legend: {
@@ -212,8 +220,13 @@ function buildStackedOption(
                 ...years.map(String),
             ],
             bottom: 85,
+            textStyle: { fontSize: FONT_CHARTS.legend },
         },
-        title: { text: "Indicateur thermique national", left: "center" },
+        title: {
+            text: "Indicateur thermique national",
+            left: "center",
+            textStyle: { fontSize: FONT_CHARTS.title },
+        },
         tooltip: {
             trigger: "axis",
             formatter: (params) =>
@@ -288,13 +301,12 @@ const option = computed<ECOption>(() => {
         },
         xAxis: {
             type: "time",
-            ...(props.adapter.granularity.value === "day"
-                ? {
-                      axisLabel: {
-                          formatter: formatContinuousAxisLabel,
-                      },
-                  }
-                : {}),
+            axisLabel: {
+                fontSize: FONT_CHARTS.axis,
+                ...(props.adapter.granularity.value === "day"
+                    ? { formatter: formatContinuousAxisLabel }
+                    : {}),
+            },
         },
         yAxis: {
             type: "value",
@@ -302,6 +314,11 @@ const option = computed<ECOption>(() => {
             nameRotate: 90,
             nameLocation: "middle",
             nameGap: 40,
+            nameTextStyle: { fontSize: FONT_CHARTS.axisName },
+            axisLabel: { fontSize: FONT_CHARTS.axis },
+            splitLine: {
+                lineStyle: { type: "dashed", color: mapColors.value.splitLine },
+            },
         },
         series: [
             // extreme - Invisible base — pushes the band up to start at lower bound
@@ -323,9 +340,9 @@ const option = computed<ECOption>(() => {
                 stack: "extreme",
                 stackStrategy: "all",
                 symbol: "none",
-                color: colorExtremes,
+                color: itnColors.value.extremes,
                 lineStyle: { opacity: 0 },
-                areaStyle: { color: colorExtremes },
+                areaStyle: { color: itnColors.value.extremes },
             },
             // ecart-type - Invisible base — pushes the band up to start at lower bound
             {
@@ -346,9 +363,9 @@ const option = computed<ECOption>(() => {
                 stack: "std",
                 stackStrategy: "all",
                 symbol: "none",
-                color: colorEcartType,
+                color: itnColors.value.ecartType,
                 lineStyle: { opacity: 0 },
-                areaStyle: { color: colorEcartType },
+                areaStyle: { color: itnColors.value.ecartType },
             },
             // Moyenne - baseline_mean
             {
@@ -363,7 +380,7 @@ const option = computed<ECOption>(() => {
                 type: "line",
                 stack: "temperature",
                 encode: { x: "date", y: "temperature" },
-                color: "#999",
+                color: itnColors.value.temperatureLine,
                 lineStyle: { width: 0.5 },
                 symbol: "none",
             },
@@ -387,9 +404,9 @@ const option = computed<ECOption>(() => {
                 stack: "hot_cold",
                 stackStrategy: "all",
                 symbol: "none",
-                color: "#f00",
+                color: itnColors.value.hotBand,
                 lineStyle: { opacity: 0 },
-                areaStyle: { color: "rgba(255, 0, 0, 0.6)" },
+                areaStyle: { color: itnColors.value.hotBand },
                 tooltip: { show: false },
             },
             // cold_blue_band
@@ -400,15 +417,16 @@ const option = computed<ECOption>(() => {
                 stack: "hot_cold",
                 stackStrategy: "all",
                 symbol: "none",
-                color: "#00f",
+                color: itnColors.value.coldBand,
                 lineStyle: { opacity: 0 },
-                areaStyle: { color: "rgba(0, 0, 255, 0.6)" },
+                areaStyle: { color: itnColors.value.coldBand },
                 tooltip: { show: false },
             },
         ],
         title: {
             text: "Indicateur thermique national",
             left: "center",
+            textStyle: { fontSize: FONT_CHARTS.title },
         },
         legend: {
             data: [
@@ -418,6 +436,7 @@ const option = computed<ECOption>(() => {
                 ITN_SERIES.extremes,
             ],
             bottom: 85,
+            textStyle: { fontSize: FONT_CHARTS.legend },
         },
         tooltip: {
             trigger: "axis",
@@ -427,7 +446,16 @@ const option = computed<ECOption>(() => {
                     props.adapter.granularity.value,
                 ),
         },
-        dataZoom: [{ type: "inside", minSpan: 20 }],
+        dataZoom: [
+            {
+                type: "slider",
+                minSpan: 20,
+            },
+            {
+                type: "inside",
+                minSpan: 20,
+            },
+        ],
         emphasis: {
             focus: "none",
             disabled: true, // disables all emphasis state changes on hover

--- a/frontend/app/components/charts/ItnKpiPanel.vue
+++ b/frontend/app/components/charts/ItnKpiPanel.vue
@@ -1,5 +1,5 @@
 <template>
-    <div class="flex flex-col gap-3 md:w-52 md:shrink-0 py-2">
+    <div class="flex flex-col gap-3 w-52 shrink-0 py-2">
         <Card
             title="ITN moyen"
             tooltip-text="Moyenne de l'Indicateur Thermique National sur la période sélectionnée."

--- a/frontend/app/components/charts/recordsCharts/recordsPyramidChart.vue
+++ b/frontend/app/components/charts/recordsCharts/recordsPyramidChart.vue
@@ -107,7 +107,9 @@ const option = computed<ECOption>(() => {
         min: 0,
         max: globalMax,
         minInterval: 1,
-        splitLine: { lineStyle: { type: "dashed" } },
+        splitLine: {
+            lineStyle: { type: "dashed", color: mapColors.value.splitLine },
+        },
     };
 
     const option: ECOption = {
@@ -155,7 +157,7 @@ const option = computed<ECOption>(() => {
                     margin: labelMargin,
                     width: labelMargin * 2,
                     align: "center",
-                    fontSize: FONT_CHARTS.fontSize,
+                    fontSize: FONT_CHARTS.axis,
                     fontWeight: "bold",
                 },
                 axisTick: { show: false },
@@ -173,14 +175,14 @@ const option = computed<ECOption>(() => {
                 text: pd.name,
                 right: "right",
                 top: `${i * slotSize + 2}%`,
-                textStyle: { fontSize: FONT_CHARTS.fontSize },
+                textStyle: { fontSize: FONT_CHARTS.title },
             })),
             {
                 text: "Nombre de records",
                 bottom: 25,
                 left: "50%",
                 textAlign: "center",
-                textStyle: { fontSize: FONT_CHARTS.fontSize, color: "#fff" },
+                textStyle: { fontSize: FONT_CHARTS.title, color: "#fff" },
             },
         ],
         legend: {

--- a/frontend/app/components/charts/recordsCharts/recordsScatterChart.vue
+++ b/frontend/app/components/charts/recordsCharts/recordsScatterChart.vue
@@ -128,7 +128,7 @@ const option = computed<ECOption>(() => {
             nameLocation: "middle",
             nameGap: 25,
             nameTextStyle: {
-                fontSize: FONT_CHARTS.fontSize,
+                fontSize: FONT_CHARTS.axisName,
                 fontWeight: "bold",
             },
             axisPointer: { type: "line", label: { show: false } },
@@ -154,11 +154,13 @@ const option = computed<ECOption>(() => {
             nameLocation: "middle",
             nameGap: 40,
             nameTextStyle: {
-                fontSize: FONT_CHARTS.fontSize,
+                fontSize: FONT_CHARTS.axisName,
                 fontWeight: "bold",
             },
-            axisLabel: { fontSize: FONT_CHARTS.fontSize },
-            splitLine: { lineStyle: { type: "dashed" } },
+            axisLabel: { fontSize: FONT_CHARTS.axis },
+            splitLine: {
+                lineStyle: { type: "dashed", color: mapColors.value.splitLine },
+            },
         })),
         series: [
             ...territoryPlots.flatMap((_, index) => [

--- a/frontend/app/composables/useDeviationCalendarOption.ts
+++ b/frontend/app/composables/useDeviationCalendarOption.ts
@@ -235,7 +235,7 @@ export function useDeviationCalendarOption(
             axisLine: { lineStyle: { color: "#3a5080" } },
             axisLabel: {
                 color: "#000000",
-                fontSize: FONT_CHARTS.fontSize,
+                fontSize: FONT_CHARTS.axis,
                 interval: labelInterval,
                 rotate: labelRotate,
             },
@@ -244,7 +244,7 @@ export function useDeviationCalendarOption(
             nameGap: granularity === "year" ? 25 : 38,
             nameTextStyle: {
                 color: mapColors.value.foreground,
-                fontSize: FONT_CHARTS.fontSize,
+                fontSize: FONT_CHARTS.axisName,
                 fontWeight: "bold",
             },
         });
@@ -258,14 +258,14 @@ export function useDeviationCalendarOption(
             axisLine: { lineStyle: { color: "#3a5080" } },
             axisLabel: {
                 color: mapColors.value.foreground,
-                fontSize: FONT_CHARTS.fontSize,
+                fontSize: FONT_CHARTS.axis,
             },
             name: yAxisName,
             nameLocation: "middle",
             nameGap: 35,
             nameTextStyle: {
                 color: mapColors.value.foreground,
-                fontSize: FONT_CHARTS.fontSize,
+                fontSize: FONT_CHARTS.axisName,
                 fontWeight: "bold",
             },
         });
@@ -275,7 +275,7 @@ export function useDeviationCalendarOption(
             top: `${top - 4}%`,
             right: "12%",
             textStyle: {
-                fontSize: FONT_CHARTS.fontSize,
+                fontSize: FONT_CHARTS.title,
                 fontWeight: "bold",
                 color: mapColors.value.foreground,
             },

--- a/frontend/app/constants/colors.ts
+++ b/frontend/app/constants/colors.ts
@@ -9,6 +9,7 @@ const DARK_COLORS = {
     transparent: "#202d4300",
     cold: TEMPERATURE_COLORS.cold,
     hot: TEMPERATURE_COLORS.hot,
+    splitLine: "rgba(255, 255, 255, 0.08)",
 };
 const LIGHT_COLORS = {
     background: "#FFFFFF",
@@ -16,6 +17,7 @@ const LIGHT_COLORS = {
     transparent: "#ffffff00",
     cold: TEMPERATURE_COLORS.cold,
     hot: TEMPERATURE_COLORS.hot,
+    splitLine: "rgba(0, 0, 0, 0.12)",
 };
 
 export function useMapColors() {

--- a/frontend/app/constants/fonts.ts
+++ b/frontend/app/constants/fonts.ts
@@ -1,5 +1,8 @@
 export const FONT_CHARTS = {
-    fontSize: 13,
+    axis: 13,
+    axisName: 13,
+    legend: 13,
+    title: 14,
 };
 
 export const GRAPH_RECORDS_POSITION = {

--- a/frontend/app/constants/itn.ts
+++ b/frontend/app/constants/itn.ts
@@ -1,3 +1,4 @@
+import { TEMPERATURE_COLORS } from "./colors";
 export const ITN_SERIES = {
     temperature: "ITN",
     baseline: "ITN des normales",
@@ -5,7 +6,27 @@ export const ITN_SERIES = {
     stdDev: "Écart-type",
 };
 
-export const ITN_COLORS = {
-    EXTREMES: "rgba(100, 100, 100, 0.2)",
-    ECART_TYPE: "rgba(175, 175, 175, 1)",
+const ITN_LIGHT_COLORS = {
+    extremes: "rgba(100, 100, 100, 0.20)",
+    ecartType: "rgba(175, 175, 175, 1)",
+    hotBand: TEMPERATURE_COLORS.hot,
+    coldBand: TEMPERATURE_COLORS.cold,
+    temperatureLine: "#999",
+    baselineLine: "#333",
 };
+
+const ITN_DARK_COLORS = {
+    extremes: "rgb(132, 145, 167, 0.2)",
+    ecartType: "rgb(132, 145, 167, 0.5)",
+    hotBand: TEMPERATURE_COLORS.hot,
+    coldBand: TEMPERATURE_COLORS.cold,
+    temperatureLine: "#bbbbbb",
+    baselineLine: "#ccc",
+};
+
+export function useItnColors() {
+    const cm = useColorMode();
+    return computed(() =>
+        cm.value === "dark" ? ITN_DARK_COLORS : ITN_LIGHT_COLORS,
+    );
+}


### PR DESCRIPTION
## Type de PR
- [ ] Bugfix
- [x] Feature
- [ ] Refactor
- [ ] Chore / Tech debt
- [ ] Documentation
- [ ] Autre (à préciser)

## Objectif
Adapte l'ui du graphe ITN au dark theme

## Contexte
Restart de la branche feat/front/itn_tune_dark_theme pour gérer les conflits.
PR déjà approuvée par jean sur ancienne PR

## Changements
- ajuste couleur graphe ITN light et dark theme
- supprime le zoom slider

## Décisions techniques
<!-- Choix structurants, arbitrages, compromis. -->
<!-- Ce qui aurait pu être fait autrement. -->

## Impacts
- [ ] API / contrat
- [ ] Modèle de données / DB
- [ ] Calculs métier
- [ ] Performance
- [ ] Sécurité
- [ ] Infra / déploiement
- [ ] Aucun impact transverse identifié

## Tests
<!-- Décris ce qui a été fait dans cette PR pour vérifier le comportement introduit ou modifié. -->
- [ ] Tests unitaires
- [ ] Tests d’intégration
- [x] Tests manuels
- [ ] Non applicable (à justifier)

## Points d’attention pour la review
<!-- Parties sensibles du code, dette technique introduite, risques. -->

## Suivi
- [ ] Migration à prévoir
- [ ] Documentation à mettre à jour
- [ ] Tâche(s) de suivi à créer
