### PR TITLE
Fix/security

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,6 +2,7 @@
 DEBUG=False
 SECRET_KEY=django-insecure-change-this-in-production
 ALLOWED_HOSTS=*
+MOCKED_DATA=true
 
 # Database - TimescaleDB
 DB_NAME=meteodb

--- a/.github/workflows/ci.md
+++ b/.github/workflows/ci.md
@@ -1,0 +1,62 @@
+# CI Pipeline — `ci.yml`
+
+Pipeline d'intégration continue déclenché à chaque `push` sur n'importe quelle branche.
+
+---
+
+## Jobs
+
+### 1. `basic-pipeline`
+
+Vérifie la qualité du code backend et frontend.
+
+**Étapes :**
+
+| Étape | Description |
+|---|---|
+| Checkout | Clone le dépôt avec historique complet (`fetch-depth: 0`) |
+| Setup uv / Python 3.13 | Installe l'environnement Python via `uv` |
+| Setup Node 24 | Installe Node.js avec cache npm |
+| Install backend deps | `uv sync` + démarrage de TimescaleDB via Docker Compose |
+| Install frontend deps | `npm ci` + ajout de vitest |
+| Tests backend | `pytest` avec export JUnit XML uploadé en artifact |
+| Lint backend | `ruff check` (règle DJ001 ignorée) |
+| Lint frontend | `npm run lint` |
+| Scan Trivy | Analyse du filesystem pour vulnérabilités HIGH/CRITICAL |
+| Upload rapport Trivy | Rapport uploadé en artifact même en cas d'échec |
+| Check Trivy | Fait échouer le job si des vulnérabilités sont détectées |
+
+---
+
+### 2. `docker-build-push`
+
+Construit et publie les images Docker sur GitHub Container Registry (GHCR).
+Déclenché uniquement si `basic-pipeline` réussit.
+
+**Images produites :**
+
+| Service | Image |
+|---|---|
+| Backend | `ghcr.io/<owner>/<repo>/backend` |
+| Frontend | `ghcr.io/<owner>/<repo>/frontend` |
+
+**Tags appliqués :** `latest` + SHA court du commit.
+
+**Note :** l'authentification utilise le secret `CR_PAT` (Personal Access Token)
+au lieu du `GITHUB_TOKEN` par défaut, nécessaire car le dépôt est un fork
+(le token par défaut y est restreint en écriture sur GHCR).
+
+---
+
+## Secrets requis
+
+| Secret | Usage |
+|---|---|
+| `CR_PAT` | Token GitHub avec scope `write:packages` pour pousser sur GHCR |
+
+## Artifacts produits
+
+| Artifact | Contenu |
+|---|---|
+| `test-report` | Résultats pytest au format JUnit XML |
+| `security-report` | Rapport Trivy des vulnérabilités détectées |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -119,7 +119,7 @@ jobs:
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+          password: ${{ secrets.CR_PAT }}
 
       - name: Extract Docker metadata
         id: meta

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -159,7 +159,7 @@ jobs:
         uses: docker/build-push-action@v6
         with:
           context: ${{ matrix.context }}
-          push: github.ref == 'refs/heads/main'
+          push: ${{ github.ref == 'refs/heads/main' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,11 @@ name: CI
 
 on:
   push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
 
 jobs:
   basic-pipeline:
@@ -81,6 +86,24 @@ jobs:
           name: security-report
           path: security-report.txt
 
+      - name: Trivy scan (CycloneDX / VEX)
+        uses: aquasecurity/trivy-action@v0.14.0
+        with:
+          scan-type: 'fs'
+          ignore-unfixed: true
+          format: 'cyclonedx'
+          output: 'trivy-vex.json'
+          severity: 'HIGH,CRITICAL'
+          exit-code: '0'
+          vex: '.vex/vex.json'
+
+      - name: Upload VEX report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: trivy-vex
+          path: trivy-vex.json
+
       - name: Check Trivy report
         if: always()
         run: |
@@ -94,7 +117,6 @@ jobs:
   docker-build-push:
     runs-on: ubuntu-latest
     needs: basic-pipeline
-    # if: github.ref == 'refs/heads/main'
 
     permissions:
       contents: read
@@ -137,7 +159,7 @@ jobs:
         uses: docker/build-push-action@v6
         with:
           context: ${{ matrix.context }}
-          push: true
+          push: github.ref == 'refs/heads/main'
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,141 @@
+name: CI
+
+on:
+  push:
+
+jobs:
+  basic-pipeline:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: checkout repository
+        uses: actions/checkout@v4
+        with:
+          # Disabling shallow clones is recommended for improving the relevancy of sonar reporting
+          fetch-depth: 0
+
+      - uses: astral-sh/setup-uv@v7
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.13"
+
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "24"
+          cache: 'npm'
+          cache-dependency-path: 'frontend/package-lock.json'
+
+      - name: install backend dependencies
+        run: |
+          cd backend
+          uv sync --frozen --extra dev
+          cp .env.example .env
+          cd timescaledb-env
+          docker compose up -d timescaledb
+
+      - name: install frontend dependencies
+        run: |
+          cd frontend
+          npm ci --legacy-peer-deps --frozen-lockfile
+          npm add vitest --save-dev
+
+      - name: run backend tests
+        run: |
+          cd backend
+          uv run pytest --junitxml=../test-report.xml
+
+      - name: upload test report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-report
+          path: test-report.xml
+
+      - name: run backend lint
+        run: |
+          cd backend && uv run ruff check . --ignore DJ001
+
+      - name: run frontend lint
+        run: |
+          cd frontend && npm run lint
+
+      - name: Security scan using Trivy
+        uses: aquasecurity/trivy-action@v0.14.0
+        with:
+          scan-type: 'fs'
+          ignore-unfixed: true
+          format: 'table'
+          output: 'security-report.txt'
+          severity: 'HIGH,CRITICAL'
+          exit-code: '0'  # ne pas faire échouer ici ; on gère ça dans l'étape suivante
+
+      - name: upload security report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: security-report
+          path: security-report.txt
+
+      - name: Check Trivy report
+        if: always()
+        run: |
+          if [ -s security-report.txt ]; then
+            echo "::error::Des vulnérabilités HIGH/CRITICAL ont été détectées !"
+            exit 1
+          else
+            echo "Aucune vulnérabilité HIGH/CRITICAL détectée."
+          fi
+
+  docker-build-push:
+    runs-on: ubuntu-latest
+    needs: basic-pipeline
+    # if: github.ref == 'refs/heads/main'
+
+    permissions:
+      contents: read
+      packages: write
+
+    strategy:
+      matrix:
+        include:
+          - service: backend
+            context: ./backend
+            image: ghcr.io/${{ github.repository }}/backend
+          - service: frontend
+            context: ./frontend
+            image: ghcr.io/${{ github.repository }}/frontend
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract Docker metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ matrix.image }}
+          tags: |
+            type=sha,prefix=,suffix=,format=short
+            type=raw,value=latest
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build and push ${{ matrix.service }} image
+        uses: docker/build-push-action@v6
+        with:
+          context: ${{ matrix.context }}
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,9 @@ jobs:
   basic-pipeline:
     runs-on: ubuntu-latest
 
+    permissions:
+      contents: write
+
     steps:
       - name: checkout repository
         uses: actions/checkout@v4

--- a/.vex/vex.json
+++ b/.vex/vex.json
@@ -1,0 +1,7 @@
+{
+  "@context": "https://openvex.dev/ns/v0.2.0",
+  "@id": "https://github.com/servalD/14_ValorisationDonneeMeteo/vex/1",
+  "author": "servalD",
+  "timestamp": "2026-04-27T00:00:00Z",
+  "statements": []
+}

--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # Valorisation Donnée Météo
 
+[![CI](https://github.com/servalD/14_ValorisationDonneeMeteo/actions/workflows/ci.yml/badge.svg)](https://github.com/servalD/14_ValorisationDonneeMeteo/actions/workflows/ci.yml)
+[![Trivy Security Scan](https://github.com/servalD/14_ValorisationDonneeMeteo/actions/workflows/ci.yml/badge.svg?label=trivy)](https://github.com/servalD/14_ValorisationDonneeMeteo/actions/workflows/ci.yml)
+[![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/servalD/14_ValorisationDonneeMeteo/badge)](https://securityscorecards.dev/viewer/?uri=github.com/servalD/14_ValorisationDonneeMeteo)
+
 Projet Data For Good - Saison 14
 
 ## Structure du projet

--- a/backend/.dockerignore
+++ b/backend/.dockerignore
@@ -1,0 +1,9 @@
+.venv/
+__pycache__/
+*.pyc
+.pytest_cache/
+.ruff_cache/
+.env
+CONTRIBUTING.md
+CHANGELOG.md
+.git/

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,15 +1,37 @@
-FROM python:3.12-slim-bookworm
+FROM dhi.io/python:3.12-dev AS builder
 
 WORKDIR /app
 
 ENV PYTHONDONTWRITEBYTECODE=1 \
     PYTHONUNBUFFERED=1 \
-    UV_NO_DEV=1
+    UV_NO_DEV=1 \
+    UV_PROJECT_ENVIRONMENT=/app/.venv
 
-COPY --from=ghcr.io/astral-sh/uv:0.10.0 /uv /uvx /bin/
+COPY --from=ghcr.io/astral-sh/uv:0.10.0 /uv /bin/uv
+
+COPY pyproject.toml uv.lock ./
+RUN uv sync --locked --no-install-project
 
 COPY . .
 RUN uv sync --locked
 
+FROM dhi.io/python:3.12 AS final
+
+WORKDIR /app
+COPY --from=builder /app/.venv /app/.venv
+COPY --from=builder /app/config ./config
+COPY --from=builder /app/weather ./weather
+COPY --from=builder /app/manage.py ./manage.py
+COPY --from=builder /app/pyproject.toml ./pyproject.toml
+
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1 \
+    PATH="/app/.venv/bin:$PATH"
+
 EXPOSE 8000
-CMD ["uv", "run", "gunicorn", "config.wsgi:application", "--bind", "0.0.0.0:8000", "--access-logfile", "-", "--error-logfile", "-", "--log-level", "info"]
+
+CMD ["gunicorn", "config.wsgi:application", \
+     "--bind", "0.0.0.0:8000", \
+     "--access-logfile", "-", \
+     "--error-logfile", "-", \
+     "--log-level", "info"]

--- a/backend/config/settings.py
+++ b/backend/config/settings.py
@@ -32,6 +32,7 @@ MOCKED_DATA = env("MOCKED_DATA", False)
 # Application definition
 INSTALLED_APPS = [
     # Third-party
+    "django_prometheus",
     "rest_framework",
     "corsheaders",
     "django_filters",
@@ -45,9 +46,11 @@ if DEBUG:
     INSTALLED_APPS += ["django_extensions"]
 
 MIDDLEWARE = [
+    "django_prometheus.middleware.PrometheusBeforeMiddleware",
     "django.middleware.security.SecurityMiddleware",
     "corsheaders.middleware.CorsMiddleware",
     "django.middleware.common.CommonMiddleware",
+    "django_prometheus.middleware.PrometheusAfterMiddleware",
 ]
 
 ROOT_URLCONF = "config.urls"
@@ -73,6 +76,7 @@ DATABASES = {
 # No migrations
 MIGRATION_MODULES = {
     "weather": None,
+    "django_prometheus": None,
 }
 
 # Password validation

--- a/backend/config/urls.py
+++ b/backend/config/urls.py
@@ -10,6 +10,8 @@ from drf_spectacular.views import (
 )
 
 urlpatterns = [
+    # Prometheus metrics
+    path("", include("django_prometheus.urls")),
     # API v1
     path("api/v1/", include("weather.urls")),
     # OpenAPI schema and documentation

--- a/backend/notebooks/national_indicator_sandbox.ipynb
+++ b/backend/notebooks/national_indicator_sandbox.ipynb
@@ -8,8 +8,9 @@
    "outputs": [],
    "source": [
     "import datetime as dt\n",
-    "import pandas as pd\n",
-    "import matplotlib.pyplot as plt"
+    "\n",
+    "import matplotlib.pyplot as plt\n",
+    "import pandas as pd"
    ]
   },
   {
@@ -19,7 +20,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from weather.data_generators.national_indicator_fake import generate_fake_national_indicator\n"
+    "from weather.data_generators.national_indicator_fake import (\n",
+    "    generate_fake_national_indicator,\n",
+    ")"
    ]
   },
   {
@@ -34,12 +37,11 @@
     "    date_end=dt.date(2024, 12, 31),\n",
     "    granularity=\"month\",\n",
     "    slice_type=\"day_of_month\",\n",
-    "    day_of_month=31\n",
+    "    day_of_month=31,\n",
     ")\n",
     "\n",
     "df = pd.DataFrame(payload[\"time_series\"])\n",
-    "df[\"date\"] = pd.to_datetime(df[\"date\"])\n",
-    "\n"
+    "df[\"date\"] = pd.to_datetime(df[\"date\"])"
    ]
   },
   {

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -16,6 +16,7 @@ dependencies = [
     "whitenoise>=6.7.0",
     "numpy>=1.26.0",
     "django-extensions>=4.1",
+    "django-prometheus>=2.3.0",
 ]
 
 [project.optional-dependencies]

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -638,6 +638,19 @@ wheels = [
 ]
 
 [[package]]
+name = "django-prometheus"
+version = "2.4.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "django" },
+    { name = "prometheus-client" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/98/f4/cb39ddd2a41e07a274c4e162c076e906ae232d63b66bbabdea0300878877/django_prometheus-2.4.1.tar.gz", hash = "sha256:073628243d2a6de6a8a8c20e5b512872dfb85d66e1b60b28bcf1eca0155dad95", size = 24464, upload-time = "2025-06-25T15:45:37.149Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/01/50/9c5e022fa92574e5d20606687f15a2aa255e10512a17d11a8216fa117f72/django_prometheus-2.4.1-py2.py3-none-any.whl", hash = "sha256:7fe5af7f7c9ad9cd8a429fe0f3f1bf651f0e244f77162147869eab7ec09cc5e7", size = 29541, upload-time = "2025-06-25T15:45:35.433Z" },
+]
+
+[[package]]
 name = "djangorestframework"
 version = "3.16.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1425,6 +1438,7 @@ dependencies = [
     { name = "django-environ" },
     { name = "django-extensions" },
     { name = "django-filter" },
+    { name = "django-prometheus" },
     { name = "djangorestframework" },
     { name = "drf-spectacular" },
     { name = "gunicorn" },
@@ -1459,6 +1473,7 @@ requires-dist = [
     { name = "django-extensions", specifier = ">=4.1" },
     { name = "django-extensions", marker = "extra == 'dev'", specifier = ">=3.2.0" },
     { name = "django-filter", specifier = ">=24.0" },
+    { name = "django-prometheus", specifier = ">=2.3.0" },
     { name = "djangorestframework", specifier = ">=3.15.0" },
     { name = "drf-spectacular", specifier = ">=0.27.0" },
     { name = "factory-boy", marker = "extra == 'dev'", specifier = ">=3.3.0" },

--- a/backend/weather/calcul_itn.py
+++ b/backend/weather/calcul_itn.py
@@ -75,9 +75,9 @@ def separate_by_station(
           temperature records, with one column per station
     """
 
-    assert (
-        (index != "") and (columns != "") and (values != "")
-    ), "Cannot pivot, missing arguments"
+    assert (index != "") and (columns != "") and (values != ""), (
+        "Cannot pivot, missing arguments"
+    )
 
     data_temp = pd.pivot_table(
         df, index=index, columns=columns, values=values, sort=False

--- a/backend/weather/calcul_itn.py
+++ b/backend/weather/calcul_itn.py
@@ -75,9 +75,9 @@ def separate_by_station(
           temperature records, with one column per station
     """
 
-    assert (index != "") and (columns != "") and (values != ""), (
-        "Cannot pivot, missing arguments"
-    )
+    assert (
+        (index != "") and (columns != "") and (values != "")
+    ), "Cannot pivot, missing arguments"
 
     data_temp = pd.pivot_table(
         df, index=index, columns=columns, values=values, sort=False

--- a/backend/weather/tests/unit/test_national_indicator_business.py
+++ b/backend/weather/tests/unit/test_national_indicator_business.py
@@ -22,7 +22,7 @@ def _build_station_code_to_fixed_temperature_map(
     always_station_temperature: float = 10.0,
 ) -> dict[str, float]:
     """Construit un mapping complet (30 slots attendus pour ce jour)."""
-    m = {code: always_station_temperature for code in ITN_ALWAYS_STATION_CODES}
+    m = dict.fromkeys(ITN_ALWAYS_STATION_CODES, always_station_temperature)
     m[expected_reims_code(day)] = reims_station_temperature
     return m
 
@@ -63,7 +63,7 @@ def test_compute_itn_drop_if_missing_any_always_station():
 
 def test_compute_itn_drop_if_missing_expected_reims():
     day = dt.date(2025, 1, 1)
-    m = {code: 10.0 for code in ITN_ALWAYS_STATION_CODES}
+    m = dict.fromkeys(ITN_ALWAYS_STATION_CODES, 10.0)
     # pas de Reims attendue => drop
     assert compute_itn_for_day(day, m) is None
 

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -8,7 +8,7 @@ services:
       POSTGRES_DB: meteodb
     volumes:
       - timescaledb-data:/var/lib/postgresql/data
-      - ./timescaledb-env/meteodb_dump.sql:/docker-entrypoint-initdb.d/dump.sql:ro
+      - ./db_data/meteodb_dump.sql:/docker-entrypoint-initdb.d/dump.sql:ro
     networks:
       - bd_net
     healthcheck:

--- a/docker-compose.monitoring.yml
+++ b/docker-compose.monitoring.yml
@@ -21,7 +21,7 @@ services:
     environment:
       GF_SECURITY_ADMIN_USER: admin
       GF_SECURITY_ADMIN_PASSWORD: admin
-      GF_USERS_ALLOW_SIGN_UP: "false"
+      GF_USERS_ALLOW_SIGN_UP: "true"
     volumes:
       - grafana-data:/var/lib/grafana
       - ./monitoring/grafana/provisioning:/etc/grafana/provisioning:ro

--- a/docker-compose.monitoring.yml
+++ b/docker-compose.monitoring.yml
@@ -1,0 +1,46 @@
+services:
+  prometheus:
+    image: prom/prometheus:v3.4.0
+    container_name: prometheus
+    volumes:
+      - ./monitoring/prometheus.yml:/etc/prometheus/prometheus.yml:ro
+      - prometheus-data:/prometheus
+    command:
+      - "--config.file=/etc/prometheus/prometheus.yml"
+      - "--storage.tsdb.retention.time=15d"
+    ports:
+      - "9090:9090"
+    networks:
+      - monitoring_net
+      - 14_valorisationdonneemeteo_app_net
+    restart: unless-stopped
+
+  grafana:
+    image: grafana/grafana:12.0.0
+    container_name: grafana
+    environment:
+      GF_SECURITY_ADMIN_USER: admin
+      GF_SECURITY_ADMIN_PASSWORD: admin
+      GF_USERS_ALLOW_SIGN_UP: "false"
+    volumes:
+      - grafana-data:/var/lib/grafana
+      - ./monitoring/grafana/provisioning:/etc/grafana/provisioning:ro
+      - ./monitoring/grafana/dashboards:/var/lib/grafana/dashboards:ro
+    ports:
+      - "3001:3000"
+    depends_on:
+      - prometheus
+    networks:
+      - monitoring_net
+    restart: unless-stopped
+
+volumes:
+  prometheus-data:
+    driver: local
+  grafana-data:
+    driver: local
+
+networks:
+  monitoring_net:
+  14_valorisationdonneemeteo_app_net:
+    external: true

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -2,10 +2,8 @@ services:
   timescaledb:
     image: timescale/timescaledb:2.25.0-pg17
     container_name: timescaledb
-    environment:
-      POSTGRES_USER: infoclimat
-      POSTGRES_PASSWORD: infoclimat2026
-      POSTGRES_DB: meteodb
+    env_file:
+      - ./.env
     volumes:
       - timescaledb-data:/var/lib/postgresql/data
       - ./timescaledb-env/meteodb_dump.sql:/docker-entrypoint-initdb.d/dump.sql:ro

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -1,0 +1,61 @@
+services:
+  timescaledb:
+    image: timescale/timescaledb:2.25.0-pg17
+    container_name: timescaledb
+    environment:
+      POSTGRES_USER: infoclimat
+      POSTGRES_PASSWORD: infoclimat2026
+      POSTGRES_DB: meteodb
+    volumes:
+      - timescaledb-data:/var/lib/postgresql/data
+      - ./timescaledb-env/meteodb_dump.sql:/docker-entrypoint-initdb.d/dump.sql:ro
+    networks:
+      - bd_net
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U infoclimat -d meteodb"]
+      interval: 10s
+      timeout: 20s
+      retries: 10
+      start_period: 40s
+    restart: unless-stopped
+
+  backend:
+    image: ghcr.io/servald/14_valorisationdonneemeteo/backend:latest
+    env_file:
+      - ./.env
+    depends_on:
+      timescaledb:
+        condition: service_healthy
+    networks:
+      - app_net
+      - bd_net
+    restart: unless-stopped
+
+  frontend:
+    image: ghcr.io/servald/14_valorisationdonneemeteo/frontend:latest
+    env_file:
+      - ./.env
+    networks:
+      - app_net
+    restart: unless-stopped
+
+  nginx:
+    image: dhi.io/nginx:1.27
+    ports:
+      - "80:80"
+    volumes:
+      - ./nginx/nginx.conf:/etc/nginx/conf.d/default.conf:ro
+    depends_on:
+      - frontend
+      - backend
+    networks:
+      - app_net
+    restart: unless-stopped
+
+volumes:
+  timescaledb-data:
+    driver: local
+
+networks:
+  app_net:
+  bd_net:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,7 @@ services:
       POSTGRES_DB: meteodb
     volumes:
       - timescaledb-data:/var/lib/postgresql/data
-      - ./timescaledb-env/meteodb_dump.sql:/docker-entrypoint-initdb.d/dump.sql:ro
+      - ./db_data/meteodb_dump.sql:/docker-entrypoint-initdb.d/dump.sql:ro
     networks:
       - bd_net
     healthcheck:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,65 @@
+services:
+  timescaledb:
+    image: timescale/timescaledb:2.25.0-pg17
+    container_name: timescaledb
+    environment:
+      POSTGRES_USER: infoclimat
+      POSTGRES_PASSWORD: infoclimat2026
+      POSTGRES_DB: meteodb
+    volumes:
+      - timescaledb-data:/var/lib/postgresql/data
+      - ./timescaledb-env/meteodb_dump.sql:/docker-entrypoint-initdb.d/dump.sql:ro
+    networks:
+      - bd_net
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U infoclimat -d meteodb"]
+      interval: 10s
+      timeout: 20s
+      retries: 10
+      start_period: 40s
+    restart: unless-stopped
+
+  backend:
+    build:
+      context: ./backend
+      target: final
+    env_file:
+      - ./.env
+    depends_on:
+      timescaledb:
+        condition: service_healthy
+    networks:
+      - app_net
+      - bd_net
+    restart: unless-stopped
+
+  frontend:
+    build:
+      context: ./frontend
+      target: final
+    env_file:
+      - ./.env
+    networks:
+      - app_net
+    restart: unless-stopped
+
+  nginx:
+    image: dhi.io/nginx:1.27
+    ports:
+      - "80:80"
+    volumes:
+      - ./nginx/nginx.conf:/etc/nginx/conf.d/default.conf:ro
+    depends_on:
+      - frontend
+      - backend
+    networks:
+      - app_net
+    restart: unless-stopped
+
+volumes:
+  timescaledb-data:
+    driver: local
+
+networks:
+  app_net:
+  bd_net:

--- a/frontend/.dockerignore
+++ b/frontend/.dockerignore
@@ -1,0 +1,6 @@
+node_modules/
+.nuxt/
+.output/
+.env
+*.md
+.git/

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,23 +1,22 @@
-FROM node:24-alpine AS build
+FROM dhi.io/node:24-dev AS builder
 
 WORKDIR /app
 
-COPY package*.json .
-
-RUN npm install
+COPY package*.json ./
+RUN npm ci --frozen-lockfile
 
 COPY . .
-
 RUN npm run build
 
-FROM node:24-alpine AS prod
+
+FROM dhi.io/node:24 AS final
 
 WORKDIR /app
 
-COPY --from=build /app/.output /app/.output
+COPY --from=builder /app/.output /app/.output
 
 ENV NODE_ENV=production
 
 EXPOSE 3000
 
-CMD [ "node", ".output/server/index.mjs" ]
+CMD ["node", ".output/server/index.mjs"]

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -8,7 +8,6 @@ RUN npm ci --frozen-lockfile
 COPY . .
 RUN npm run build
 
-
 FROM dhi.io/node:24 AS final
 
 WORKDIR /app

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -6886,13 +6886,13 @@
             }
         },
         "node_modules/@unhead/vue": {
-            "version": "2.1.12",
-            "resolved": "https://registry.npmjs.org/@unhead/vue/-/vue-2.1.12.tgz",
-            "integrity": "sha512-zEWqg0nZM8acpuTZE40wkeUl8AhIe0tU0OkilVi1D4fmVjACrwoh5HP6aNqJ8kUnKsoy6D+R3Vi/O+fmdNGO7g==",
+            "version": "2.1.13",
+            "resolved": "https://registry.npmjs.org/@unhead/vue/-/vue-2.1.13.tgz",
+            "integrity": "sha512-HYy0shaHRnLNW9r85gppO8IiGz0ONWVV3zGdlT8CQ0tbTwixznJCIiyqV4BSV1aIF1jJIye0pd1p/k6Eab8Z/A==",
             "license": "MIT",
             "dependencies": {
                 "hookable": "^6.0.1",
-                "unhead": "2.1.12"
+                "unhead": "2.1.13"
             },
             "funding": {
                 "url": "https://github.com/sponsors/harlan-zw"
@@ -9674,9 +9674,9 @@
             }
         },
         "node_modules/defu": {
-            "version": "6.1.4",
-            "resolved": "https://registry.npmjs.org/defu/-/defu-6.1.4.tgz",
-            "integrity": "sha512-mEQCMmwJu317oSz8CwdIOdwf3xMif1ttiM8LTufzc3g6kR+9Pe236twL8j3IYT1F7GfRgGcW6MWxzZjLIkuHIg==",
+            "version": "6.1.7",
+            "resolved": "https://registry.npmjs.org/defu/-/defu-6.1.7.tgz",
+            "integrity": "sha512-7z22QmUWiQ/2d0KkdYmANbRUVABpZ9SNYyH5vx6PZ+nE5bcC0l7uFvEfHlyld/HcGBFTL536ClDt3DEcSlEJAQ==",
             "license": "MIT"
         },
         "node_modules/delaunator": {
@@ -13229,9 +13229,10 @@
             }
         },
         "node_modules/lodash": {
-            "version": "4.17.23",
-            "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
-            "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
+            "version": "4.18.0",
+            "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.0.tgz",
+            "integrity": "sha512-l1mfj2atMqndAHI3ls7XqPxEjV2J9ZkcNyHpoZA3r2T1LLwDB69jgkMWh71YKwhBbK0G2f4WSn05ahmQXVxupA==",
+            "deprecated": "Bad release. Please use lodash@4.17.21 instead.",
             "license": "MIT"
         },
         "node_modules/lodash.defaults": {
@@ -14779,9 +14780,9 @@
             }
         },
         "node_modules/postcss": {
-            "version": "8.5.8",
-            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.8.tgz",
-            "integrity": "sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==",
+            "version": "8.5.12",
+            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.12.tgz",
+            "integrity": "sha512-W62t/Se6rA0Az3DfCL0AqJwXuKwBeYg6nOaIgzP+xZ7N5BFCI7DYi1qs6ygUYT6rvfi6t9k65UMLJC+PHZpDAA==",
             "funding": [
                 {
                     "type": "opencollective",
@@ -15526,9 +15527,9 @@
             "license": "ISC"
         },
         "node_modules/protocol-buffers-schema": {
-            "version": "3.6.0",
-            "resolved": "https://registry.npmjs.org/protocol-buffers-schema/-/protocol-buffers-schema-3.6.0.tgz",
-            "integrity": "sha512-TdDRD+/QNdrCGCE7v8340QyuXd4kIWIgapsE2+n/SaGiSSbomYl4TjHlvIoCWRpE7wFt02EpB35VVA2ImcBVqw==",
+            "version": "3.6.1",
+            "resolved": "https://registry.npmjs.org/protocol-buffers-schema/-/protocol-buffers-schema-3.6.1.tgz",
+            "integrity": "sha512-VG2K63Igkiv9p76tk1lilczEK1cT+kCjKtkdhw1dQZV3k3IXJbd3o6Ho8b9zJZaHSnT2hKe4I+ObmX9w6m5SmQ==",
             "license": "MIT"
         },
         "node_modules/punycode": {
@@ -17103,9 +17104,9 @@
             }
         },
         "node_modules/unhead": {
-            "version": "2.1.12",
-            "resolved": "https://registry.npmjs.org/unhead/-/unhead-2.1.12.tgz",
-            "integrity": "sha512-iTHdWD9ztTunOErtfUFk6Wr11BxvzumcYJ0CzaSCBUOEtg+DUZ9+gnE99i8QkLFT2q1rZD48BYYGXpOZVDLYkA==",
+            "version": "2.1.13",
+            "resolved": "https://registry.npmjs.org/unhead/-/unhead-2.1.13.tgz",
+            "integrity": "sha512-jO9M1sI6b2h/1KpIu4Jeu+ptumLmUKboRRLxys5pYHFeT+lqTzfNHbYUX9bxVDhC1FBszAGuWcUVlmvIPsah8Q==",
             "license": "MIT",
             "dependencies": {
                 "hookable": "^6.0.1"
@@ -17662,9 +17663,9 @@
             }
         },
         "node_modules/vite": {
-            "version": "7.3.1",
-            "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.1.tgz",
-            "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
+            "version": "7.3.2",
+            "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.2.tgz",
+            "integrity": "sha512-Bby3NOsna2jsjfLVOHKes8sGwgl4TT0E6vvpYgnAYDIF/tie7MRaFthmKuHx1NSXjiTueXH3do80FMQgvEktRg==",
             "license": "MIT",
             "dependencies": {
                 "esbuild": "^0.27.0",

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -112,7 +112,6 @@
             "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.0.tgz",
             "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@babel/code-frame": "^7.29.0",
                 "@babel/generator": "^7.29.0",
@@ -1117,9 +1116,9 @@
             "license": "MIT"
         },
         "node_modules/@eslint/config-array/node_modules/brace-expansion": {
-            "version": "1.1.12",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-            "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+            "version": "1.1.13",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
+            "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
             "devOptional": true,
             "license": "MIT",
             "dependencies": {
@@ -1225,9 +1224,9 @@
             "license": "MIT"
         },
         "node_modules/@eslint/eslintrc/node_modules/brace-expansion": {
-            "version": "1.1.12",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-            "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+            "version": "1.1.13",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
+            "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
             "devOptional": true,
             "license": "MIT",
             "dependencies": {
@@ -1339,7 +1338,6 @@
             "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.7.6.tgz",
             "integrity": "sha512-9gZSAI5XM36880PPMm//9dfiEngYoC6Am2izES1FF406YFsjvyBMmeJ2g4SAju3xWwtuynNRFL2s9hgxpLI5SQ==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@floating-ui/core": "^1.7.5",
                 "@floating-ui/utils": "^0.2.11"
@@ -2382,8 +2380,7 @@
             "version": "0.2.1",
             "resolved": "https://registry.npmjs.org/citty/-/citty-0.2.1.tgz",
             "integrity": "sha512-kEV95lFBhQgtogAPlQfJJ0WGVSokvLr/UEoFPiKKOXF7pl98HfUVUD0ejsuTCld/9xH9vogSywZ5KqHzXrZpqg==",
-            "license": "MIT",
-            "peer": true
+            "license": "MIT"
         },
         "node_modules/@nuxt/cli/node_modules/giget": {
             "version": "3.1.2",
@@ -2676,7 +2673,6 @@
             "resolved": "https://registry.npmjs.org/@nuxt/kit/-/kit-4.4.2.tgz",
             "integrity": "sha512-5+IPRNX2CjkBhuWUwz0hBuLqiaJPRoKzQ+SvcdrQDbAyE+VDeFt74VpSFr5/R0ujrK4b+XnSHUJWdS72w6hsog==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "c12": "^3.3.3",
                 "consola": "^3.4.2",
@@ -5603,7 +5599,6 @@
             "integrity": "sha512-nPK52ZHvot8Ju/0A4ucSX1dcPV2/1clx0kLcH5wDmrE4naKso7TUC/voUyU1O9OTKTrR6MYip6LP0ogEMQ9jPQ==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@eslint-community/eslint-utils": "^4.9.1",
                 "@typescript-eslint/types": "^8.56.0",
@@ -5961,7 +5956,6 @@
             "resolved": "https://registry.npmjs.org/@tiptap/core/-/core-3.20.4.tgz",
             "integrity": "sha512-3i/DG89TFY/b34T5P+j35UcjYuB5d3+9K8u6qID+iUqNPiza015HPIZLuPfE5elNwVdV3EXIoPo0LLeBLgXXAg==",
             "license": "MIT",
-            "peer": true,
             "funding": {
                 "type": "github",
                 "url": "https://github.com/sponsors/ueberdosis"
@@ -6058,7 +6052,6 @@
             "resolved": "https://registry.npmjs.org/@tiptap/extension-collaboration/-/extension-collaboration-3.20.4.tgz",
             "integrity": "sha512-6KSZ5hCpscT4losDeRbZ2G9xifgMvSGJZnw+tFPgmNrbZToKMSbPnKMUTx4DYUiB2yTDv/fJOrcCFaQ5EpbHBA==",
             "license": "MIT",
-            "peer": true,
             "funding": {
                 "type": "github",
                 "url": "https://github.com/sponsors/ueberdosis"
@@ -6088,7 +6081,6 @@
             "resolved": "https://registry.npmjs.org/@tiptap/extension-drag-handle/-/extension-drag-handle-3.20.4.tgz",
             "integrity": "sha512-qVf+fuvT7Dh7P3hwhowrds6AX3l/BO/Uppf+q3OL49G9URkYZr77ZuP6TsZAwRxylyJ6RVLAFScODXnX0b/kfQ==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@floating-ui/dom": "^1.6.13"
             },
@@ -6249,7 +6241,6 @@
             "resolved": "https://registry.npmjs.org/@tiptap/extension-list/-/extension-list-3.20.4.tgz",
             "integrity": "sha512-X+5plTKhOioNcQ4KsAFJJSb/3+zR8Xhdpow4HzXtoV1KcbdDey1fhZdpsfkbrzCL0s6/wAgwZuAchCK7HujurQ==",
             "license": "MIT",
-            "peer": true,
             "funding": {
                 "type": "github",
                 "url": "https://github.com/sponsors/ueberdosis"
@@ -6305,7 +6296,6 @@
             "resolved": "https://registry.npmjs.org/@tiptap/extension-node-range/-/extension-node-range-3.20.4.tgz",
             "integrity": "sha512-ymDNgsM+EVeoQP/bixMR4iiXK/Sp/osRSmOhcSNAXllzTV1QogEClessU/z7gl26H0XLhMkxzKIYCaUT0LXTbA==",
             "license": "MIT",
-            "peer": true,
             "funding": {
                 "type": "github",
                 "url": "https://github.com/sponsors/ueberdosis"
@@ -6398,7 +6388,6 @@
             "resolved": "https://registry.npmjs.org/@tiptap/extensions/-/extensions-3.20.4.tgz",
             "integrity": "sha512-8p6hVT65DjuQjtEdlH6ewX9SOJHlVQAOee3sWIJQmeJNRnZNvqPIBLleebUqDiljNTpxBv6s6QWkSTKgf3btwg==",
             "license": "MIT",
-            "peer": true,
             "funding": {
                 "type": "github",
                 "url": "https://github.com/sponsors/ueberdosis"
@@ -6430,7 +6419,6 @@
             "resolved": "https://registry.npmjs.org/@tiptap/pm/-/pm-3.20.4.tgz",
             "integrity": "sha512-rCHYSBToilBEuI6PtjziHDdRkABH/XqwJ7dG4Amn/SD3yGiZKYCiEApQlTUS2zZeo8DsLeuqqqB4vEOeD4OEPg==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "prosemirror-changeset": "^2.3.0",
                 "prosemirror-collab": "^1.3.1",
@@ -6497,7 +6485,6 @@
             "resolved": "https://registry.npmjs.org/@tiptap/suggestion/-/suggestion-3.20.4.tgz",
             "integrity": "sha512-7uqgLwjEAvsosrfoVrYVBQtAKI2pJFHOM8wgsQMLv1pQL8mfRz5ByD2xet4DOKb23q4mDvrvzp6z0kvCp0hMDw==",
             "license": "MIT",
-            "peer": true,
             "funding": {
                 "type": "github",
                 "url": "https://github.com/sponsors/ueberdosis"
@@ -6512,7 +6499,6 @@
             "resolved": "https://registry.npmjs.org/@tiptap/vue-3/-/vue-3-3.20.4.tgz",
             "integrity": "sha512-OL0lXt6geUu5P+uavOz3PIFfLE6pW4qbdS9gy+ZOZMIHVgcH7isz2V2PjCOOTLY3mb2LWBHVvJIZdfwhQQ0+0Q==",
             "license": "MIT",
-            "peer": true,
             "funding": {
                 "type": "github",
                 "url": "https://github.com/sponsors/ueberdosis"
@@ -6594,8 +6580,7 @@
             "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
             "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
             "devOptional": true,
-            "license": "MIT",
-            "peer": true
+            "license": "MIT"
         },
         "node_modules/@types/linkify-it": {
             "version": "5.0.0",
@@ -6625,7 +6610,6 @@
             "integrity": "sha512-jp2P3tQMSxWugkCUKLRPVUpGaL5MVFwF8RDuSRztfwgN1wmqJeMSbKlnEtQqU8UrhTmzEmZdu2I6v2dpp7XIxw==",
             "devOptional": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "undici-types": "~7.18.0"
             }
@@ -6703,7 +6687,6 @@
             "integrity": "sha512-30ScMRHIAD33JJQkgfGW1t8CURZtjc2JpTrq5n2HFhOefbAhb7ucc7xJwdWcrEtqUIYJ73Nybpsggii6GtAHjA==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@typescript-eslint/scope-manager": "8.57.2",
                 "@typescript-eslint/types": "8.57.2",
@@ -7545,7 +7528,6 @@
             "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.5.30.tgz",
             "integrity": "sha512-LqmFPDn89dtU9vI3wHJnwaV6GfTRD87AjWpTWpyrdVOObVtjIuSeZr181z5C4PmVx/V3j2p+0f7edFKGRMpQ5A==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@babel/parser": "^7.29.0",
                 "@vue/compiler-core": "3.5.30",
@@ -7676,7 +7658,6 @@
             "integrity": "sha512-FMxEjOpYNYiFe0GkaHsnJPXFHxQ6m4t8vI/ElPGpMWxZKpmRvQ33OIrvRXemy6yha03RxhOlQuy+gZMC3CQSow==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "js-beautify": "^1.14.9",
                 "vue-component-type-helpers": "^2.0.0"
@@ -7694,7 +7675,6 @@
             "resolved": "https://registry.npmjs.org/@vueuse/core/-/core-14.2.1.tgz",
             "integrity": "sha512-3vwDzV+GDUNpdegRY6kzpLm4Igptq+GA0QkJ3W61Iv27YWwW/ufSlOfgQIpN6FZRMG0mkaz4gglJRtq5SeJyIQ==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@types/web-bluetooth": "^0.0.21",
                 "@vueuse/metadata": "14.2.1",
@@ -7821,7 +7801,6 @@
             "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
             "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
             "license": "MIT",
-            "peer": true,
             "bin": {
                 "acorn": "bin/acorn"
             },
@@ -8129,7 +8108,6 @@
             "resolved": "https://registry.npmjs.org/bare-events/-/bare-events-2.8.2.tgz",
             "integrity": "sha512-riJjyv1/mHLIPX4RwiK+oW9/4c3TEUeORHKefKAKnZ5kyslbN+HXowtbaVEqt4IMUB7OXlfixcs6gsFeo/jhiQ==",
             "license": "Apache-2.0",
-            "peer": true,
             "peerDependencies": {
                 "bare-abort-controller": "*"
             },
@@ -8282,9 +8260,9 @@
             "license": "ISC"
         },
         "node_modules/brace-expansion": {
-            "version": "5.0.4",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.4.tgz",
-            "integrity": "sha512-h+DEnpVvxmfVefa4jFbCf5HdH5YMDXRsmKflpf1pILZWRFlTbJpxeU55nJl4Smt5HQaGzg1o6RHFPJaOqnmBDg==",
+            "version": "5.0.5",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
+            "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
             "license": "MIT",
             "dependencies": {
                 "balanced-match": "^4.0.2"
@@ -8333,7 +8311,6 @@
                 }
             ],
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "baseline-browser-mapping": "^2.9.0",
                 "caniuse-lite": "^1.0.30001759",
@@ -8560,8 +8537,7 @@
             "resolved": "https://registry.npmjs.org/change-case/-/change-case-5.4.4.tgz",
             "integrity": "sha512-HRQyTk2/YPEkt9TnUPbOpr64Uw3KOicFWPVBb+xiHvd6eBx/qPr9xqfBFDT8P2vWsvvz4jbEkfDe71W3VyNu2w==",
             "devOptional": true,
-            "license": "MIT",
-            "peer": true
+            "license": "MIT"
         },
         "node_modules/chart.js": {
             "version": "4.5.1",
@@ -8897,6 +8873,7 @@
             "resolved": "https://registry.npmjs.org/copy-anything/-/copy-anything-4.0.5.tgz",
             "integrity": "sha512-7Vv6asjS4gMOuILabD3l739tsaxFQmC+a7pLZm02zyvs8p977bL3zEgq3yDk5rn9B0PbYgIv++jmHcuUab4RhA==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "is-what": "^5.2.0"
             },
@@ -9495,7 +9472,6 @@
             "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
             "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
             "license": "ISC",
-            "peer": true,
             "engines": {
                 "node": ">=12"
             }
@@ -9883,6 +9859,7 @@
             "resolved": "https://registry.npmjs.org/echarts/-/echarts-6.0.0.tgz",
             "integrity": "sha512-Tte/grDQRiETQP4xz3iZWSvoHrkCQtwqd6hs+mifXcjrCuo2iKWbajFObuLJVBlDIJlOzgQPd1hsaKt/3+OMkQ==",
             "license": "Apache-2.0",
+            "peer": true,
             "dependencies": {
                 "tslib": "2.3.0",
                 "zrender": "6.0.0"
@@ -9892,7 +9869,8 @@
             "version": "2.3.0",
             "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.0.tgz",
             "integrity": "sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg==",
-            "license": "0BSD"
+            "license": "0BSD",
+            "peer": true
         },
         "node_modules/editorconfig": {
             "version": "1.0.7",
@@ -9921,9 +9899,9 @@
             "license": "MIT"
         },
         "node_modules/editorconfig/node_modules/brace-expansion": {
-            "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-            "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.3.tgz",
+            "integrity": "sha512-MCV/fYJEbqx68aE58kv2cA/kiky1G8vux3OR6/jbS+jIMe/6fJWa0DTzJU7dqijOWYwHi1t29FlfYI9uytqlpA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -9972,8 +9950,7 @@
             "version": "8.6.0",
             "resolved": "https://registry.npmjs.org/embla-carousel/-/embla-carousel-8.6.0.tgz",
             "integrity": "sha512-SjWyZBHJPbqxHOzckOfo8lHisEaJWmwd23XppYFYVh10bU66/Pn5tkVkbkCMZVdbUE5eTCI2nD8OyIP4Z+uwkA==",
-            "license": "MIT",
-            "peer": true
+            "license": "MIT"
         },
         "node_modules/embla-carousel-auto-height": {
             "version": "8.6.0",
@@ -10124,7 +10101,6 @@
             "integrity": "sha512-Rq4vbHnYkK5fws5NF7MYTU68FPRE1ajX7heQ/8QXXWqNgqqJ/GkmmyxIzUnf2Sr/bakf8l54716CcMGHYhMrrQ==",
             "hasInstallScript": true,
             "license": "MIT",
-            "peer": true,
             "bin": {
                 "esbuild": "bin/esbuild"
             },
@@ -10193,7 +10169,6 @@
             "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
             "devOptional": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@eslint-community/eslint-utils": "^4.8.0",
                 "@eslint-community/regexpp": "^4.12.1",
@@ -10639,9 +10614,9 @@
             "license": "MIT"
         },
         "node_modules/eslint/node_modules/brace-expansion": {
-            "version": "1.1.12",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-            "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+            "version": "1.1.13",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
+            "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
             "devOptional": true,
             "license": "MIT",
             "dependencies": {
@@ -11741,7 +11716,6 @@
             "resolved": "https://registry.npmjs.org/fuse.js/-/fuse.js-7.1.0.tgz",
             "integrity": "sha512-trLf4SzuuUxfusZADLINj+dE8clK1frKdmqiJNb1Es75fmI5oY6X2mxLVUciLLjxqw/xr72Dhy+lER6dGd02FQ==",
             "license": "Apache-2.0",
-            "peer": true,
             "engines": {
                 "node": ">=10"
             }
@@ -11877,9 +11851,9 @@
             "license": "MIT"
         },
         "node_modules/glob/node_modules/brace-expansion": {
-            "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-            "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.3.tgz",
+            "integrity": "sha512-MCV/fYJEbqx68aE58kv2cA/kiky1G8vux3OR6/jbS+jIMe/6fJWa0DTzJU7dqijOWYwHi1t29FlfYI9uytqlpA==",
             "license": "MIT",
             "dependencies": {
                 "balanced-match": "^1.0.0"
@@ -12043,12 +12017,11 @@
             }
         },
         "node_modules/happy-dom": {
-            "version": "20.8.7",
-            "resolved": "https://registry.npmjs.org/happy-dom/-/happy-dom-20.8.7.tgz",
-            "integrity": "sha512-7wfBi+UqulQlyLcis+9a+hTK0A/fMO4QKP6w6J9HnadXVkRdOvGf/N5G4XVpfgCYfnY7oKazlOSdWmsfatNSLQ==",
+            "version": "20.8.9",
+            "resolved": "https://registry.npmjs.org/happy-dom/-/happy-dom-20.8.9.tgz",
+            "integrity": "sha512-Tz23LR9T9jOGVZm2x1EPdXqwA37G/owYMxRwU0E4miurAtFsPMQ1d2Jc2okUaSjZqAFz2oEn3FLXC5a0a+siyA==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@types/node": ">=20.0.0",
                 "@types/whatwg-mimetype": "^3.0.2",
@@ -12555,6 +12528,7 @@
             "resolved": "https://registry.npmjs.org/is-what/-/is-what-5.5.0.tgz",
             "integrity": "sha512-oG7cgbmg5kLYae2N5IVd3jm2s+vldjxJzK1pcu9LfpGuQ93MQSzo0okvRna+7y5ifrD+20FE8FvjusyGaz14fw==",
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=18"
             },
@@ -12609,6 +12583,7 @@
             "resolved": "https://registry.npmjs.org/isomorphic.js/-/isomorphic.js-0.2.5.tgz",
             "integrity": "sha512-PIeMbHqMt4DnUP3MA/Flc0HElYjMXArsw1qwJZcm9sqR8mq3l8NYizFMty0pWwE/tzIGH3EKK5+jes5mAr85yw==",
             "license": "MIT",
+            "peer": true,
             "funding": {
                 "type": "GitHub Sponsors ❤",
                 "url": "https://github.com/sponsors/dmonad"
@@ -12872,6 +12847,7 @@
             "resolved": "https://registry.npmjs.org/lib0/-/lib0-0.2.117.tgz",
             "integrity": "sha512-DeXj9X5xDCjgKLU/7RR+/HQEVzuuEUiwldwOGsHK/sfAfELGWEyTcf0x+uOvCvK3O2zPmZePXWL85vtia6GyZw==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "isomorphic.js": "^0.2.4"
             },
@@ -13360,7 +13336,6 @@
             "resolved": "https://registry.npmjs.org/maplibre-gl/-/maplibre-gl-5.21.0.tgz",
             "integrity": "sha512-n0v4J/Ge0EG8ix/z3TY3ragtJYMqzbtSnj1riOC0OwQbzwp0lUF2maS1ve1z8HhitQCKtZZiZJhb8to36aMMfQ==",
             "license": "BSD-3-Clause",
-            "peer": true,
             "dependencies": {
                 "@mapbox/jsonlint-lines-primitives": "^2.0.2",
                 "@mapbox/point-geometry": "^1.1.0",
@@ -13584,7 +13559,8 @@
             "version": "3.0.1",
             "resolved": "https://registry.npmjs.org/mitt/-/mitt-3.0.1.tgz",
             "integrity": "sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw==",
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/mlly": {
             "version": "1.8.2",
@@ -13936,9 +13912,9 @@
             "license": "MIT"
         },
         "node_modules/node-forge": {
-            "version": "1.3.3",
-            "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.3.3.tgz",
-            "integrity": "sha512-rLvcdSyRCyouf6jcOIPe/BgwG/d7hKjzMKOas33/pHEr6gbq18IK9zV7DiPvzsz0oBJPme6qr6H6kGZuI9/DZg==",
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.4.0.tgz",
+            "integrity": "sha512-LarFH0+6VfriEhqMMcLX2F7SwSXeWwnEAJEsYm5QKWchiVYVvJyV9v7UDvUv+w5HO23ZpQTXDv/GxdDdMyOuoQ==",
             "license": "(BSD-3-Clause OR GPL-2.0)",
             "engines": {
                 "node": ">= 6.13.0"
@@ -14036,7 +14012,6 @@
             "resolved": "https://registry.npmjs.org/nuxt/-/nuxt-4.4.2.tgz",
             "integrity": "sha512-iWVFpr/YEqVU/CenqIHMnIkvb2HE/9f+q8oxZ+pj2et+60NljGRClCgnmbvGPdmNFE0F1bEhoBCYfqbDOCim3Q==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@dxup/nuxt": "^0.4.0",
                 "@nuxt/cli": "^3.34.0",
@@ -14377,7 +14352,6 @@
             "integrity": "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==",
             "devOptional": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "deep-is": "^0.1.3",
                 "fast-levenshtein": "^2.0.6",
@@ -14435,7 +14409,6 @@
             "resolved": "https://registry.npmjs.org/oxc-parser/-/oxc-parser-0.117.0.tgz",
             "integrity": "sha512-l3cbgK5wUvWDVNWM/JFU77qDdGZK1wudnLsFcrRyNo/bL1CyU8pC25vDhMHikVY29lbK2InTWsX42RxVSutUdQ==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@oxc-project/types": "^0.117.0"
             },
@@ -14729,6 +14702,7 @@
             "resolved": "https://registry.npmjs.org/@vue/devtools-api/-/devtools-api-7.7.9.tgz",
             "integrity": "sha512-kIE8wvwlcZ6TJTbNeU2HQNtaxLx3a84aotTITUuL/4bzfPxzajGBOoqjMhwZJ8L9qFYDU/lAYMEEm11dnZOD6g==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@vue/devtools-kit": "^7.7.9"
             }
@@ -14738,6 +14712,7 @@
             "resolved": "https://registry.npmjs.org/@vue/devtools-kit/-/devtools-kit-7.7.9.tgz",
             "integrity": "sha512-PyQ6odHSgiDVd4hnTP+aDk2X4gl2HmLDfiyEnn3/oV+ckFDuswRs4IbBT7vacMuGdwY/XemxBoh302ctbsptuA==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@vue/devtools-shared": "^7.7.9",
                 "birpc": "^2.3.0",
@@ -14753,6 +14728,7 @@
             "resolved": "https://registry.npmjs.org/@vue/devtools-shared/-/devtools-shared-7.7.9.tgz",
             "integrity": "sha512-iWAb0v2WYf0QWmxCGy0seZNDPdO3Sp5+u78ORnyeonS6MT4PC7VPrryX2BpMJrwlDeaZ6BD4vP4XKjK0SZqaeA==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "rfdc": "^1.4.1"
             }
@@ -14762,6 +14738,7 @@
             "resolved": "https://registry.npmjs.org/birpc/-/birpc-2.9.0.tgz",
             "integrity": "sha512-KrayHS5pBi69Xi9JmvoqrIgYGDkD6mcSe/i6YKi3w5kekCLzrX4+nawcXqrj2tIp50Kw/mT/s3p+GVK0A0sKxw==",
             "license": "MIT",
+            "peer": true,
             "funding": {
                 "url": "https://github.com/sponsors/antfu"
             }
@@ -14770,13 +14747,15 @@
             "version": "5.5.3",
             "resolved": "https://registry.npmjs.org/hookable/-/hookable-5.5.3.tgz",
             "integrity": "sha512-Yc+BQe8SvoXH1643Qez1zqLRmbA5rCL+sSmk6TVos0LWVfNIB7PGncdlId77WzLGSIB5KaWgTaNTs2lNVEI6VQ==",
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/pinia/node_modules/perfect-debounce": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/perfect-debounce/-/perfect-debounce-1.0.0.tgz",
             "integrity": "sha512-xCy9V055GLEqoFaHoC1SoLIaLmWctgCUaBaWxDZ7/Zx4CTyX7cJQLJOok/orfjZAh9kEYpjJa4d0KcJmCbctZA==",
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/pkg-types": {
             "version": "2.3.0",
@@ -14818,7 +14797,6 @@
                 }
             ],
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "nanoid": "^3.3.11",
                 "picocolors": "^1.1.1",
@@ -15457,7 +15435,6 @@
             "resolved": "https://registry.npmjs.org/prosemirror-model/-/prosemirror-model-1.25.4.tgz",
             "integrity": "sha512-PIM7E43PBxKce8OQeezAs9j4TP+5yDpZVbuurd1h5phUxEKIu+G2a+EUZzIC5nS1mJktDJWzbqS23n1tsAf5QA==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "orderedmap": "^2.0.0"
             }
@@ -15487,7 +15464,6 @@
             "resolved": "https://registry.npmjs.org/prosemirror-state/-/prosemirror-state-1.4.4.tgz",
             "integrity": "sha512-6jiYHH2CIGbCfnxdHbXZ12gySFY/fz/ulZE333G6bPqIZ4F+TXo9ifiR86nAHpWnfoNjOb3o5ESi7J8Uz1jXHw==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "prosemirror-model": "^1.0.0",
                 "prosemirror-transform": "^1.0.0",
@@ -15536,7 +15512,6 @@
             "resolved": "https://registry.npmjs.org/prosemirror-view/-/prosemirror-view-1.41.7.tgz",
             "integrity": "sha512-jUwKNCEIGiqdvhlS91/2QAg21e4dfU5bH2iwmSDQeosXJgKF7smG0YSplOWK0cjSNgIqXe7VXqo7EIfUFJdt3w==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "prosemirror-model": "^1.20.0",
                 "prosemirror-state": "^1.0.0",
@@ -15674,9 +15649,9 @@
             "license": "MIT"
         },
         "node_modules/readdir-glob/node_modules/brace-expansion": {
-            "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-            "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.3.tgz",
+            "integrity": "sha512-MCV/fYJEbqx68aE58kv2cA/kiky1G8vux3OR6/jbS+jIMe/6fJWa0DTzJU7dqijOWYwHi1t29FlfYI9uytqlpA==",
             "license": "MIT",
             "dependencies": {
                 "balanced-match": "^1.0.0"
@@ -15884,7 +15859,8 @@
             "version": "1.4.1",
             "resolved": "https://registry.npmjs.org/rfdc/-/rfdc-1.4.1.tgz",
             "integrity": "sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==",
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/robust-predicates": {
             "version": "3.0.3",
@@ -15897,7 +15873,6 @@
             "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.0.tgz",
             "integrity": "sha512-yqjxruMGBQJ2gG4HtjZtAfXArHomazDHoFwFFmZZl0r7Pdo7qCIXKqKHZc8yeoMgzJJ+pO6pEEHa+V7uzWlrAQ==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@types/estree": "1.0.8"
             },
@@ -16115,9 +16090,9 @@
             }
         },
         "node_modules/serialize-javascript": {
-            "version": "7.0.4",
-            "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-7.0.4.tgz",
-            "integrity": "sha512-DuGdB+Po43Q5Jxwpzt1lhyFSYKryqoNjQSA9M92tyw0lyHIOur+XCalOUe0KTJpyqzT8+fQ5A0Jf7vCx/NKmIg==",
+            "version": "7.0.5",
+            "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-7.0.5.tgz",
+            "integrity": "sha512-F4LcB0UqUl1zErq+1nYEEzSHJnIwb3AF2XWB94b+afhrekOUijwooAYqFyRbjYkm2PAKBabx6oYv/xDxNi8IBw==",
             "license": "BSD-3-Clause",
             "engines": {
                 "node": ">=20.0.0"
@@ -16386,6 +16361,7 @@
             "resolved": "https://registry.npmjs.org/speakingurl/-/speakingurl-14.0.1.tgz",
             "integrity": "sha512-1POYv7uv2gXoyGFpBCmpDVSNV74IfsWlDW216UPjbWufNf+bSU6GdbDsxdcxtfwb4xlI3yxzOTKClUosxARYrQ==",
             "license": "BSD-3-Clause",
+            "peer": true,
             "engines": {
                 "node": ">=0.10.0"
             }
@@ -16648,6 +16624,7 @@
             "resolved": "https://registry.npmjs.org/superjson/-/superjson-2.2.6.tgz",
             "integrity": "sha512-H+ue8Zo4vJmV2nRjpx86P35lzwDT3nItnIsocgumgr0hHMQ+ZGq5vrERg9kJBo5AWGmxZDhzDo+WVIJqkB0cGA==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "copy-anything": "^4"
             },
@@ -16743,7 +16720,6 @@
             "resolved": "https://registry.npmjs.org/tailwind-merge/-/tailwind-merge-3.5.0.tgz",
             "integrity": "sha512-I8K9wewnVDkL1NTGoqWmVEIlUcB9gFriAEkXkfCjX5ib8ezGxtR3xD7iZIxrfArjEsH7F1CHD4RFUtxefdqV/A==",
             "license": "MIT",
-            "peer": true,
             "funding": {
                 "type": "github",
                 "url": "https://github.com/sponsors/dcastil"
@@ -16772,8 +16748,7 @@
             "version": "4.2.2",
             "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.2.2.tgz",
             "integrity": "sha512-KWBIxs1Xb6NoLdMVqhbhgwZf2PGBpPEiwOqgI4pFIYbNTfBXiKYyWoTsXgBQ9WFg/OlhnvHaY+AEpW7wSmFo2Q==",
-            "license": "MIT",
-            "peer": true
+            "license": "MIT"
         },
         "node_modules/tapable": {
             "version": "2.3.2",
@@ -17067,7 +17042,6 @@
             "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
             "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
             "license": "Apache-2.0",
-            "peer": true,
             "bin": {
                 "tsc": "bin/tsc",
                 "tsserver": "bin/tsserver"
@@ -17344,7 +17318,6 @@
             "dev": true,
             "hasInstallScript": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "napi-postinstall": "^0.3.0"
             },
@@ -17693,7 +17666,6 @@
             "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.1.tgz",
             "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "esbuild": "^0.27.0",
                 "fdir": "^6.5.0",
@@ -18041,7 +18013,6 @@
             "integrity": "sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@types/chai": "^5.2.2",
                 "@vitest/expect": "3.2.4",
@@ -18177,7 +18148,6 @@
             "resolved": "https://registry.npmjs.org/vue/-/vue-3.5.30.tgz",
             "integrity": "sha512-hTHLc6VNZyzzEH/l7PFGjpcTvUgiaPK5mdLkbjrTeWSRcEfxFrv56g/XckIYlE9ckuobsdwqd5mk2g1sBkMewg==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@vue/compiler-dom": "3.5.30",
                 "@vue/compiler-sfc": "3.5.30",
@@ -18232,7 +18202,6 @@
             "integrity": "sha512-Vxi9pJdbN3ZnVGLODVtZ7y4Y2kzAAE2Cm0CZ3ZDRvydVYxZ6VrnBhLikBsRS+dpwj4Jv4UCv21PTEwF5rQ9WXg==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "debug": "^4.4.0",
                 "eslint-scope": "^8.2.0 || ^9.0.0",
@@ -18256,7 +18225,6 @@
             "resolved": "https://registry.npmjs.org/vue-router/-/vue-router-4.6.4.tgz",
             "integrity": "sha512-Hz9q5sa33Yhduglwz6g9skT8OBPii+4bFn88w6J+J4MfEo4KRRpmiNG/hHHkdbRFlLBOqxN8y8gf2Fb0MTUgVg==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@vue/devtools-api": "^6.6.4"
             },
@@ -18700,6 +18668,7 @@
             "resolved": "https://registry.npmjs.org/zrender/-/zrender-6.0.0.tgz",
             "integrity": "sha512-41dFXEEXuJpNecuUQq6JlbybmnHaqqpGlbH1yxnA5V9MMP4SbohSVZsJIwz+zdjQXSSlR1Vc34EgH1zxyTDvhg==",
             "license": "BSD-3-Clause",
+            "peer": true,
             "dependencies": {
                 "tslib": "2.3.0"
             }
@@ -18708,7 +18677,8 @@
             "version": "2.3.0",
             "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.0.tgz",
             "integrity": "sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg==",
-            "license": "0BSD"
+            "license": "0BSD",
+            "peer": true
         }
     }
 }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -5,6 +5,9 @@
     "engines": {
         "node": ">=24"
     },
+    "overrides": {
+        "lodash": "4.18.0"
+    },
     "scripts": {
         "build": "nuxt build",
         "dev": "nuxt dev",

--- a/monitoring/grafana/dashboards/django.json
+++ b/monitoring/grafana/dashboards/django.json
@@ -2,60 +2,151 @@
   "title": "Django - Meteo API",
   "uid": "django-meteo-api",
   "schemaVersion": 41,
-  "version": 1,
+  "version": 2,
   "refresh": "30s",
   "time": { "from": "now-1h", "to": "now" },
   "panels": [
     {
       "id": 1,
-      "title": "Requêtes / seconde",
-      "type": "timeseries",
+      "title": "Total requêtes",
+      "type": "stat",
       "datasource": "Prometheus",
-      "gridPos": { "x": 0, "y": 0, "w": 12, "h": 8 },
+      "gridPos": { "x": 0, "y": 0, "w": 6, "h": 4 },
       "targets": [
         {
           "datasource": "Prometheus",
-          "expr": "sum(rate(django_http_requests_total_by_method_total[1m])) by (method)",
-          "legendFormat": "{{method}}",
+          "expr": "sum(django_http_requests_before_middlewares_total)",
           "refId": "A"
         }
       ],
-      "fieldConfig": { "defaults": { "unit": "reqps" } }
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "color": { "mode": "thresholds" },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [{ "color": "blue", "value": null }]
+          }
+        }
+      },
+      "options": { "reduceOptions": { "calcs": ["lastNotNull"] }, "graphMode": "area", "colorMode": "background" }
     },
     {
       "id": 2,
-      "title": "Latence p50 / p95 / p99",
-      "type": "timeseries",
+      "title": "Taux d'erreur 5xx",
+      "type": "stat",
       "datasource": "Prometheus",
-      "gridPos": { "x": 12, "y": 0, "w": 12, "h": 8 },
+      "gridPos": { "x": 6, "y": 0, "w": 6, "h": 4 },
       "targets": [
         {
           "datasource": "Prometheus",
-          "expr": "histogram_quantile(0.50, sum(rate(django_http_requests_latency_seconds_by_view_method_bucket[1m])) by (le))",
-          "legendFormat": "p50",
+          "expr": "100 * sum(rate(django_http_responses_total_by_status_total{status=~\"5..\"}[5m])) / sum(rate(django_http_requests_before_middlewares_total[5m]))",
           "refId": "A"
-        },
-        {
-          "datasource": "Prometheus",
-          "expr": "histogram_quantile(0.95, sum(rate(django_http_requests_latency_seconds_by_view_method_bucket[1m])) by (le))",
-          "legendFormat": "p95",
-          "refId": "B"
-        },
-        {
-          "datasource": "Prometheus",
-          "expr": "histogram_quantile(0.99, sum(rate(django_http_requests_latency_seconds_by_view_method_bucket[1m])) by (le))",
-          "legendFormat": "p99",
-          "refId": "C"
         }
       ],
-      "fieldConfig": { "defaults": { "unit": "s" } }
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percent",
+          "color": { "mode": "thresholds" },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "orange", "value": 1 },
+              { "color": "red", "value": 5 }
+            ]
+          }
+        }
+      },
+      "options": { "reduceOptions": { "calcs": ["lastNotNull"] }, "graphMode": "none", "colorMode": "background" }
     },
     {
       "id": 3,
+      "title": "Mémoire RSS",
+      "type": "stat",
+      "datasource": "Prometheus",
+      "gridPos": { "x": 12, "y": 0, "w": 6, "h": 4 },
+      "targets": [
+        {
+          "datasource": "Prometheus",
+          "expr": "process_resident_memory_bytes",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "bytes",
+          "color": { "mode": "thresholds" },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "orange", "value": 200000000 },
+              { "color": "red", "value": 500000000 }
+            ]
+          }
+        }
+      },
+      "options": { "reduceOptions": { "calcs": ["lastNotNull"] }, "graphMode": "area", "colorMode": "background" }
+    },
+    {
+      "id": 4,
+      "title": "CPU",
+      "type": "stat",
+      "datasource": "Prometheus",
+      "gridPos": { "x": 18, "y": 0, "w": 6, "h": 4 },
+      "targets": [
+        {
+          "datasource": "Prometheus",
+          "expr": "rate(process_cpu_seconds_total[1m]) * 100",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percent",
+          "color": { "mode": "thresholds" },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "orange", "value": 50 },
+              { "color": "red", "value": 80 }
+            ]
+          }
+        }
+      },
+      "options": { "reduceOptions": { "calcs": ["lastNotNull"] }, "graphMode": "area", "colorMode": "background" }
+    },
+    {
+      "id": 5,
+      "title": "Requêtes / seconde",
+      "type": "timeseries",
+      "datasource": "Prometheus",
+      "gridPos": { "x": 0, "y": 4, "w": 12, "h": 8 },
+      "targets": [
+        {
+          "datasource": "Prometheus",
+          "expr": "sum(rate(django_http_requests_before_middlewares_total[1m]))",
+          "legendFormat": "req/s",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "reqps",
+          "color": { "mode": "palette-classic" },
+          "custom": { "lineWidth": 2, "fillOpacity": 15 }
+        }
+      },
+      "options": { "tooltip": { "mode": "multi" } }
+    },
+    {
+      "id": 6,
       "title": "Réponses par code HTTP",
       "type": "timeseries",
       "datasource": "Prometheus",
-      "gridPos": { "x": 0, "y": 8, "w": 12, "h": 8 },
+      "gridPos": { "x": 12, "y": 4, "w": 12, "h": 8 },
       "targets": [
         {
           "datasource": "Prometheus",
@@ -64,76 +155,162 @@
           "refId": "A"
         }
       ],
-      "fieldConfig": { "defaults": { "unit": "reqps" } }
+      "fieldConfig": {
+        "defaults": {
+          "unit": "reqps",
+          "custom": { "lineWidth": 2, "fillOpacity": 10 }
+        },
+        "overrides": [
+          { "matcher": { "id": "byName", "options": "HTTP 200" }, "properties": [{ "id": "color", "value": { "fixedColor": "green", "mode": "fixed" } }] },
+          { "matcher": { "id": "byName", "options": "HTTP 404" }, "properties": [{ "id": "color", "value": { "fixedColor": "orange", "mode": "fixed" } }] },
+          { "matcher": { "id": "byName", "options": "HTTP 500" }, "properties": [{ "id": "color", "value": { "fixedColor": "red", "mode": "fixed" } }] }
+        ]
+      },
+      "options": { "tooltip": { "mode": "multi" } }
     },
     {
-      "id": 4,
-      "title": "Taux d'erreurs 4xx / 5xx",
+      "id": 7,
+      "title": "Latence globale — p50 / p95 / p99",
       "type": "timeseries",
       "datasource": "Prometheus",
-      "gridPos": { "x": 12, "y": 8, "w": 12, "h": 8 },
+      "gridPos": { "x": 0, "y": 12, "w": 12, "h": 8 },
       "targets": [
         {
           "datasource": "Prometheus",
-          "expr": "sum(rate(django_http_responses_total_by_status_total{status=~\"4..\"}[1m]))",
-          "legendFormat": "4xx",
+          "expr": "histogram_quantile(0.50, sum(rate(django_http_requests_latency_including_middlewares_seconds_bucket[1m])) by (le))",
+          "legendFormat": "p50",
           "refId": "A"
         },
         {
           "datasource": "Prometheus",
-          "expr": "sum(rate(django_http_responses_total_by_status_total{status=~\"5..\"}[1m]))",
-          "legendFormat": "5xx",
+          "expr": "histogram_quantile(0.95, sum(rate(django_http_requests_latency_including_middlewares_seconds_bucket[1m])) by (le))",
+          "legendFormat": "p95",
           "refId": "B"
+        },
+        {
+          "datasource": "Prometheus",
+          "expr": "histogram_quantile(0.99, sum(rate(django_http_requests_latency_including_middlewares_seconds_bucket[1m])) by (le))",
+          "legendFormat": "p99",
+          "refId": "C"
         }
       ],
-      "fieldConfig": { "defaults": { "unit": "reqps" } }
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s",
+          "custom": { "lineWidth": 2, "fillOpacity": 8 }
+        }
+      },
+      "options": { "tooltip": { "mode": "multi" } }
     },
     {
-      "id": 5,
-      "title": "Total requêtes",
-      "type": "stat",
+      "id": 8,
+      "title": "Latence p95 par endpoint",
+      "type": "timeseries",
       "datasource": "Prometheus",
-      "gridPos": { "x": 0, "y": 16, "w": 6, "h": 4 },
+      "gridPos": { "x": 12, "y": 12, "w": 12, "h": 8 },
       "targets": [
         {
           "datasource": "Prometheus",
-          "expr": "sum(django_http_requests_total_by_method_total)",
-          "refId": "A"
-        }
-      ],
-      "fieldConfig": { "defaults": { "unit": "short" } }
-    },
-    {
-      "id": 6,
-      "title": "Connexions DB",
-      "type": "stat",
-      "datasource": "Prometheus",
-      "gridPos": { "x": 6, "y": 16, "w": 6, "h": 4 },
-      "targets": [
-        {
-          "datasource": "Prometheus",
-          "expr": "django_db_connections_total",
-          "refId": "A"
-        }
-      ],
-      "fieldConfig": { "defaults": { "unit": "short" } }
-    },
-    {
-      "id": 7,
-      "title": "Top 10 vues par RPS",
-      "type": "bargauge",
-      "datasource": "Prometheus",
-      "gridPos": { "x": 12, "y": 16, "w": 12, "h": 8 },
-      "options": { "orientation": "horizontal" },
-      "targets": [
-        {
-          "datasource": "Prometheus",
-          "expr": "topk(10, sum(rate(django_http_requests_latency_seconds_by_view_method_count[5m])) by (view))",
+          "expr": "histogram_quantile(0.95, sum(rate(django_http_requests_latency_seconds_by_view_method_bucket{view!=\"prometheus-django-metrics\"}[1m])) by (le, view))",
           "legendFormat": "{{view}}",
           "refId": "A"
         }
       ],
-      "fieldConfig": { "defaults": { "unit": "reqps" } }
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s",
+          "custom": { "lineWidth": 2, "fillOpacity": 8 }
+        }
+      },
+      "options": { "tooltip": { "mode": "multi" } }
+    },
+    {
+      "id": 9,
+      "title": "Exceptions par type",
+      "type": "timeseries",
+      "datasource": "Prometheus",
+      "gridPos": { "x": 0, "y": 20, "w": 6, "h": 8 },
+      "targets": [
+        {
+          "datasource": "Prometheus",
+          "expr": "sum(rate(django_http_exceptions_total_by_type_total[1m])) by (type)",
+          "legendFormat": "{{type}}",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "color": { "mode": "fixed", "fixedColor": "red" },
+          "custom": { "lineWidth": 2, "fillOpacity": 20 }
+        }
+      }
+    },
+    {
+      "id": 10,
+      "title": "Exceptions par vue",
+      "type": "timeseries",
+      "datasource": "Prometheus",
+      "gridPos": { "x": 6, "y": 20, "w": 6, "h": 8 },
+      "targets": [
+        {
+          "datasource": "Prometheus",
+          "expr": "sum(rate(django_http_exceptions_total_by_view_total[1m])) by (view)",
+          "legendFormat": "{{view}}",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "color": { "mode": "palette-classic" },
+          "custom": { "lineWidth": 2, "fillOpacity": 15 }
+        }
+      }
+    },
+    {
+      "id": 11,
+      "title": "Mémoire RSS",
+      "type": "timeseries",
+      "datasource": "Prometheus",
+      "gridPos": { "x": 12, "y": 20, "w": 6, "h": 8 },
+      "targets": [
+        {
+          "datasource": "Prometheus",
+          "expr": "process_resident_memory_bytes",
+          "legendFormat": "RSS",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "bytes",
+          "color": { "mode": "fixed", "fixedColor": "purple" },
+          "custom": { "lineWidth": 2, "fillOpacity": 15 }
+        }
+      }
+    },
+    {
+      "id": 12,
+      "title": "Taille moyenne des réponses",
+      "type": "timeseries",
+      "datasource": "Prometheus",
+      "gridPos": { "x": 18, "y": 20, "w": 6, "h": 8 },
+      "targets": [
+        {
+          "datasource": "Prometheus",
+          "expr": "rate(django_http_responses_body_total_bytes_sum[1m]) / rate(django_http_responses_body_total_bytes_count[1m])",
+          "legendFormat": "avg size",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "bytes",
+          "color": { "mode": "fixed", "fixedColor": "teal" },
+          "custom": { "lineWidth": 2, "fillOpacity": 15 }
+        }
+      }
     }
   ]
 }

--- a/monitoring/grafana/dashboards/django.json
+++ b/monitoring/grafana/dashboards/django.json
@@ -1,0 +1,139 @@
+{
+  "title": "Django - Meteo API",
+  "uid": "django-meteo-api",
+  "schemaVersion": 41,
+  "version": 1,
+  "refresh": "30s",
+  "time": { "from": "now-1h", "to": "now" },
+  "panels": [
+    {
+      "id": 1,
+      "title": "Requêtes / seconde",
+      "type": "timeseries",
+      "datasource": "Prometheus",
+      "gridPos": { "x": 0, "y": 0, "w": 12, "h": 8 },
+      "targets": [
+        {
+          "datasource": "Prometheus",
+          "expr": "sum(rate(django_http_requests_total_by_method_total[1m])) by (method)",
+          "legendFormat": "{{method}}",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": { "defaults": { "unit": "reqps" } }
+    },
+    {
+      "id": 2,
+      "title": "Latence p50 / p95 / p99",
+      "type": "timeseries",
+      "datasource": "Prometheus",
+      "gridPos": { "x": 12, "y": 0, "w": 12, "h": 8 },
+      "targets": [
+        {
+          "datasource": "Prometheus",
+          "expr": "histogram_quantile(0.50, sum(rate(django_http_requests_latency_seconds_by_view_method_bucket[1m])) by (le))",
+          "legendFormat": "p50",
+          "refId": "A"
+        },
+        {
+          "datasource": "Prometheus",
+          "expr": "histogram_quantile(0.95, sum(rate(django_http_requests_latency_seconds_by_view_method_bucket[1m])) by (le))",
+          "legendFormat": "p95",
+          "refId": "B"
+        },
+        {
+          "datasource": "Prometheus",
+          "expr": "histogram_quantile(0.99, sum(rate(django_http_requests_latency_seconds_by_view_method_bucket[1m])) by (le))",
+          "legendFormat": "p99",
+          "refId": "C"
+        }
+      ],
+      "fieldConfig": { "defaults": { "unit": "s" } }
+    },
+    {
+      "id": 3,
+      "title": "Réponses par code HTTP",
+      "type": "timeseries",
+      "datasource": "Prometheus",
+      "gridPos": { "x": 0, "y": 8, "w": 12, "h": 8 },
+      "targets": [
+        {
+          "datasource": "Prometheus",
+          "expr": "sum(rate(django_http_responses_total_by_status_total[1m])) by (status)",
+          "legendFormat": "HTTP {{status}}",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": { "defaults": { "unit": "reqps" } }
+    },
+    {
+      "id": 4,
+      "title": "Taux d'erreurs 4xx / 5xx",
+      "type": "timeseries",
+      "datasource": "Prometheus",
+      "gridPos": { "x": 12, "y": 8, "w": 12, "h": 8 },
+      "targets": [
+        {
+          "datasource": "Prometheus",
+          "expr": "sum(rate(django_http_responses_total_by_status_total{status=~\"4..\"}[1m]))",
+          "legendFormat": "4xx",
+          "refId": "A"
+        },
+        {
+          "datasource": "Prometheus",
+          "expr": "sum(rate(django_http_responses_total_by_status_total{status=~\"5..\"}[1m]))",
+          "legendFormat": "5xx",
+          "refId": "B"
+        }
+      ],
+      "fieldConfig": { "defaults": { "unit": "reqps" } }
+    },
+    {
+      "id": 5,
+      "title": "Total requêtes",
+      "type": "stat",
+      "datasource": "Prometheus",
+      "gridPos": { "x": 0, "y": 16, "w": 6, "h": 4 },
+      "targets": [
+        {
+          "datasource": "Prometheus",
+          "expr": "sum(django_http_requests_total_by_method_total)",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": { "defaults": { "unit": "short" } }
+    },
+    {
+      "id": 6,
+      "title": "Connexions DB",
+      "type": "stat",
+      "datasource": "Prometheus",
+      "gridPos": { "x": 6, "y": 16, "w": 6, "h": 4 },
+      "targets": [
+        {
+          "datasource": "Prometheus",
+          "expr": "django_db_connections_total",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": { "defaults": { "unit": "short" } }
+    },
+    {
+      "id": 7,
+      "title": "Top 10 vues par RPS",
+      "type": "bargauge",
+      "datasource": "Prometheus",
+      "gridPos": { "x": 12, "y": 16, "w": 12, "h": 8 },
+      "options": { "orientation": "horizontal" },
+      "targets": [
+        {
+          "datasource": "Prometheus",
+          "expr": "topk(10, sum(rate(django_http_requests_latency_seconds_by_view_method_count[5m])) by (view))",
+          "legendFormat": "{{view}}",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": { "defaults": { "unit": "reqps" } }
+    }
+  ]
+}

--- a/monitoring/grafana/provisioning/dashboards/default.yml
+++ b/monitoring/grafana/provisioning/dashboards/default.yml
@@ -1,0 +1,9 @@
+apiVersion: 1
+
+providers:
+  - name: default
+    type: file
+    disableDeletion: false
+    updateIntervalSeconds: 30
+    options:
+      path: /var/lib/grafana/dashboards

--- a/monitoring/grafana/provisioning/datasources/prometheus.yml
+++ b/monitoring/grafana/provisioning/datasources/prometheus.yml
@@ -1,0 +1,9 @@
+apiVersion: 1
+
+datasources:
+  - name: Prometheus
+    type: prometheus
+    access: proxy
+    url: http://prometheus:9090
+    isDefault: true
+    editable: false

--- a/monitoring/prometheus.yml
+++ b/monitoring/prometheus.yml
@@ -1,0 +1,10 @@
+global:
+  scrape_interval: 15s
+  evaluation_interval: 15s
+
+scrape_configs:
+  - job_name: django-backend
+    static_configs:
+      - targets:
+          - backend:8000
+    metrics_path: /metrics


### PR DESCRIPTION
## Type de PR                                                                                                                                                                                                                                     
  - [x] Bugfix                                                                                                                                                                                                                                      
  - [ ] Feature                                                                                                                                                                                                                                     
  - [x] Refactor                                                                                                                                                                                                                                    
  - [ ] Chore / Tech debt                                                                                                                                                                                                                           
  - [ ] Documentation                                                                                                                                                                                                                               
  - [ ] Autre (à préciser)                                                                                                                                                                                                                          
                                                                                                                                                                                                                                                    
  ## Objectif                                                                                                                                                                                                                                       
  Durcissement de la configuration Docker en production et refonte du dashboard Grafana pour exposer les métriques système réellement disponibles.
                                                                                                                                                                                                                                                    
  ## Contexte                                               
  Deux problèmes identifiés lors de la mise en place de l'environnement :                                                                                                                                                                           
  1. Les credentials TimescaleDB étaient codés en dur dans `docker-compose.prod.yml` — ils doivent être injectés via `.env`.                                                                                                                        
  2. Le dashboard Grafana référençait `django_db_connections_total`, une métrique absente du backend, et ne montrait pas la consommation CPU/RAM.                                                                                                   
                                                                                                                                                                                                                                                    
  ## Changements                                                                                                                                                                                                                                    
  - `docker-compose.prod.yml` : remplacement des `environment:` hardcodés du service `timescaledb` par `env_file: ./.env`                                                                                                                           
  - `.env.example` : ajout de `MOCKED_DATA` manquant                                                                                                                                                                                                
  - `docker-compose.dev.yml` / `docker-compose.yml` : correction du chemin du dump SQL (pointait vers un dossier au lieu d'un fichier)                                                                                                              
  - `docker-compose.monitoring.yml` : correction du réseau externe référencé                                                                                                                                                                        
  - `backend/.dockerignore` : création (exclut `.venv`, caches, `.env`, `.git`) pour réduire le contexte de build                                                                                                                                   
  - `frontend/.dockerignore` : création (exclut `node_modules`, `.nuxt`, `.output`)                                                                                                                                                                 
  - `frontend/Dockerfile` : suppression d'une ligne redondante                                                                                                                                                                                      
  - `monitoring/grafana/dashboards/django.json` : refonte complète — 12 panels sur 4 lignes couvrant 10 métriques réelles (requêtes/s, latence p50/p95/p99, codes HTTP, taux 5xx, exceptions par type/vue, mémoire RSS, CPU, taille des réponses)   
                                                                                                                                                                                                                                                    
  ## Décisions techniques                                                                                                                                                                                                                           
  - Le panel "Connexions DB" (`django_db_connections_total`) a été supprimé car la métrique n'est pas exposée par `django-prometheus` dans la configuration actuelle — inutile de garder un panel vide.                                             
  - Les `.dockerignore` excluent `*.md` sauf `README.md` (requis par hatchling pour builder le package Python).                                                                                                                                     
  - Le dashboard utilise `histogram_quantile` sur `django_http_requests_latency_including_middlewares_seconds` plutôt que `by_view_method` pour la latence globale, afin d'inclure toutes les requêtes sans filtre.                                 
                                                                                                                                                                                                                                                    
  ## Impacts                                                                                                                                                                                                                                        
  - [ ] API / contrat                                                                                                                                                                                                                               
  - [ ] Modèle de données / DB                                                                                                                                                                                                                      
  - [ ] Calculs métier
  - [ ] Performance                                                                                                                                                                                                                                 
  - [x] Sécurité — credentials DB plus exposés dans le fichier compose prod
  - [x] Infra / déploiement — `.env` requis en prod pour TimescaleDB                                                                                                                                                                                
  - [ ] Aucun impact transverse identifié                                                                                                                                                                                                           
                                                                                                                                                                                                                                                    
  ## Tests                                                                                                                                                                                                                                          
  - [x] Tests manuels — dashboard validé visuellement dans Grafana, build Docker vérifié                                                                                                                                                            
  - [ ] Tests unitaires                                                                                                                                                                                                                             
  - [ ] Tests d'intégration                                                                                                                                                                                                                         
  - [ ] Non applicable (à justifier)                                                                                                                                                                                                                
                                                                                                                                                                                                                                                    
  ## Points d'attention pour la review                                                                                                                                                                                                              
  - Le dump SQL (`db_data/meteodb_dump.sql`) exporté via Adminer est incompatible avec TimescaleDB 2.25.0 (table `_timescaledb_catalog.chunk_index` supprimée). La DB démarre mais sans données — utiliser `MOCKED_DATA=true` en attendant un dump
  propre ou les fichiers CSV de seed.                                                                                                                                                                                                               
  - En prod, le `.env` doit contenir à la fois les variables Django (`DB_*`) **et** les variables TimescaleDB (`POSTGRES_*`) pour que le service `timescaledb` démarre correctement.
                                                                                                                                                                                                                                                    
  ## Suivi                                                  
  - [ ] Migration à prévoir                                                                                                                                                                                                                         
  - [x] Documentation à mettre à jour — `.env.prod.example` à compléter et partager avec l'équipe
  - [x] Tâche(s) de suivi à créer — obtenir les fichiers CSV de seed auprès des mainteneurs Data for Good pour remplacer `MOCKED_DATA=true`  