### PR TITLE
bugfix/front/itn_stacked_theme_line_color

### DIFF
--- a/frontend/app/components/charts/ItnChart.vue
+++ b/frontend/app/components/charts/ItnChart.vue
@@ -60,6 +60,7 @@ provide(INIT_OPTIONS_KEY, initOptions);
 
 const itnColors = useItnColors();
 const mapColors = useMapColors();
+const colorMode = useColorMode();
 
 function buildStackedOption(
     timeSeries: NationalIndicatorDataPoint[],
@@ -458,7 +459,7 @@ const option = computed<ECOption>(() => {
 <template>
     <VChart
         :ref="adapter.chartRef"
-        :key="`${adapter.granularity.value}-${adapter.chartType?.value ?? 'line'}`"
+        :key="`${adapter.granularity.value}-${adapter.chartType?.value ?? 'line'}-${colorMode.value}`"
         :option="option"
         :init-options="initOptions"
         :loading="adapter.pending.value"


### PR DESCRIPTION
## Type de PR
- [x] Bugfix
- [ ] Feature
- [ ] Refactor
- [ ] Chore / Tech debt
- [ ] Documentation
- [ ] Autre (à préciser)

## Objectif
bugfix le rendu du graphe itn stacked quand on swithc de theme

## Contexte
US: https://github.com/dataforgoodfr/14_ValorisationDonneeMeteo/issues/410

## Changements
- force la recréation complète du chart lors d'un changement de thème

## Décisions techniques
<!-- Choix structurants, arbitrages, compromis. -->
<!-- Ce qui aurait pu être fait autrement. -->

## Impacts
- [ ] API / contrat
- [ ] Modèle de données / DB
- [ ] Calculs métier
- [ ] Performance
- [ ] Sécurité
- [ ] Infra / déploiement
- [ ] Aucun impact transverse identifié

## Tests
<!-- Décris ce qui a été fait dans cette PR pour vérifier le comportement introduit ou modifié. -->
- [ ] Tests unitaires
- [ ] Tests d’intégration
- [x] Tests manuels
- [ ] Non applicable (à justifier)

## Points d’attention pour la review
<!-- Parties sensibles du code, dette technique introduite, risques. -->

## Suivi
- [ ] Migration à prévoir
- [ ] Documentation à mettre à jour
- [ ] Tâche(s) de suivi à créer
