### PR TITLE
Feat/front/tri tableau records

### DIFF
--- a/frontend/app/components/map/RecordsMap.vue
+++ b/frontend/app/components/map/RecordsMap.vue
@@ -7,8 +7,13 @@
             tooltip-text="Station avec le record absolu sur la période sélectionnée"
         >
             <template #kpi>
+                <UIcon
+                    v-if="store.pending"
+                    name="i-lucide-loader-circle"
+                    class="text-lg animate-spin text-muted"
+                />
                 <span
-                    v-if="extremeStation"
+                    v-else-if="extremeStation"
                     class="text-lg font-semibold"
                     :class="
                         store.typeRecords === 'hot'
@@ -22,7 +27,7 @@
                 <span v-else class="text-lg font-semibold text-muted">—</span>
             </template>
             <template #kpi-context-text>
-                <template v-if="extremeStation">
+                <template v-if="!store.pending && extremeStation">
                     {{ extremeStation.station_name }} ·
                     {{ extremeStation.department }} ·
                     {{ formatDate(extremeStation.record_date) }}

--- a/frontend/app/components/table/records/recordsTable.vue
+++ b/frontend/app/components/table/records/recordsTable.vue
@@ -22,7 +22,6 @@ const {
     pageSize,
     typeRecords,
     periodSelection,
-    pagedStations,
     filteredRecords,
     filteredCount,
     pending,
@@ -46,7 +45,7 @@ function downloadCsv() {
 // Track the record type that corresponds to the data currently displayed,
 // so the badge color only flips once the new data has arrived.
 const displayedTypeRecords = ref(typeRecords.value);
-watch(pagedStations, () => {
+watch(filteredRecords, () => {
     displayedTypeRecords.value = typeRecords.value;
 });
 
@@ -56,6 +55,7 @@ const temperatureBadgeColor = computed(() =>
 
 const ordering = ref("");
 function setOrdering(key: string) {
+    page.value = 1;
     if (ordering.value === key) ordering.value = `-${key}`;
     else if (ordering.value === `-${key}`) ordering.value = "";
     else ordering.value = key;
@@ -68,27 +68,30 @@ interface TableRow {
     recordDate: string;
 }
 
-const rawTableData = computed<TableRow[]>(() =>
-    pagedStations.value.map((s) => ({
+// Sort ALL filtered records before pagination so that ordering is global.
+const sortedRecords = computed<TableRow[]>(() => {
+    const all = filteredRecords.value.map((s) => ({
         name: s.station_name,
         departement: s.department,
         record: s.record_value,
         recordDate: s.record_date,
-    })),
-);
-
-const tableData = computed<TableRow[]>(() => {
-    if (!ordering.value) return rawTableData.value;
+    }));
+    if (!ordering.value) return all;
     const desc = ordering.value.startsWith("-");
     const key = (
         desc ? ordering.value.slice(1) : ordering.value
     ) as keyof TableRow;
     const dir = desc ? -1 : 1;
-    return [...rawTableData.value].sort((a, b) => {
+    return [...all].sort((a, b) => {
         if (a[key] < b[key]) return -dir;
         if (a[key] > b[key]) return dir;
         return 0;
     });
+});
+
+const tableData = computed<TableRow[]>(() => {
+    const start = (page.value - 1) * pageSize.value;
+    return sortedRecords.value.slice(start, start + pageSize.value);
 });
 
 const sortableCol = makeSortableColFactory<TableRow>(ordering, setOrdering);

--- a/frontend/app/composables/useTemperature.ts
+++ b/frontend/app/composables/useTemperature.ts
@@ -8,7 +8,7 @@ import type {
     TemperatureDeviationParams,
     TemperatureDeviationResponse,
     TemperatureRecordsParams,
-    TemperatureRecordFlatEntry,
+    TemperatureRecordsPaginatedResponse,
 } from "~/types/api";
 
 export function useTemperatureDeviation(
@@ -147,7 +147,7 @@ export function useTemperatureRecords(
     const { useApiFetch } = useApiClient();
 
     if (enabled === undefined) {
-        return useApiFetch<TemperatureRecordFlatEntry[]>(
+        return useApiFetch<TemperatureRecordsPaginatedResponse>(
             "/temperature/records",
             {
                 query: params,
@@ -157,7 +157,7 @@ export function useTemperatureRecords(
 
     const isEnabled = toRef(enabled);
 
-    const result = useApiFetch<TemperatureRecordFlatEntry[]>(
+    const result = useApiFetch<TemperatureRecordsPaginatedResponse>(
         "/temperature/records",
         {
             query: params,

--- a/frontend/app/stores/recordsTableStore.ts
+++ b/frontend/app/stores/recordsTableStore.ts
@@ -1,4 +1,3 @@
-import { refDebounced } from "@vueuse/core";
 import { useTemperatureRecords } from "~/composables/useTemperature";
 import { departements } from "~/data/records/departements";
 import { dateToStringYMD } from "~/utils/date";
@@ -22,8 +21,6 @@ type RecordsFilters = {
     record?: RangeFilterValue;
     record_date?: DateFilterValue;
 };
-
-const debounceDuration = 300;
 
 export const periodOptions = [
     { value: "all_time", label: "Toute l'année" },
@@ -133,14 +130,6 @@ export const useRecordsTableStore = defineStore("recordsTableStore", () => {
         }
     }
 
-    // Debounce filter inputs before applying client-side filters
-    const debouncedStationIds = refDebounced(stationIds, debounceDuration);
-    const debouncedDepartments = refDebounced(departments, debounceDuration);
-    const debouncedTempMin = refDebounced(temperatureMin, debounceDuration);
-    const debouncedTempMax = refDebounced(temperatureMax, debounceDuration);
-    const debouncedDateStart = refDebounced(dateStart, debounceDuration);
-    const debouncedDateEnd = refDebounced(dateEnd, debounceDuration);
-
     // Build API params from periodSelection
     const params = computed<TemperatureRecordsParams>(() => {
         const result: TemperatureRecordsParams = {
@@ -167,12 +156,12 @@ export const useRecordsTableStore = defineStore("recordsTableStore", () => {
     watch(
         [
             params,
-            debouncedStationIds,
-            debouncedDepartments,
-            debouncedTempMin,
-            debouncedTempMax,
-            debouncedDateStart,
-            debouncedDateEnd,
+            stationIds,
+            departments,
+            temperatureMin,
+            temperatureMax,
+            dateStart,
+            dateEnd,
         ],
         () => {
             page.value = 1;
@@ -200,32 +189,32 @@ export const useRecordsTableStore = defineStore("recordsTableStore", () => {
     const filteredRecords = computed<TemperatureRecordFlatEntry[]>(() => {
         let result = absoluteRecords.value;
 
-        if (debouncedStationIds.value.length > 0) {
+        if (stationIds.value.length > 0) {
             result = result.filter((r) =>
-                debouncedStationIds.value.includes(r.station_id),
+                stationIds.value.includes(r.station_id),
             );
         }
-        if (debouncedDepartments.value.length > 0) {
+        if (departments.value.length > 0) {
             result = result.filter((r) =>
-                debouncedDepartments.value.includes(r.department),
+                departments.value.includes(r.department),
             );
         }
-        if (debouncedTempMin.value) {
+        if (temperatureMin.value) {
             result = result.filter(
-                (r) => r.record_value >= Number(debouncedTempMin.value),
+                (r) => r.record_value >= Number(temperatureMin.value),
             );
         }
-        if (debouncedTempMax.value) {
+        if (temperatureMax.value) {
             result = result.filter(
-                (r) => r.record_value <= Number(debouncedTempMax.value),
+                (r) => r.record_value <= Number(temperatureMax.value),
             );
         }
-        if (debouncedDateStart.value) {
-            const start = dateToStringYMD(debouncedDateStart.value);
+        if (dateStart.value) {
+            const start = dateToStringYMD(dateStart.value);
             result = result.filter((r) => r.record_date >= start);
         }
-        if (debouncedDateEnd.value) {
-            const end = dateToStringYMD(debouncedDateEnd.value);
+        if (dateEnd.value) {
+            const end = dateToStringYMD(dateEnd.value);
             result = result.filter((r) => r.record_date <= end);
         }
 

--- a/frontend/app/stores/recordsTableStore.ts
+++ b/frontend/app/stores/recordsTableStore.ts
@@ -179,12 +179,18 @@ export const useRecordsTableStore = defineStore("recordsTableStore", () => {
         },
     );
 
-    const { data: rawRecords, pending, error } = useTemperatureRecords(params);
+    const {
+        data: rawRecords,
+        pending,
+        error,
+    } = useTemperatureRecords(
+        computed(() => ({ ...params.value, page_size: 9999 })),
+    );
 
     // Group flat list by station, keeping the last record per station (= absolute record)
     const absoluteRecords = computed<TemperatureRecordFlatEntry[]>(() => {
         const stationMap = new Map<string, TemperatureRecordFlatEntry>();
-        for (const record of rawRecords.value ?? []) {
+        for (const record of rawRecords.value?.results ?? []) {
             stationMap.set(record.station_id, record);
         }
         return Array.from(stationMap.values());

--- a/frontend/app/stores/recordsTableStore.ts
+++ b/frontend/app/stores/recordsTableStore.ts
@@ -1,3 +1,4 @@
+import { refDebounced } from "@vueuse/core";
 import { useTemperatureRecords } from "~/composables/useTemperature";
 import { departements } from "~/data/records/departements";
 import { dateToStringYMD } from "~/utils/date";
@@ -42,6 +43,8 @@ export const periodOptions = [
     { value: "month_12", label: "Décembre" },
 ];
 
+const debounceDuration = 300;
+
 export const useRecordsTableStore = defineStore("recordsTableStore", () => {
     // Pagination
     const page = ref(1);
@@ -58,6 +61,19 @@ export const useRecordsTableStore = defineStore("recordsTableStore", () => {
     const temperatureMax = ref<string | undefined>(undefined);
     const dateStart = ref<Date | undefined>(undefined);
     const dateEnd = ref<Date | undefined>(undefined);
+
+    const debouncedStationIds = refDebounced(stationIds, debounceDuration);
+    const debouncedDepartments = refDebounced(departments, debounceDuration);
+    const debouncedTemperatureMin = refDebounced(
+        temperatureMin,
+        debounceDuration,
+    );
+    const debouncedTemperatureMax = refDebounced(
+        temperatureMax,
+        debounceDuration,
+    );
+    const debouncedDateStart = refDebounced(dateStart, debounceDuration);
+    const debouncedDateEnd = refDebounced(dateEnd, debounceDuration);
 
     // Static options for the Département dropdown
     const staticOptions = {
@@ -156,12 +172,12 @@ export const useRecordsTableStore = defineStore("recordsTableStore", () => {
     watch(
         [
             params,
-            stationIds,
-            departments,
-            temperatureMin,
-            temperatureMax,
-            dateStart,
-            dateEnd,
+            debouncedStationIds,
+            debouncedDepartments,
+            debouncedTemperatureMin,
+            debouncedTemperatureMax,
+            debouncedDateStart,
+            debouncedDateEnd,
         ],
         () => {
             page.value = 1;
@@ -185,36 +201,36 @@ export const useRecordsTableStore = defineStore("recordsTableStore", () => {
         return Array.from(stationMap.values());
     });
 
-    // Apply client-side filters
+    // Apply client-side filters (debounced to avoid filtering on every keystroke)
     const filteredRecords = computed<TemperatureRecordFlatEntry[]>(() => {
         let result = absoluteRecords.value;
 
-        if (stationIds.value.length > 0) {
+        if (debouncedStationIds.value.length > 0) {
             result = result.filter((r) =>
-                stationIds.value.includes(r.station_id),
+                debouncedStationIds.value.includes(r.station_id),
             );
         }
-        if (departments.value.length > 0) {
+        if (debouncedDepartments.value.length > 0) {
             result = result.filter((r) =>
-                departments.value.includes(r.department),
+                debouncedDepartments.value.includes(r.department),
             );
         }
-        if (temperatureMin.value) {
+        if (debouncedTemperatureMin.value) {
             result = result.filter(
-                (r) => r.record_value >= Number(temperatureMin.value),
+                (r) => r.record_value >= Number(debouncedTemperatureMin.value),
             );
         }
-        if (temperatureMax.value) {
+        if (debouncedTemperatureMax.value) {
             result = result.filter(
-                (r) => r.record_value <= Number(temperatureMax.value),
+                (r) => r.record_value <= Number(debouncedTemperatureMax.value),
             );
         }
-        if (dateStart.value) {
-            const start = dateToStringYMD(dateStart.value);
+        if (debouncedDateStart.value) {
+            const start = dateToStringYMD(debouncedDateStart.value);
             result = result.filter((r) => r.record_date >= start);
         }
-        if (dateEnd.value) {
-            const end = dateToStringYMD(dateEnd.value);
+        if (debouncedDateEnd.value) {
+            const end = dateToStringYMD(debouncedDateEnd.value);
             result = result.filter((r) => r.record_date <= end);
         }
 

--- a/frontend/app/types/api.ts
+++ b/frontend/app/types/api.ts
@@ -280,8 +280,17 @@ export interface TemperatureRecordsParams {
     departments?: string;
     temperature_min?: number;
     temperature_max?: number;
-    limit?: number;
-    offset?: number;
+    page?: number;
+    page_size?: number;
+}
+
+export interface TemperatureRecordsPagination {
+    total_pages: number;
+}
+
+export interface TemperatureRecordsPaginatedResponse {
+    pagination: TemperatureRecordsPagination;
+    results: TemperatureRecordFlatEntry[];
 }
 
 export interface TemperatureRecordFlatEntry {


### PR DESCRIPTION
## Type de PR
- [x] Bugfix
- [x] Feature
- [ ] Refactor
- [ ] Chore / Tech debt
- [ ] Documentation
- [ ] Autre (à préciser)

## Objectif
Adapter le front au nouveau contrat suite à la PR de tri de la table records

## Contexte
Adapter le front au nouveau contrat

## Changements
- le tri et les filtres sont fonctionnels
- ajout d'un loader lors du switch chaud/froid pour ne pas afficher fausse valeur
- Tri sur all stations pour que la valeur extreme du KPI soit cohérente avec la 1ere ligne du tableau lors du tri

## Décisions techniques
- De ce que j'ai compris, tant que le endpoint ne donne pas la possibilité de récupérer directement le record absolu et ne fait que retourner la liste de tous les records battus, il est nécessaire d'effectuer le tri coté client et non coté serveur (cette dette sera à rectifier plus tard)
- 

## Impacts
- [ ] API / contrat
- [ ] Modèle de données / DB
- [ ] Calculs métier
- [ ] Performance
- [ ] Sécurité
- [ ] Infra / déploiement
- [ ] Aucun impact transverse identifié

## Tests
<!-- Décris ce qui a été fait dans cette PR pour vérifier le comportement introduit ou modifié. -->
- [ ] Tests unitaires
- [ ] Tests d’intégration
-  {x] Tests manuels
- [ ] Non applicable (à justifier)

## Points d’attention pour la review
<!-- Parties sensibles du code, dette technique introduite, risques. -->

## Suivi
- [ ] Migration à prévoir
- [ ] Documentation à mettre à jour
- [ ] Tâche(s) de suivi à créer
