### PR TITLE
Feat/front/itn and peak last365 kpi homepage

### DIFF
--- a/frontend/app/components/home/Card.vue
+++ b/frontend/app/components/home/Card.vue
@@ -50,7 +50,7 @@ const isOpen = ref(false);
             <slot name="kpi" />
             <div
                 v-if="$slots['kpi-context-box']"
-                class="kpi-context-box py-1 px-2 rounded-lg leading-none bg-amber-500 dark:bg-amber-700 border-amber-800 dark:border-amber-500 border"
+                class="kpi-context-box w-fit py-1 px-2 rounded-lg leading-none bg-amber-500 dark:bg-amber-700 border-amber-800 dark:border-amber-500 border"
             >
                 <span
                     class="text-xs font-medium text-amber-800 dark:text-amber-500"

--- a/frontend/app/components/home/Card.vue
+++ b/frontend/app/components/home/Card.vue
@@ -3,17 +3,29 @@ interface Props {
     title: string;
     tooltipText: string;
     withBorder?: boolean;
+    showTitle?: boolean;
+    transparent?: boolean;
 }
 
-const props = defineProps<Props>();
+const props = withDefaults(defineProps<Props>(), {
+    showTitle: true,
+    transparent: false,
+});
 const isOpen = ref(false);
 </script>
 <template>
     <UCard
-        :class="['flex flex-col', props.withBorder && 'border border-blue-350']"
+        :class="[
+            'flex flex-col',
+            props.withBorder && 'border border-blue-350',
+            props.transparent && 'bg-transparent shadow-none ring-0',
+        ]"
     >
         <template #default>
-            <div class="flex items-center justify-between pb-2">
+            <div
+                v-if="props.showTitle"
+                class="flex items-center justify-between pb-2"
+            >
                 <h1
                     class="text-sm font-semibold text-blue-700 dark:text-blue-350"
                 >

--- a/frontend/app/components/home/Last365DaysSection/Itn365Cards.vue
+++ b/frontend/app/components/home/Last365DaysSection/Itn365Cards.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import Card from "../Card.vue";
+import type { NationalIndicatorParams } from "~/types/api";
 
 const { yesterday, yesterdayLess365Days } = useCustomDate();
 
@@ -11,7 +12,7 @@ const { data: kpi } = useNationalIndicatorKpi(
 );
 
 const { data: itnData } = useNationalIndicator(
-    computed(() => ({
+    computed<NationalIndicatorParams>(() => ({
         date_start: dateToStringYMD(yesterdayLess365Days.value),
         date_end: dateToStringYMD(yesterday.value),
         granularity: "year",
@@ -35,7 +36,7 @@ const itnColorClass = computed(() => {
 const itnDiff = computed(() => {
     if (kpi.value?.itn_mean == null || kpi.value.previous?.itn_mean == null)
         return null;
-    return +(kpi.value.itn_mean - kpi.value.previous.itn_mean);
+    return kpi.value.itn_mean - kpi.value.previous.itn_mean;
 });
 
 const hotPeak = computed(() => kpi.value?.hot_peak_count ?? null);

--- a/frontend/app/components/home/Last365DaysSection/Itn365Cards.vue
+++ b/frontend/app/components/home/Last365DaysSection/Itn365Cards.vue
@@ -14,8 +14,8 @@ const { data: itnData } = useNationalIndicator(
     computed(() => ({
         date_start: dateToStringYMD(yesterdayLess365Days.value),
         date_end: dateToStringYMD(yesterday.value),
-        granularity: "year" as const,
-        slice_type: "full" as const,
+        granularity: "year",
+        slice_type: "full",
     })),
 );
 

--- a/frontend/app/components/home/Last365DaysSection/Itn365Cards.vue
+++ b/frontend/app/components/home/Last365DaysSection/Itn365Cards.vue
@@ -115,9 +115,10 @@ const coldDiff = computed(() => {
         <div class="flex gap-6">
             <div class="w-fit">
                 <Card
-                    title="Pics de chaleur"
-                    tooltip-text="Nombre de jours anormalement chauds sur les 365 derniers jours, selon les normales 1991-2020."
+                    title="Nombre de jours anormalement chauds"
+                    tooltip-text="Nombre de jours parmi les 365 derniers jours, pour lesquels l'ITN est au-delà de l'écart-type de la période des normales 1991-2020"
                 >
+                    >
                     <template #kpi>
                         <p class="font-semibold text-4xl mb-1 text-red-400">
                             <span v-if="hotPeak != null">
@@ -149,8 +150,8 @@ const coldDiff = computed(() => {
 
             <div class="w-fit">
                 <Card
-                    title="Pics de froid"
-                    tooltip-text="Nombre de jours anormalement froids sur les 365 derniers jours, selon les normales 1991-2020."
+                    title="Nombre de jours anormalement froids"
+                    tooltip-text="Nombre de jours parmi les 365 derniers jours, pour lesquels l'ITN est en-deçà de l'écart-type de la période des normales 1991-2020"
                 >
                     <template #kpi>
                         <p class="font-semibold text-4xl mb-1 text-blue-400">

--- a/frontend/app/components/home/Last365DaysSection/Itn365Cards.vue
+++ b/frontend/app/components/home/Last365DaysSection/Itn365Cards.vue
@@ -53,15 +53,10 @@ const coldDiff = computed(() => {
 </script>
 
 <template>
-    <div class="flex flex-col gap-2">
-        <div class="flex gap-4 items-start">
-            <div class="flex-1">
-                <Card
-                    title="ITN moyen"
-                    tooltip-text="Moyenne de l'Indicateur Thermique National sur les 365 derniers jours."
-                    :show-title="false"
-                    transparent
-                >
+    <div class="flex items-center flex-col gap-2">
+        <div class="flex gap-40 items-start">
+            <div class="w-fit">
+                <Card title="" tooltip-text="" :show-title="false" transparent>
                     <template #kpi>
                         <p
                             class="font-semibold text-4xl mb-1"
@@ -110,15 +105,15 @@ const coldDiff = computed(() => {
             </div>
             <p
                 v-if="itnMean != null"
-                class="flex-1 text-sm text-slate-500 dark:text-slate-300 pt-8"
+                class="flex-1 text-m text-blue-700 dark:text-primary pb-2"
             >
-                L'indicateur thermique national est de
-                {{ itnMean.toFixed(1) }}°C en moyenne ces 365 derniers jours
+                La température en France métropolitaine fut en moyenne de
+                {{ itnMean.toFixed(1) }}°C ces 365 derniers jours
             </p>
         </div>
 
-        <div class="flex gap-2">
-            <div class="flex-1">
+        <div class="flex gap-6">
+            <div class="w-fit">
                 <Card
                     title="Pics de chaleur"
                     tooltip-text="Nombre de jours anormalement chauds sur les 365 derniers jours, selon les normales 1991-2020."
@@ -152,7 +147,7 @@ const coldDiff = computed(() => {
                 </Card>
             </div>
 
-            <div class="flex-1">
+            <div class="w-fit">
                 <Card
                     title="Pics de froid"
                     tooltip-text="Nombre de jours anormalement froids sur les 365 derniers jours, selon les normales 1991-2020."

--- a/frontend/app/components/home/Last365DaysSection/Itn365Cards.vue
+++ b/frontend/app/components/home/Last365DaysSection/Itn365Cards.vue
@@ -1,0 +1,190 @@
+<script setup lang="ts">
+import Card from "../Card.vue";
+
+const { yesterday, yesterdayLess365Days } = useCustomDate();
+
+const { data: kpi } = useNationalIndicatorKpi(
+    computed(() => ({
+        date_start: dateToStringYMD(yesterdayLess365Days.value),
+        date_end: dateToStringYMD(yesterday.value),
+    })),
+);
+
+const { data: itnData } = useNationalIndicator(
+    computed(() => ({
+        date_start: dateToStringYMD(yesterdayLess365Days.value),
+        date_end: dateToStringYMD(yesterday.value),
+        granularity: "year" as const,
+        slice_type: "full" as const,
+    })),
+);
+
+const itnMean = computed(() => kpi.value?.itn_mean ?? null);
+const deviationFromNormal = computed(
+    () => kpi.value?.deviation_from_normal ?? null,
+);
+
+const itnColorClass = computed(() => {
+    const point = itnData.value?.time_series[0];
+    if (!point || itnMean.value == null) return "text-green-400";
+    if (itnMean.value > point.baseline_std_dev_upper) return "text-red-400";
+    if (itnMean.value < point.baseline_std_dev_lower) return "text-blue-400";
+    return "text-green-400";
+});
+
+const itnDiff = computed(() => {
+    if (kpi.value?.itn_mean == null || kpi.value.previous?.itn_mean == null)
+        return null;
+    return +(kpi.value.itn_mean - kpi.value.previous.itn_mean).toFixed(1);
+});
+
+const hotPeak = computed(() => kpi.value?.hot_peak_count ?? null);
+const coldPeak = computed(() => kpi.value?.cold_peak_count ?? null);
+
+const hotDiff = computed(() => {
+    if (kpi.value == null) return null;
+    return kpi.value.hot_peak_count - kpi.value.previous.hot_peak_count;
+});
+
+const coldDiff = computed(() => {
+    if (kpi.value == null) return null;
+    return kpi.value.cold_peak_count - kpi.value.previous.cold_peak_count;
+});
+</script>
+
+<template>
+    <div class="flex flex-col gap-2">
+        <div class="flex gap-4 items-start">
+            <div class="flex-1">
+                <Card
+                    title="ITN moyen"
+                    tooltip-text="Moyenne de l'Indicateur Thermique National sur les 365 derniers jours."
+                    :show-title="false"
+                    transparent
+                >
+                    <template #kpi>
+                        <p
+                            class="font-semibold text-4xl mb-1"
+                            :class="itnColorClass"
+                        >
+                            <span v-if="itnMean != null"
+                                >{{ itnMean.toFixed(1) }} °C</span
+                            >
+                            <span v-else class="text-muted">—</span>
+                        </p>
+                    </template>
+                    <template
+                        v-if="deviationFromNormal != null"
+                        #kpi-context-box
+                    >
+                        {{ deviationFromNormal >= 0 ? "+" : ""
+                        }}{{ deviationFromNormal.toFixed(1) }}°C vs normale
+                        1991-2020
+                    </template>
+                    <template #kpi-context-text>
+                        en moyenne les 365 derniers jours
+                    </template>
+                    <template v-if="itnDiff != null" #variation>
+                        <UIcon
+                            :name="
+                                itnDiff < 0
+                                    ? 'i-lucide-arrow-down-right'
+                                    : 'i-lucide-arrow-up-right'
+                            "
+                            :class="
+                                itnDiff < 0 ? 'text-blue-400' : 'text-red-400'
+                            "
+                            class="font-semibold"
+                        />
+                        <span
+                            class="text-sm font-semibold"
+                            :class="
+                                itnDiff < 0 ? 'text-blue-400' : 'text-red-400'
+                            "
+                        >
+                            {{ itnDiff >= 0 ? "+" : "" }}{{ itnDiff }}°C
+                        </span>
+                        vs. 365 jours précédents
+                    </template>
+                </Card>
+            </div>
+            <p
+                v-if="itnMean != null"
+                class="flex-1 text-sm text-slate-500 dark:text-slate-300 pt-8"
+            >
+                L'indicateur thermique national est de
+                {{ itnMean.toFixed(1) }}°C en moyenne ces 365 derniers jours
+            </p>
+        </div>
+
+        <div class="flex gap-2">
+            <div class="flex-1">
+                <Card
+                    title="Pics de chaleur"
+                    tooltip-text="Nombre de jours anormalement chauds sur les 365 derniers jours, selon les normales 1991-2020."
+                >
+                    <template #kpi>
+                        <p class="font-semibold text-4xl mb-1 text-red-400">
+                            <span v-if="hotPeak != null">
+                                {{ hotPeak }}
+                                <span class="text-sm font-normal">jours</span>
+                            </span>
+                            <span v-else class="text-muted">—</span>
+                        </p>
+                    </template>
+                    <template #kpi-context-text>
+                        période des normales 1991-2020
+                    </template>
+                    <template v-if="hotDiff != null" #variation>
+                        <UIcon
+                            :name="
+                                hotDiff < 0
+                                    ? 'i-lucide-arrow-down-right'
+                                    : 'i-lucide-arrow-up-right'
+                            "
+                            class="text-red-400 font-semibold"
+                        />
+                        <span class="text-sm font-semibold text-red-400">
+                            {{ hotDiff >= 0 ? "+" : "" }}{{ hotDiff }} jours
+                        </span>
+                        vs. 365 jours précédents
+                    </template>
+                </Card>
+            </div>
+
+            <div class="flex-1">
+                <Card
+                    title="Pics de froid"
+                    tooltip-text="Nombre de jours anormalement froids sur les 365 derniers jours, selon les normales 1991-2020."
+                >
+                    <template #kpi>
+                        <p class="font-semibold text-4xl mb-1 text-blue-400">
+                            <span v-if="coldPeak != null">
+                                {{ coldPeak }}
+                                <span class="text-sm font-normal">jours</span>
+                            </span>
+                            <span v-else class="text-muted">—</span>
+                        </p>
+                    </template>
+                    <template #kpi-context-text>
+                        période des normales 1991-2020
+                    </template>
+                    <template v-if="coldDiff != null" #variation>
+                        <UIcon
+                            :name="
+                                coldDiff < 0
+                                    ? 'i-lucide-arrow-down-right'
+                                    : 'i-lucide-arrow-up-right'
+                            "
+                            class="text-blue-400 font-semibold"
+                        />
+                        <span class="text-sm font-semibold text-blue-400">
+                            {{ coldDiff >= 0 ? "+" : "" }}{{ coldDiff }} jours
+                        </span>
+                        vs. 365 jours précédents
+                    </template>
+                </Card>
+            </div>
+        </div>
+    </div>
+</template>

--- a/frontend/app/components/home/Last365DaysSection/Itn365Cards.vue
+++ b/frontend/app/components/home/Last365DaysSection/Itn365Cards.vue
@@ -35,7 +35,7 @@ const itnColorClass = computed(() => {
 const itnDiff = computed(() => {
     if (kpi.value?.itn_mean == null || kpi.value.previous?.itn_mean == null)
         return null;
-    return +(kpi.value.itn_mean - kpi.value.previous.itn_mean).toFixed(1);
+    return +(kpi.value.itn_mean - kpi.value.previous.itn_mean);
 });
 
 const hotPeak = computed(() => kpi.value?.hot_peak_count ?? null);
@@ -97,7 +97,8 @@ const coldDiff = computed(() => {
                                 itnDiff < 0 ? 'text-blue-400' : 'text-red-400'
                             "
                         >
-                            {{ itnDiff >= 0 ? "+" : "" }}{{ itnDiff }}°C
+                            {{ itnDiff >= 0 ? "+" : ""
+                            }}{{ itnDiff.toFixed(1) }}°C
                         </span>
                         vs. 365 jours précédents
                     </template>

--- a/frontend/app/components/home/Last365DaysSection/LastYearSection.vue
+++ b/frontend/app/components/home/Last365DaysSection/LastYearSection.vue
@@ -3,6 +3,7 @@ import Section from "../Section.vue";
 import ITNCard from "../ImportantInformationSection/ITNCard.vue";
 import GoToDataLink from "../GoToDataLink.vue";
 import RecordsRatioCard from "./RecordsRatioCard.vue";
+import Itn365Cards from "./Itn365Cards.vue";
 
 const { yesterday, yesterdayLess365Days } = useCustomDate();
 </script>
@@ -15,10 +16,7 @@ const { yesterday, yesterdayLess365Days } = useCustomDate();
             <h2 class="text-blue-700 dark:text-primary pb-2">
                 INDICATEUR THERMIQUE NATIONAL
             </h2>
-            <div class="flex flex-col gap-2">
-                <ITNCard />
-                <ITNCard />
-            </div>
+            <Itn365Cards />
             <GoToDataLink :data-url="'/itn'" />
             <div class="border-b to-dark-200" />
             <h2 class="text-blue-700 dark:text-primary pb-2 pt-1">

--- a/frontend/app/components/home/Last365DaysSection/RecordsRatioCard.vue
+++ b/frontend/app/components/home/Last365DaysSection/RecordsRatioCard.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import HotColdRatioCard from "~/components/home/HotColdRatioCard.vue";
+import type { TemperatureRecordsGraphParams } from "~/types/api";
 
 const { yesterday, yesterdayLess365Days, yesterdayLastYear } = useCustomDate();
 
@@ -10,11 +11,11 @@ const yesterdayLastYearLess365Days = computed(() => {
 });
 
 const { data } = useTemperatureRecordsGraph(
-    computed(() => ({
+    computed<TemperatureRecordsGraphParams>(() => ({
         date_start: dateToStringYMD(yesterdayLess365Days.value),
         date_end: dateToStringYMD(yesterday.value),
-        granularity: "day" as const,
-        type_records: "all" as const,
+        granularity: "day",
+        type_records: "all",
     })),
 );
 
@@ -22,8 +23,8 @@ const { data: previousData } = useTemperatureRecordsGraph(
     computed(() => ({
         date_start: dateToStringYMD(yesterdayLastYearLess365Days.value),
         date_end: dateToStringYMD(yesterdayLastYear.value),
-        granularity: "day" as const,
-        type_records: "all" as const,
+        granularity: "day",
+        type_records: "all",
     })),
 );
 

--- a/frontend/app/pages/records.vue
+++ b/frontend/app/pages/records.vue
@@ -82,7 +82,7 @@ const infoPanelSections: InfoSection[] = [
             :description="heroData.description"
         />
         <div class="flex gap-24 flex-col">
-            <div class="flex flex-col gap-4 bg-elevated rounded-lg p-14">
+            <div class="flex flex-col gap-4 dark:bg-elevated rounded-lg p-14">
                 <div class="flex items-end gap-4">
                     <div class="flex flex-col gap-1">
                         <div class="flex items-center gap-1">


### PR DESCRIPTION
## Type de PR
- [ ] Bugfix
- [x] Feature
- [ ] Refactor
- [ ] Chore / Tech debt
- [ ] Documentation
- [ ] Autre (à préciser)

## Objectif
Créer un kpi lié à l'itn avec nombre de pics ces 365 derniers jour

## Contexte
US: https://github.com/dataforgoodfr/14_ValorisationDonneeMeteo/issues/258

## Changements
<img width="782" height="418" alt="image" src="https://github.com/user-attachments/assets/9ec7841a-d642-41c5-8c48-95e25720ea42" />


## Décisions techniques
<!-- Choix structurants, arbitrages, compromis. -->
<!-- Ce qui aurait pu être fait autrement. -->

## Impacts
- [ ] API / contrat
- [ ] Modèle de données / DB
- [ ] Calculs métier
- [ ] Performance
- [ ] Sécurité
- [ ] Infra / déploiement
- [ ] Aucun impact transverse identifié

## Tests
<!-- Décris ce qui a été fait dans cette PR pour vérifier le comportement introduit ou modifié. -->
- [ ] Tests unitaires
- [ ] Tests d’intégration
- [x] Tests manuels
- [ ] Non applicable (à justifier)

## Points d’attention pour la review
<!-- Parties sensibles du code, dette technique introduite, risques. -->

## Suivi
- [ ] Migration à prévoir
- [ ] Documentation à mettre à jour
- [ ] Tâche(s) de suivi à créer
