### PR TITLE
feat/front/ratio_kpi_record_homepage

### DIFF
--- a/frontend/app/components/home/HotColdRatioCard.vue
+++ b/frontend/app/components/home/HotColdRatioCard.vue
@@ -1,0 +1,74 @@
+<script setup lang="ts">
+import Card from "./Card.vue";
+
+interface Props {
+    title: string;
+    tooltipText: string;
+    hotValue: number;
+    coldValue: number;
+    hotLabel?: string;
+    coldLabel?: string;
+    withBorder?: boolean;
+    variation?: number;
+}
+
+const props = withDefaults(defineProps<Props>(), {
+    hotLabel: "chaud",
+    coldLabel: "froid",
+    withBorder: false,
+    variation: undefined,
+});
+
+const total = computed(() => props.hotValue + props.coldValue);
+const hotPercent = computed(() =>
+    total.value > 0 ? Math.round((props.hotValue / total.value) * 100) : 0,
+);
+</script>
+
+<template>
+    <Card
+        :title="props.title"
+        :tooltip-text="props.tooltipText"
+        :with-border="props.withBorder"
+    >
+        <template #kpi>
+            <p class="font-semibold text-4xl mb-1 text-red-400">
+                {{ hotPercent }}%
+                <span
+                    class="text-sm font-normal text-slate-500 dark:text-slate-300"
+                >
+                    de records de {{ props.hotLabel }}
+                </span>
+            </p>
+            <div class="flex w-full h-4 rounded-full overflow-hidden mt-1 mb-2">
+                <div
+                    class="bg-red-400 transition-all duration-500"
+                    :style="{ width: `${hotPercent}%` }"
+                />
+                <div class="bg-blue-400 flex-1" />
+            </div>
+        </template>
+        <template v-if="props.variation !== undefined" #variation>
+            <UIcon
+                :name="
+                    props.variation <= 0
+                        ? 'i-lucide-arrow-down-right'
+                        : 'i-lucide-arrow-up-right'
+                "
+                :class="props.variation <= 0 ? 'text-blue-600' : 'text-red-450'"
+                class="font-semibold"
+            />
+            <span
+                class="text-sm font-semibold"
+                :class="props.variation <= 0 ? 'text-blue-600' : 'text-red-450'"
+            >
+                {{ props.variation > 0 ? "+" : "" }}{{ props.variation }} points
+            </span>
+            vs. période précédente
+        </template>
+        <template #kpi-context-text>
+            {{ props.hotValue }} records de {{ props.hotLabel }} vs
+            {{ props.coldValue }} records de {{ props.coldLabel }}
+        </template>
+    </Card>
+</template>

--- a/frontend/app/components/home/Last365DaysSection/LastYearSection.vue
+++ b/frontend/app/components/home/Last365DaysSection/LastYearSection.vue
@@ -2,6 +2,7 @@
 import Section from "../Section.vue";
 import ITNCard from "../ImportantInformationSection/ITNCard.vue";
 import GoToDataLink from "../GoToDataLink.vue";
+import RecordsRatioCard from "./RecordsRatioCard.vue";
 
 const { yesterday, yesterdayLess365Days } = useCustomDate();
 </script>
@@ -24,6 +25,7 @@ const { yesterday, yesterdayLess365Days } = useCustomDate();
                 RECORDS DE TEMPERATURE
             </h2>
             <div class="flex gap-2">
+                <RecordsRatioCard />
                 <ITNCard />
                 <ITNCard />
             </div>

--- a/frontend/app/components/home/Last365DaysSection/RecordsRatioCard.vue
+++ b/frontend/app/components/home/Last365DaysSection/RecordsRatioCard.vue
@@ -1,0 +1,69 @@
+<script setup lang="ts">
+import HotColdRatioCard from "~/components/home/HotColdRatioCard.vue";
+
+const { yesterday, yesterdayLess365Days, yesterdayLastYear } = useCustomDate();
+
+const yesterdayLastYearLess365Days = computed(() => {
+    const d = new Date(yesterdayLastYear.value);
+    d.setDate(d.getDate() - 365);
+    return d;
+});
+
+const { data } = useTemperatureRecordsGraph(
+    computed(() => ({
+        date_start: dateToStringYMD(yesterdayLess365Days.value),
+        date_end: dateToStringYMD(yesterday.value),
+        granularity: "day" as const,
+        type_records: "all" as const,
+    })),
+);
+
+const { data: previousData } = useTemperatureRecordsGraph(
+    computed(() => ({
+        date_start: dateToStringYMD(yesterdayLastYearLess365Days.value),
+        date_end: dateToStringYMD(yesterdayLastYear.value),
+        granularity: "day" as const,
+        type_records: "all" as const,
+    })),
+);
+
+const hotCount = computed(
+    () =>
+        data.value?.records.filter((r) => r.type_records === "hot").length ?? 0,
+);
+const coldCount = computed(
+    () =>
+        data.value?.records.filter((r) => r.type_records === "cold").length ??
+        0,
+);
+
+const hotPercent = computed(() => {
+    const total = hotCount.value + coldCount.value;
+    return total > 0 ? Math.round((hotCount.value / total) * 100) : 0;
+});
+
+const previousHotPercent = computed(() => {
+    const records = previousData.value?.records ?? [];
+    const hot = records.filter((r) => r.type_records === "hot").length;
+    const total = records.length;
+    return total > 0 ? Math.round((hot / total) * 100) : 0;
+});
+
+const variation = computed(() =>
+    previousData.value
+        ? hotPercent.value - previousHotPercent.value
+        : undefined,
+);
+</script>
+
+<template>
+    <HotColdRatioCard
+        title="Records de chaleur VS Records de froid"
+        tooltip-text="Ratio entre les records de chaleur et les records de froid battus en France Métropolitaine sur les 365 derniers jours."
+        :hot-value="hotCount"
+        :cold-value="coldCount"
+        :variation="variation"
+        hot-label="chaleur"
+        cold-label="froid"
+    />
+</template>


### PR DESCRIPTION
## Type de PR
- [ ] Bugfix
- [x] Feature
- [ ] Refactor
- [ ] Chore / Tech debt
- [ ] Documentation
- [ ] Autre (à préciser)

## Objectif
Créer une kpi box avec ratio de records ces 365 derniers jours

## Contexte
US: 
https://github.com/dataforgoodfr/14_ValorisationDonneeMeteo/issues/259
https://github.com/dataforgoodfr/14_ValorisationDonneeMeteo/issues/260

## Changements
- création d'un nouveau composant à partir de card.vue
- création d'un nouvel élément dans section 365 derniers jours
<img width="353" height="202" alt="image" src="https://github.com/user-attachments/assets/34cd4232-5464-4f61-832a-c7fa3f6e16a1" />


## Décisions techniques
<!-- Choix structurants, arbitrages, compromis. -->
<!-- Ce qui aurait pu être fait autrement. -->

## Impacts
- [ ] API / contrat
- [ ] Modèle de données / DB
- [ ] Calculs métier
- [ ] Performance
- [ ] Sécurité
- [ ] Infra / déploiement
- [ ] Aucun impact transverse identifié

## Tests
<!-- Décris ce qui a été fait dans cette PR pour vérifier le comportement introduit ou modifié. -->
- [ ] Tests unitaires
- [ ] Tests d’intégration
- [x] Tests manuels
- [ ] Non applicable (à justifier)

## Points d’attention pour la review
<!-- Parties sensibles du code, dette technique introduite, risques. -->

## Suivi
- [ ] Migration à prévoir
- [ ] Documentation à mettre à jour
- [ ] Tâche(s) de suivi à créer
