### PR TITLE
Feat/back/front/kpi peak homepage

### DIFF
--- a/backend/openapi/target-specs/openapi.yaml
+++ b/backend/openapi/target-specs/openapi.yaml
@@ -843,7 +843,6 @@ paths:
                 sample:
                   summary: Exemple de réponse
                   value:
-
                     pagination:
                       total_count: 100
                       page: 1
@@ -1438,6 +1437,8 @@ components:
               - baseline_std_dev_lower
               - baseline_max
               - baseline_min
+              - is_hot_peak
+              - is_cold_peak
             properties:
               date:
                 type: string
@@ -1471,6 +1472,12 @@ components:
                 type: number
                 format: float
                 description: "Température minimale observée sur la période 1991-2020"
+              is_hot_peak:
+                type: boolean
+                description: "Vrai si la température dépasse baseline_std_dev_upper"
+              is_cold_peak:
+                type: boolean
+                description: "Vrai si la température est inférieure à baseline_std_dev_lower"
 
     KpiPeriodStats:
       type: object

--- a/backend/weather/serializers.py
+++ b/backend/weather/serializers.py
@@ -152,6 +152,8 @@ class NationalIndicatorTimePointSerializer(serializers.Serializer):
     baseline_std_dev_lower = serializers.FloatField()
     baseline_max = serializers.FloatField()
     baseline_min = serializers.FloatField()
+    is_hot_peak = serializers.BooleanField()
+    is_cold_peak = serializers.BooleanField()
 
 
 class NationalIndicatorMetadataSerializer(serializers.Serializer):

--- a/backend/weather/services/national_indicator/service.py
+++ b/backend/weather/services/national_indicator/service.py
@@ -173,6 +173,8 @@ def compute_national_indicator(
                 baseline_std_dev_lower=b.baseline_std_dev_lower,
                 baseline_max=b.baseline_max,
                 baseline_min=b.baseline_min,
+                is_hot_peak=p.temperature > b.baseline_std_dev_upper,
+                is_cold_peak=p.temperature < b.baseline_std_dev_lower,
             )
         )
 
@@ -187,6 +189,8 @@ def compute_national_indicator(
                 "baseline_std_dev_lower": round(p.baseline_std_dev_lower, 2),
                 "baseline_max": round(p.baseline_max, 2),
                 "baseline_min": round(p.baseline_min, 2),
+                "is_hot_peak": p.is_hot_peak,
+                "is_cold_peak": p.is_cold_peak,
             }
             for p in points
         ]

--- a/backend/weather/services/national_indicator/types.py
+++ b/backend/weather/services/national_indicator/types.py
@@ -28,6 +28,8 @@ class OutputPoint:
     baseline_std_dev_lower: float
     baseline_max: float
     baseline_min: float
+    is_hot_peak: bool
+    is_cold_peak: bool
 
 
 @dataclass(frozen=True)

--- a/backend/weather/tests/integration/test_national_indicator_endpoint.py
+++ b/backend/weather/tests/integration/test_national_indicator_endpoint.py
@@ -108,6 +108,77 @@ def test_get_national_indicator_month_happy_path(client: APIClient):
     # month + full => baseline mensuelle
     assert ts[0]["baseline_mean"] == 2001.0
 
+    # température (≈1.06) << lower (1999.0) => cold peak
+    assert ts[0]["is_cold_peak"] is True
+    assert ts[0]["is_hot_peak"] is False
+
+
+def test_get_national_indicator_peak_flags_in_response(client: APIClient):
+    # baseline upper=12, lower=8 pour chaque jour
+    _upper = 12.0
+    _lower = 8.0
+    _mean = 10.0
+
+    class PeakTestDependency(
+        NationalIndicatorObservedDataSource,
+        NationalIndicatorBaselineDataSource,
+    ):
+        def fetch_daily_series(self, query: DailySeriesQuery) -> list[ObservedPoint]:
+            days = query.target_dates or tuple(
+                iter_days_intersecting(query.date_start, query.date_end)
+            )
+            temps = {
+                dt.date(2025, 6, 1): _upper + 1.0,  # hot peak
+                dt.date(2025, 6, 2): _mean,  # normal
+                dt.date(2025, 6, 3): _lower - 1.0,  # cold peak
+            }
+            return [ObservedPoint(date=d, temperature=temps[d]) for d in days]
+
+        def fetch_daily_baseline(self, day: dt.date) -> BaselinePoint:
+            return BaselinePoint(
+                baseline_mean=_mean,
+                baseline_std_dev_upper=_upper,
+                baseline_std_dev_lower=_lower,
+                baseline_max=0.0,
+                baseline_min=0.0,
+            )
+
+        def fetch_monthly_baseline(self, month: int) -> BaselinePoint:
+            return self.fetch_daily_baseline(dt.date(2025, month, 1))
+
+        def fetch_yearly_baseline(self) -> BaselinePoint:
+            return self.fetch_daily_baseline(dt.date(2025, 1, 1))
+
+    ITNDependencyProvider.set_builder(
+        lambda: ITNDependencies(
+            observed_data_source=PeakTestDependency(),
+            baseline_data_source=PeakTestDependency(),
+        )
+    )
+
+    url = reverse("temperature-national-indicator")
+    resp = client.get(
+        url,
+        {
+            "date_start": "2025-06-01",
+            "date_end": "2025-06-03",
+            "granularity": "day",
+        },
+    )
+
+    assert resp.status_code == 200
+    ts = resp.json()["time_series"]
+    assert len(ts) == 3
+
+    assert ts[0]["is_hot_peak"] is True
+    assert ts[0]["is_cold_peak"] is False
+
+    assert ts[1]["is_hot_peak"] is False
+    assert ts[1]["is_cold_peak"] is False
+
+    assert ts[2]["is_hot_peak"] is False
+    assert ts[2]["is_cold_peak"] is True
+
 
 def test_get_national_indicator_missing_required_parameter_returns_400(
     client: APIClient,

--- a/backend/weather/tests/unit/test_national_indicator_peak_flags.py
+++ b/backend/weather/tests/unit/test_national_indicator_peak_flags.py
@@ -1,0 +1,122 @@
+from __future__ import annotations
+
+import datetime as dt
+
+from weather.services.national_indicator.protocols import (
+    NationalIndicatorBaselineDataSource,
+    NationalIndicatorObservedDataSource,
+)
+from weather.services.national_indicator.service import compute_national_indicator
+from weather.services.national_indicator.types import (
+    BaselinePoint,
+    DailySeriesQuery,
+    ObservedPoint,
+)
+from weather.utils.date_range import iter_days_intersecting
+
+# baseline_mean=10, std_dev=2 => upper=12, lower=8
+_BASELINE_MEAN = 10.0
+_BASELINE_STD_DEV = 2.0
+_UPPER = _BASELINE_MEAN + _BASELINE_STD_DEV  # 12.0
+_LOWER = _BASELINE_MEAN - _BASELINE_STD_DEV  # 8.0
+
+
+class FixedBaselineDataSource(
+    NationalIndicatorObservedDataSource,
+    NationalIndicatorBaselineDataSource,
+):
+    def __init__(self, day_to_temp: dict[dt.date, float]):
+        self._temps = day_to_temp
+
+    def fetch_daily_series(self, query: DailySeriesQuery) -> list[ObservedPoint]:
+        days = query.target_dates or tuple(
+            iter_days_intersecting(query.date_start, query.date_end)
+        )
+        return [ObservedPoint(date=d, temperature=self._temps[d]) for d in days]
+
+    def fetch_daily_baseline(self, day: dt.date) -> BaselinePoint:
+        return BaselinePoint(
+            baseline_mean=_BASELINE_MEAN,
+            baseline_std_dev_upper=_UPPER,
+            baseline_std_dev_lower=_LOWER,
+            baseline_max=0.0,
+            baseline_min=0.0,
+        )
+
+    def fetch_monthly_baseline(self, month: int) -> BaselinePoint:
+        return self.fetch_daily_baseline(dt.date(2025, month, 1))
+
+    def fetch_yearly_baseline(self) -> BaselinePoint:
+        return self.fetch_daily_baseline(dt.date(2025, 1, 1))
+
+
+def _run(temps: dict[dt.date, float]) -> list[dict]:
+    ds = FixedBaselineDataSource(temps)
+    date_start = min(temps)
+    date_end = max(temps)
+    res = compute_national_indicator(
+        observed_data_source=ds,
+        baseline_data_source=ds,
+        date_start=date_start,
+        date_end=date_end,
+        granularity="day",
+    )
+    return res["time_series"]
+
+
+def test_temperature_above_upper_is_hot_peak():
+    day = dt.date(2025, 6, 1)
+    ts = _run({day: _UPPER + 0.01})
+    assert ts[0]["is_hot_peak"] is True
+    assert ts[0]["is_cold_peak"] is False
+
+
+def test_temperature_below_lower_is_cold_peak():
+    day = dt.date(2025, 6, 1)
+    ts = _run({day: _LOWER - 0.01})
+    assert ts[0]["is_hot_peak"] is False
+    assert ts[0]["is_cold_peak"] is True
+
+
+def test_temperature_equal_upper_is_not_hot_peak():
+    day = dt.date(2025, 6, 1)
+    ts = _run({day: _UPPER})
+    assert ts[0]["is_hot_peak"] is False
+
+
+def test_temperature_equal_lower_is_not_cold_peak():
+    day = dt.date(2025, 6, 1)
+    ts = _run({day: _LOWER})
+    assert ts[0]["is_cold_peak"] is False
+
+
+def test_temperature_within_bounds_is_no_peak():
+    day = dt.date(2025, 6, 1)
+    ts = _run({day: _BASELINE_MEAN})
+    assert ts[0]["is_hot_peak"] is False
+    assert ts[0]["is_cold_peak"] is False
+
+
+def test_multiple_days_peaks_are_independent():
+    days = {
+        dt.date(2025, 6, 1): _UPPER + 1.0,  # hot
+        dt.date(2025, 6, 2): _BASELINE_MEAN,  # normal
+        dt.date(2025, 6, 3): _LOWER - 1.0,  # cold
+    }
+    ts = _run(days)
+
+    assert ts[0]["is_hot_peak"] is True
+    assert ts[0]["is_cold_peak"] is False
+
+    assert ts[1]["is_hot_peak"] is False
+    assert ts[1]["is_cold_peak"] is False
+
+    assert ts[2]["is_hot_peak"] is False
+    assert ts[2]["is_cold_peak"] is True
+
+
+def test_peak_flags_present_in_output_keys():
+    day = dt.date(2025, 6, 1)
+    ts = _run({day: _BASELINE_MEAN})
+    assert "is_hot_peak" in ts[0]
+    assert "is_cold_peak" in ts[0]

--- a/backend/weather/tests/unit/test_national_indicator_time_point_serializer.py
+++ b/backend/weather/tests/unit/test_national_indicator_time_point_serializer.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+import datetime as dt
+
+import pytest
+
+from weather.serializers import NationalIndicatorTimePointSerializer
+
+
+def _valid_base() -> dict:
+    return {
+        "date": dt.date(2025, 6, 1),
+        "temperature": 15.5,
+        "baseline_mean": 12.0,
+        "baseline_std_dev_upper": 14.0,
+        "baseline_std_dev_lower": 10.0,
+        "baseline_max": 20.0,
+        "baseline_min": 5.0,
+        "is_hot_peak": True,
+        "is_cold_peak": False,
+    }
+
+
+def test_serializer_is_valid_with_hot_peak():
+    s = NationalIndicatorTimePointSerializer(data=_valid_base())
+    assert s.is_valid(), s.errors
+    assert s.validated_data["is_hot_peak"] is True
+    assert s.validated_data["is_cold_peak"] is False
+
+
+def test_serializer_is_valid_with_cold_peak():
+    data = {**_valid_base(), "is_hot_peak": False, "is_cold_peak": True}
+    s = NationalIndicatorTimePointSerializer(data=data)
+    assert s.is_valid(), s.errors
+    assert s.validated_data["is_hot_peak"] is False
+    assert s.validated_data["is_cold_peak"] is True
+
+
+def test_serializer_is_valid_with_no_peak():
+    data = {**_valid_base(), "is_hot_peak": False, "is_cold_peak": False}
+    s = NationalIndicatorTimePointSerializer(data=data)
+    assert s.is_valid(), s.errors
+
+
+@pytest.mark.parametrize("missing_field", ["is_hot_peak", "is_cold_peak"])
+def test_serializer_requires_peak_flags(missing_field: str):
+    data = {k: v for k, v in _valid_base().items() if k != missing_field}
+    s = NationalIndicatorTimePointSerializer(data=data)
+    assert not s.is_valid()
+    assert missing_field in s.errors

--- a/frontend/app/components/home/ImportantInformationSection/ImportantInformationSection.vue
+++ b/frontend/app/components/home/ImportantInformationSection/ImportantInformationSection.vue
@@ -2,6 +2,7 @@
 import Section from "../Section.vue";
 import ITNCard from "./ITNCard.vue";
 import ItnDayRankCard from "./ItnDayRankCard.vue";
+import OngoingPeakCard from "./OngoingPeakCard.vue";
 </script>
 <template>
     <div>
@@ -9,7 +10,7 @@ import ItnDayRankCard from "./ItnDayRankCard.vue";
             <div class="flex flex-col gap-5 md:flex-row">
                 <ITNCard />
                 <ItnDayRankCard />
-                <ITNCard />
+                <OngoingPeakCard />
             </div>
         </Section>
     </div>

--- a/frontend/app/components/home/ImportantInformationSection/OngoingPeakCard.vue
+++ b/frontend/app/components/home/ImportantInformationSection/OngoingPeakCard.vue
@@ -1,0 +1,101 @@
+<script setup lang="ts">
+import Card from "../Card.vue";
+import { dateToStringYMD } from "~/utils/date";
+import { useNationalIndicator } from "~/composables/useNationalIndicator";
+import type {
+    NationalIndicatorDataPoint,
+    NationalIndicatorParams,
+} from "~/types/api";
+
+const { yesterday } = useCustomDate();
+
+const dateStart = computed(() => {
+    const d = new Date(yesterday.value);
+    d.setDate(d.getDate() - 90);
+    return d;
+});
+
+const params = computed<NationalIndicatorParams>(() => ({
+    date_start: dateToStringYMD(dateStart.value),
+    date_end: dateToStringYMD(yesterday.value),
+    granularity: "day",
+}));
+
+const { data } = useNationalIndicator(params);
+
+const series = computed(() => data.value?.time_series ?? []);
+
+type PeakType = "hot" | "cold";
+
+interface Streak {
+    type: PeakType;
+    count: number;
+    avgDeviation: number;
+}
+
+function pointPeakType(p: NationalIndicatorDataPoint): PeakType | null {
+    if (p.is_hot_peak) return "hot";
+    if (p.is_cold_peak) return "cold";
+    return null;
+}
+
+const currentStreak = computed((): Streak | null => {
+    const pts = series.value;
+    if (!pts.length) return null;
+    const lastType = pointPeakType(pts[pts.length - 1]);
+    if (!lastType) return null;
+
+    let count = 0;
+    let totalDev = 0;
+    for (let i = pts.length - 1; i >= 0; i--) {
+        if (pointPeakType(pts[i]) !== lastType) break;
+        count++;
+        totalDev += pts[i].temperature - pts[i].baseline_mean;
+    }
+    return { type: lastType, count, avgDeviation: totalDev / count };
+});
+
+function sign(n: number): string {
+    return n >= 0 ? `+${n.toFixed(1)}` : n.toFixed(1);
+}
+
+const kpiColor = computed(() => {
+    if (currentStreak.value?.type === "hot") return "text-red-450";
+    if (currentStreak.value?.type === "cold") return "text-blue-600";
+    return "text-muted";
+});
+</script>
+
+<template>
+    <Card
+        title="Pic en cours"
+        tooltip-text="Nombre de jours consécutifs de pic de chaleur ou de froid jusqu'à hier (température au-delà d'un écart-type de la normale)"
+    >
+        <template #kpi>
+            <p class="font-semibold mb-1">
+                <template v-if="currentStreak">
+                    <span class="text-4xl" :class="kpiColor">
+                        {{ currentStreak.count }}
+                    </span>
+                    <span class="text-xl text-muted"> jours</span>
+                </template>
+                <span v-else class="text-4xl text-muted">—</span>
+            </p>
+        </template>
+
+        <template v-if="currentStreak" #kpi-context-box>
+            consécutifs de pics de
+            {{ currentStreak.type === "hot" ? "chaleur" : "froid" }}
+        </template>
+
+        <template #kpi-context-text>
+            <template v-if="currentStreak">
+                <span :class="kpiColor">
+                    {{ sign(currentStreak.avgDeviation) }}°C
+                </span>
+                en moyenne depuis {{ currentStreak.count }} jours
+            </template>
+            <template v-else>Aucune anomalie récente</template>
+        </template>
+    </Card>
+</template>

--- a/frontend/app/types/api.ts
+++ b/frontend/app/types/api.ts
@@ -72,6 +72,8 @@ export interface NationalIndicatorDataPoint {
     baseline_std_dev_lower: number;
     baseline_max: number;
     baseline_min: number;
+    is_hot_peak: boolean;
+    is_cold_peak: boolean;
     isInterpolated?: boolean;
 }
 


### PR DESCRIPTION
## Type de PR
- [ ] Bugfix
- [x] Feature
- [ ] Refactor
- [ ] Chore / Tech debt
- [ ] Documentation
- [ ] Autre (à préciser)

## Objectif
Ajouter kpi avec série de pic de chaleur/froid en cours dans info à retenir de la homepage

## Contexte
Il existe un endpoint temperature/itn/kpi mais il est mieux d'enrichir le endpoint temperature/itn

## Changements
- (partie backend) enrichit endpoint temperature/itn avec is_peak_hot et is_peak_cold par unité de granularité
- mise à jour swagger
- (partie frontend) ajoute une carde avec série en cours de pic ou "pas de pic en cours" dans homepage

## Décisions techniques
<!-- Choix structurants, arbitrages, compromis. -->
<!-- Ce qui aurait pu être fait autrement. -->

## Impacts
- [x] API / contrat
- [ ] Modèle de données / DB
- [ ] Calculs métier
- [ ] Performance
- [ ] Sécurité
- [ ] Infra / déploiement
- [ ] Aucun impact transverse identifié

## Tests
<!-- Décris ce qui a été fait dans cette PR pour vérifier le comportement introduit ou modifié. -->
- [x] Tests unitaires
- [x] Tests d’intégration
- [x] Tests manuels
- [ ] Non applicable (à justifier)

## Points d’attention pour la review
<!-- Parties sensibles du code, dette technique introduite, risques. -->

## Suivi
- [ ] Migration à prévoir
- [ ] Documentation à mettre à jour
- [ ] Tâche(s) de suivi à créer
