### PR TITLE
Fix/Front/KPI home page non chargées

### DIFF
--- a/frontend/app/composables/useApiClient.ts
+++ b/frontend/app/composables/useApiClient.ts
@@ -22,5 +22,33 @@ export function useApiClient() {
         });
     }
 
-    return { apiFetch, useApiFetch, baseURL };
+    function useApiQuery<T, P>(
+        endpoint: string,
+        params: MaybeRef<P>,
+        enabled?: MaybeRef<boolean>,
+    ) {
+        const isEnabled = computed<boolean>(() =>
+            enabled !== undefined ? toValue(enabled) : true,
+        );
+
+        const result = useApiFetch<T>(endpoint, {
+            query: params,
+            immediate: false,
+            watch: false,
+        });
+
+        watch(
+            [isEnabled, params],
+            ([enabled]) => {
+                if (enabled) {
+                    result.execute();
+                }
+            },
+            { immediate: true },
+        );
+
+        return result;
+    }
+
+    return { apiFetch, useApiFetch, useApiQuery, baseURL };
 }

--- a/frontend/app/composables/useApiClient.ts
+++ b/frontend/app/composables/useApiClient.ts
@@ -22,7 +22,7 @@ export function useApiClient() {
         });
     }
 
-    function useApiQuery<T, P>(
+    function createWatchedQuery<T, P>(
         endpoint: string,
         params: MaybeRef<P>,
         enabled?: MaybeRef<boolean>,
@@ -50,5 +50,5 @@ export function useApiClient() {
         return result;
     }
 
-    return { apiFetch, useApiFetch, useApiQuery, baseURL };
+    return { apiFetch, useApiFetch, createWatchedQuery, baseURL };
 }

--- a/frontend/app/composables/useNationalIndicator.ts
+++ b/frontend/app/composables/useNationalIndicator.ts
@@ -7,37 +7,11 @@ export function useNationalIndicator(
     params: MaybeRef<NationalIndicatorParams>,
     enabled?: MaybeRef<boolean>,
 ) {
-    const { useApiFetch } = useApiClient();
+    const { useApiQuery } = useApiClient();
 
-    if (enabled === undefined) {
-        const result = useApiFetch<NationalIndicatorResponse>(
-            "/temperature/national-indicator",
-            { query: params, watch: false },
-        );
-
-        watch(params, () => {
-            result.execute();
-        });
-
-        return result;
-    }
-
-    const isEnabled = toRef(enabled);
-
-    const result = useApiFetch<NationalIndicatorResponse>(
+    return useApiQuery<NationalIndicatorResponse, NationalIndicatorParams>(
         "/temperature/national-indicator",
-        {
-            query: params,
-            immediate: isEnabled.value,
-            watch: false,
-        },
+        params,
+        enabled,
     );
-
-    watch([isEnabled, params], () => {
-        if (isEnabled.value) {
-            result.execute();
-        }
-    });
-
-    return result;
 }

--- a/frontend/app/composables/useNationalIndicator.ts
+++ b/frontend/app/composables/useNationalIndicator.ts
@@ -7,11 +7,10 @@ export function useNationalIndicator(
     params: MaybeRef<NationalIndicatorParams>,
     enabled?: MaybeRef<boolean>,
 ) {
-    const { useApiQuery } = useApiClient();
+    const { createWatchedQuery } = useApiClient();
 
-    return useApiQuery<NationalIndicatorResponse, NationalIndicatorParams>(
-        "/temperature/national-indicator",
-        params,
-        enabled,
-    );
+    return createWatchedQuery<
+        NationalIndicatorResponse,
+        NationalIndicatorParams
+    >("/temperature/national-indicator", params, enabled);
 }

--- a/frontend/app/composables/useNationalIndicatorKpi.ts
+++ b/frontend/app/composables/useNationalIndicatorKpi.ts
@@ -5,11 +5,12 @@ import type {
 
 export function useNationalIndicatorKpi(
     params: MaybeRef<NationalIndicatorKpiParams>,
+    enabled?: MaybeRef<boolean>,
 ) {
-    const { useApiFetch } = useApiClient();
+    const { useApiQuery } = useApiClient();
 
-    return useApiFetch<NationalIndicatorKpiResponse>(
-        "/temperature/national-indicator/kpi",
-        { query: params },
-    );
+    return useApiQuery<
+        NationalIndicatorKpiResponse,
+        NationalIndicatorKpiParams
+    >("/temperature/national-indicator/kpi", params, enabled);
 }

--- a/frontend/app/composables/useNationalIndicatorKpi.ts
+++ b/frontend/app/composables/useNationalIndicatorKpi.ts
@@ -7,9 +7,9 @@ export function useNationalIndicatorKpi(
     params: MaybeRef<NationalIndicatorKpiParams>,
     enabled?: MaybeRef<boolean>,
 ) {
-    const { useApiQuery } = useApiClient();
+    const { createWatchedQuery } = useApiClient();
 
-    return useApiQuery<
+    return createWatchedQuery<
         NationalIndicatorKpiResponse,
         NationalIndicatorKpiParams
     >("/temperature/national-indicator/kpi", params, enabled);


### PR DESCRIPTION
## Type de PR
- [x] Bugfix
- [ ] Feature
- [ ] Refactor
- [ ] Chore / Tech debt
- [ ] Documentation
- [ ] Autre (à préciser)

## Objectif
Charger les données pour certains KPI de la page home
<!-- Problème résolu ou fonctionnalité apportée. Une phrase claire. -->

## Contexte
Issue: https://github.com/dataforgoodfr/14_ValorisationDonneeMeteo/issues/423

Actuellement es requêtes : `/temperature/national-indicator/kpi` et `/temperature/national-indicator/` ne s'effectuent pas en prod, certains KPI ne sont donc pas chargées.
Bug visible seulement en prod, non reproductible en local.
Hypothèse: les requêtes : `/temperature/national-indicator/kpi` et `/temperature/national-indicator/` partaient trop tôt (et les params n'étaient pas correctement chargés) => ajout de `immediate: false` lors du fetch avec un watch qui lance la requête lorsque les params sont existants (j'ai repris cela d'une requête qui fonctionne correctement en prod)

## Changements
- Ajout dans useApiClient composable de : useApiQuery car logique réutilisé plusieurs fois

## Décisions techniques
<!-- Choix structurants, arbitrages, compromis. -->
<!-- Ce qui aurait pu être fait autrement. -->

## Impacts
- [ ] API / contrat
- [ ] Modèle de données / DB
- [ ] Calculs métier
- [ ] Performance
- [ ] Sécurité
- [ ] Infra / déploiement
- [x] Aucun impact transverse identifié

## Tests
<!-- Décris ce qui a été fait dans cette PR pour vérifier le comportement introduit ou modifié. -->
- [ ] Tests unitaires
- [ ] Tests d’intégration
- [x] Tests manuels
- [ ] Non applicable (à justifier)

## Points d’attention pour la review
<!-- Parties sensibles du code, dette technique introduite, risques. -->

## Suivi
- [ ] Migration à prévoir
- [ ] Documentation à mettre à jour
- [ ] Tâche(s) de suivi à créer
