### PR TITLE
ajout classe et date de création dans tableau deviation et records

### DIFF
--- a/frontend/app/components/table/deviation/DeviationFilterBar.vue
+++ b/frontend/app/components/table/deviation/DeviationFilterBar.vue
@@ -27,6 +27,12 @@ const filterFields: FilterField[] = [
         type: "number-range",
         unit: "°C",
     },
+    { id: "classe", label: "Classe", type: "number-range" },
+    {
+        id: "anneeDeCreation",
+        label: "Année de création",
+        type: "number-range",
+    },
 ];
 
 const store = useDeviationTableStore();

--- a/frontend/app/components/table/deviation/DeviationTable.vue
+++ b/frontend/app/components/table/deviation/DeviationTable.vue
@@ -68,8 +68,8 @@ interface TableRow {
     region: string | undefined;
     deviation: number | undefined;
     temperatureMean: number | undefined;
-    classeRecente: number;
-    anneeDeCreation: number;
+    classeRecente: number | undefined;
+    anneeDeCreation: number | undefined;
 }
 
 const tableData = computed<TableRow[]>(() =>

--- a/frontend/app/components/table/deviation/DeviationTable.vue
+++ b/frontend/app/components/table/deviation/DeviationTable.vue
@@ -68,6 +68,8 @@ interface TableRow {
     region: string | undefined;
     deviation: number | undefined;
     temperatureMean: number | undefined;
+    classeRecente: number;
+    anneeDeCreation: number;
 }
 
 const tableData = computed<TableRow[]>(() =>
@@ -77,6 +79,8 @@ const tableData = computed<TableRow[]>(() =>
         region: s.region,
         deviation: s.deviation,
         temperatureMean: s.temperature_mean,
+        classeRecente: s.classe_recente,
+        anneeDeCreation: new Date(s.date_de_creation).getFullYear(),
     })),
 );
 
@@ -90,7 +94,25 @@ const columns = [
         meta: STATION_META,
         cellCustom: ({ row }) => truncatedCell(row.getValue("station_name")),
     }),
-    sortableCol("department", "Département", { meta: CENTERED_TD }),
+    sortableCol("department", "Département", {
+        meta: CENTERED_TD,
+        headerCustom: () =>
+            h(
+                UButton,
+                {
+                    variant: "ghost",
+                    trailingIcon: ordering.value.includes("department")
+                        ? ordering.value.startsWith("-")
+                            ? "i-lucide-arrow-down"
+                            : "i-lucide-arrow-up"
+                        : "i-lucide-arrow-up-down",
+                    color: "neutral",
+                    class: TABLE_HEADER_BTN_MULTILINE_CLASS,
+                    onClick: () => setOrdering("department"),
+                },
+                () => h("span", { class: "whitespace-pre-line" }, "Dept."),
+            ),
+    }),
     sortableCol("region", "Région", {
         meta: REGION_META,
         cellCustom: ({ row }) => truncatedCell(row.getValue("region")),
@@ -162,6 +184,31 @@ const columns = [
             ),
         cellCustom: ({ row }) =>
             `${row.getValue<number>("temperatureMean").toFixed(1)} °C`,
+    }),
+    sortableCol("classeRecente", "Classe", { meta: CENTERED_TD }),
+    sortableCol("anneeDeCreation", "Année de création", {
+        meta: CENTERED_TD,
+        headerCustom: () =>
+            h(
+                UButton,
+                {
+                    variant: "ghost",
+                    trailingIcon: ordering.value.includes("anneeDeCreation")
+                        ? ordering.value.startsWith("-")
+                            ? "i-lucide-arrow-down"
+                            : "i-lucide-arrow-up"
+                        : "i-lucide-arrow-up-down",
+                    color: "neutral",
+                    class: TABLE_HEADER_BTN_MULTILINE_CLASS,
+                    onClick: () => setOrdering("anneeDeCreation"),
+                },
+                () =>
+                    h(
+                        "span",
+                        { class: "whitespace-pre-line" },
+                        "Année\nde création",
+                    ),
+            ),
     }),
 ];
 </script>

--- a/frontend/app/components/table/deviation/DeviationTable.vue
+++ b/frontend/app/components/table/deviation/DeviationTable.vue
@@ -64,12 +64,12 @@ const { setOrdering } = store;
 
 interface TableRow {
     station_name: string;
-    department: string | undefined;
-    region: string | undefined;
-    deviation: number | undefined;
-    temperatureMean: number | undefined;
-    classeRecente: number | undefined;
-    anneeDeCreation: number | undefined;
+    department: string;
+    region: string;
+    deviation: number;
+    temperatureMean: number;
+    classeRecente: number;
+    anneeDeCreation: number;
 }
 
 const tableData = computed<TableRow[]>(() =>

--- a/frontend/app/components/table/records/RecordsFilterBar.vue
+++ b/frontend/app/components/table/records/RecordsFilterBar.vue
@@ -15,6 +15,12 @@ const filterFields: FilterField[] = [
     { id: "departement", label: "Département", type: "string" },
     { id: "record", label: "Température record", type: "number-range" },
     { id: "record_date", label: "Date du record", type: "date-range" },
+    { id: "classe", label: "Classe", type: "number-range" },
+    {
+        id: "anneeDeCreation",
+        label: "Année de création",
+        type: "number-range",
+    },
 ];
 
 const store = useRecordsTableStore();

--- a/frontend/app/components/table/records/RecordsFilterBar.vue
+++ b/frontend/app/components/table/records/RecordsFilterBar.vue
@@ -16,6 +16,7 @@ const filterFields: FilterField[] = [
     { id: "record", label: "Température record", type: "number-range" },
     { id: "record_date", label: "Date du record", type: "date-range" },
     { id: "classe", label: "Classe", type: "number-range" },
+    { id: "altitude", label: "Altitude", type: "number-range" },
     {
         id: "anneeDeCreation",
         label: "Année de création",

--- a/frontend/app/components/table/records/recordsTable.vue
+++ b/frontend/app/components/table/records/recordsTable.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { h } from "vue";
-import { UBadge } from "#components";
+import { UBadge, UButton } from "#components";
 import { storeToRefs } from "pinia";
 import { useRecordsTableStore } from "~/stores/recordsTableStore";
 import RecordsFilterBar from "~/components/table/records/RecordsFilterBar.vue";
@@ -11,6 +11,7 @@ import {
     REGION_META,
     STATION_META,
     TEMPERATURE_BADGE_SIZE,
+    TABLE_HEADER_BTN_MULTILINE_CLASS,
     makeSortableColFactory,
     temperatureBadgeClass,
     truncatedCell,
@@ -66,6 +67,8 @@ interface TableRow {
     departement: string;
     record: number;
     recordDate: string;
+    classeRecente: number;
+    anneeDeCreation: number;
 }
 
 // Sort ALL filtered records before pagination so that ordering is global.
@@ -75,6 +78,8 @@ const sortedRecords = computed<TableRow[]>(() => {
         departement: s.department,
         record: s.record_value,
         recordDate: s.record_date,
+        classeRecente: s.classe_recente,
+        anneeDeCreation: new Date(s.date_de_creation).getFullYear(),
     }));
     if (!ordering.value) return all;
     const desc = ordering.value.startsWith("-");
@@ -101,7 +106,7 @@ const columns = [
         meta: STATION_META,
         cellCustom: ({ row }) => truncatedCell(row.getValue("name")),
     }),
-    sortableCol("departement", "Département", {
+    sortableCol("departement", "Dept.", {
         meta: REGION_META,
         cellCustom: ({ row }) => truncatedCell(row.getValue("departement")),
     }),
@@ -123,7 +128,55 @@ const columns = [
                 () => `${row.getValue<number>("record").toFixed(1)} °C`,
             ),
     }),
-    sortableCol("recordDate", "Date du record", { meta: CENTERED_COL }),
+    sortableCol("recordDate", "Date du record", {
+        meta: CENTERED_COL,
+        headerCustom: () =>
+            h(
+                UButton,
+                {
+                    variant: "ghost",
+                    trailingIcon: ordering.value.includes("recordDate")
+                        ? ordering.value.startsWith("-")
+                            ? "i-lucide-arrow-down"
+                            : "i-lucide-arrow-up"
+                        : "i-lucide-arrow-up-down",
+                    color: "neutral",
+                    class: TABLE_HEADER_BTN_MULTILINE_CLASS,
+                    onClick: () => setOrdering("recordDate"),
+                },
+                () =>
+                    h(
+                        "span",
+                        { class: "whitespace-pre-line" },
+                        "Date du\nrecord",
+                    ),
+            ),
+    }),
+    sortableCol("classeRecente", "Classe", { meta: CENTERED_COL }),
+    sortableCol("anneeDeCreation", "Année de création", {
+        meta: CENTERED_COL,
+        headerCustom: () =>
+            h(
+                UButton,
+                {
+                    variant: "ghost",
+                    trailingIcon: ordering.value.includes("anneeDeCreation")
+                        ? ordering.value.startsWith("-")
+                            ? "i-lucide-arrow-down"
+                            : "i-lucide-arrow-up"
+                        : "i-lucide-arrow-up-down",
+                    color: "neutral",
+                    class: TABLE_HEADER_BTN_MULTILINE_CLASS,
+                    onClick: () => setOrdering("anneeDeCreation"),
+                },
+                () =>
+                    h(
+                        "span",
+                        { class: "whitespace-pre-line" },
+                        "Année\nde création",
+                    ),
+            ),
+    }),
 ];
 </script>
 

--- a/frontend/app/components/table/records/recordsTable.vue
+++ b/frontend/app/components/table/records/recordsTable.vue
@@ -69,6 +69,7 @@ interface TableRow {
     recordDate: string;
     classeRecente: number;
     anneeDeCreation: number;
+    alt: number;
 }
 
 // Sort ALL filtered records before pagination so that ordering is global.
@@ -80,6 +81,7 @@ const sortedRecords = computed<TableRow[]>(() => {
         recordDate: s.record_date,
         classeRecente: s.classe_recente,
         anneeDeCreation: new Date(s.date_de_creation).getFullYear(),
+        alt: s.alt,
     }));
     if (!ordering.value) return all;
     const desc = ordering.value.startsWith("-");
@@ -112,6 +114,27 @@ const columns = [
     }),
     sortableCol("record", "Record", {
         meta: CENTERED_COL,
+        headerCustom: () =>
+            h(
+                UButton,
+                {
+                    variant: "ghost",
+                    trailingIcon: ordering.value.includes("record")
+                        ? ordering.value.startsWith("-")
+                            ? "i-lucide-arrow-down"
+                            : "i-lucide-arrow-up"
+                        : "i-lucide-arrow-up-down",
+                    color: "neutral",
+                    class: TABLE_HEADER_BTN_MULTILINE_CLASS,
+                    onClick: () => setOrdering("record"),
+                },
+                () =>
+                    h(
+                        "span",
+                        { class: "whitespace-pre-line" },
+                        "Température\nrecord",
+                    ),
+            ),
         cellCustom: ({ row }) =>
             h(
                 UBadge,
@@ -153,6 +176,26 @@ const columns = [
             ),
     }),
     sortableCol("classeRecente", "Classe", { meta: CENTERED_COL }),
+    sortableCol("alt", "Altitude (m)", {
+        meta: CENTERED_COL,
+        headerCustom: () =>
+            h(
+                UButton,
+                {
+                    variant: "ghost",
+                    trailingIcon: ordering.value.includes("alt")
+                        ? ordering.value.startsWith("-")
+                            ? "i-lucide-arrow-down"
+                            : "i-lucide-arrow-up"
+                        : "i-lucide-arrow-up-down",
+                    color: "neutral",
+                    class: TABLE_HEADER_BTN_MULTILINE_CLASS,
+                    onClick: () => setOrdering("alt"),
+                },
+                () => h("span", { class: "whitespace-pre-line" }, "Alt."),
+            ),
+        cellCustom: ({ row }) => h(() => `${row.getValue<number>("alt")} m`),
+    }),
     sortableCol("anneeDeCreation", "Année de création", {
         meta: CENTERED_COL,
         headerCustom: () =>

--- a/frontend/app/constants/tableUtils.ts
+++ b/frontend/app/constants/tableUtils.ts
@@ -9,7 +9,7 @@ export const CENTERED_COL = { class: { th: "text-center", td: "text-center" } };
 export const STATION_META = {
     class: {
         th: "text-center w-44",
-        td: "w-44 max-w-44 overflow-hidden",
+        td: "w-40 max-w-40 overflow-hidden",
     },
 };
 

--- a/frontend/app/stores/deviationTableStore.ts
+++ b/frontend/app/stores/deviationTableStore.ts
@@ -15,6 +15,8 @@ type DeviationTableFilters = {
     // altitude?: RangeFilterValue;
     deviation?: RangeFilterValue;
     temperatureMean?: RangeFilterValue;
+    classe?: RangeFilterValue;
+    anneeDeCreation?: RangeFilterValue;
 };
 
 const dates = useCustomDate();
@@ -35,6 +37,10 @@ export const useDeviationTableStore = defineStore("deviationTableStore", () => {
     const deviationMax = ref<string | undefined>(undefined);
     const temperatureMeanMin = ref<string | undefined>(undefined);
     const temperatureMeanMax = ref<string | undefined>(undefined);
+    const classeMin = ref<string | undefined>(undefined);
+    const classeMax = ref<string | undefined>(undefined);
+    const creationYearMin = ref<string | undefined>(undefined);
+    const creationYearMax = ref<string | undefined>(undefined);
 
     // Static options
     const staticOptions = {
@@ -77,6 +83,18 @@ export const useDeviationTableStore = defineStore("deviationTableStore", () => {
                 min: temperatureMeanMin.value,
                 max: temperatureMeanMax.value,
             };
+        if (classeMin.value || classeMax.value)
+            result.classe = {
+                type: "number-range",
+                min: classeMin.value,
+                max: classeMax.value,
+            };
+        if (creationYearMin.value || creationYearMax.value)
+            result.anneeDeCreation = {
+                type: "number-range",
+                min: creationYearMin.value,
+                max: creationYearMax.value,
+            };
         return result;
     });
 
@@ -95,6 +113,12 @@ export const useDeviationTableStore = defineStore("deviationTableStore", () => {
             } else if (id === "temperatureMean") {
                 temperatureMeanMin.value = value.min;
                 temperatureMeanMax.value = value.max;
+            } else if (id === "classe") {
+                classeMin.value = value.min;
+                classeMax.value = value.max;
+            } else if (id === "anneeDeCreation") {
+                creationYearMin.value = value.min;
+                creationYearMax.value = value.max;
             }
         }
     }
@@ -115,6 +139,12 @@ export const useDeviationTableStore = defineStore("deviationTableStore", () => {
         } else if (id === "temperatureMean") {
             temperatureMeanMin.value = undefined;
             temperatureMeanMax.value = undefined;
+        } else if (id === "classe") {
+            classeMin.value = undefined;
+            classeMax.value = undefined;
+        } else if (id === "anneeDeCreation") {
+            creationYearMin.value = undefined;
+            creationYearMax.value = undefined;
         }
     }
 
@@ -134,6 +164,16 @@ export const useDeviationTableStore = defineStore("deviationTableStore", () => {
     );
     const debouncedTMeanMax = refDebounced(
         temperatureMeanMax,
+        debounceDuration,
+    );
+    const debouncedClasseMin = refDebounced(classeMin, debounceDuration);
+    const debouncedClasseMax = refDebounced(classeMax, debounceDuration);
+    const debouncedCreationYearMin = refDebounced(
+        creationYearMin,
+        debounceDuration,
+    );
+    const debouncedCreationYearMax = refDebounced(
+        creationYearMax,
         debounceDuration,
     );
 
@@ -167,6 +207,14 @@ export const useDeviationTableStore = defineStore("deviationTableStore", () => {
             result.temperature_mean_min = Number(debouncedTMeanMin.value);
         if (debouncedTMeanMax.value)
             result.temperature_mean_max = Number(debouncedTMeanMax.value);
+        if (debouncedClasseMin.value)
+            result.classe_recente_min = Number(debouncedClasseMin.value);
+        if (debouncedClasseMax.value)
+            result.classe_recente_max = Number(debouncedClasseMax.value);
+        if (debouncedCreationYearMin.value)
+            result.date_de_creation_min = `${debouncedCreationYearMin.value}-01-01`;
+        if (debouncedCreationYearMax.value)
+            result.date_de_creation_max = `${debouncedCreationYearMax.value}-12-31`;
         return result;
     });
 

--- a/frontend/app/stores/recordsTableStore.ts
+++ b/frontend/app/stores/recordsTableStore.ts
@@ -21,6 +21,8 @@ type RecordsFilters = {
     departement?: StringFilterValue;
     record?: RangeFilterValue;
     record_date?: DateFilterValue;
+    classe?: RangeFilterValue;
+    anneeDeCreation?: RangeFilterValue;
 };
 
 export const periodOptions = [
@@ -61,6 +63,10 @@ export const useRecordsTableStore = defineStore("recordsTableStore", () => {
     const temperatureMax = ref<string | undefined>(undefined);
     const dateStart = ref<Date | undefined>(undefined);
     const dateEnd = ref<Date | undefined>(undefined);
+    const classeMin = ref<string | undefined>(undefined);
+    const classeMax = ref<string | undefined>(undefined);
+    const creationYearMin = ref<string | undefined>(undefined);
+    const creationYearMax = ref<string | undefined>(undefined);
 
     const debouncedStationIds = refDebounced(stationIds, debounceDuration);
     const debouncedDepartments = refDebounced(departments, debounceDuration);
@@ -74,6 +80,16 @@ export const useRecordsTableStore = defineStore("recordsTableStore", () => {
     );
     const debouncedDateStart = refDebounced(dateStart, debounceDuration);
     const debouncedDateEnd = refDebounced(dateEnd, debounceDuration);
+    const debouncedClasseMin = refDebounced(classeMin, debounceDuration);
+    const debouncedClasseMax = refDebounced(classeMax, debounceDuration);
+    const debouncedCreationYearMin = refDebounced(
+        creationYearMin,
+        debounceDuration,
+    );
+    const debouncedCreationYearMax = refDebounced(
+        creationYearMax,
+        debounceDuration,
+    );
 
     // Static options for the Département dropdown
     const staticOptions = {
@@ -106,6 +122,20 @@ export const useRecordsTableStore = defineStore("recordsTableStore", () => {
                 max: dateEnd.value,
             };
         }
+        if (classeMin.value || classeMax.value) {
+            result.classe = {
+                type: "number-range",
+                min: classeMin.value,
+                max: classeMax.value,
+            };
+        }
+        if (creationYearMin.value || creationYearMax.value) {
+            result.anneeDeCreation = {
+                type: "number-range",
+                min: creationYearMin.value,
+                max: creationYearMax.value,
+            };
+        }
 
         return result;
     });
@@ -122,6 +152,12 @@ export const useRecordsTableStore = defineStore("recordsTableStore", () => {
             if (id === "record") {
                 temperatureMin.value = value.min;
                 temperatureMax.value = value.max;
+            } else if (id === "classe") {
+                classeMin.value = value.min;
+                classeMax.value = value.max;
+            } else if (id === "anneeDeCreation") {
+                creationYearMin.value = value.min;
+                creationYearMax.value = value.max;
             }
         } else if (value.type === "date-range") {
             if (id === "record_date") {
@@ -143,6 +179,12 @@ export const useRecordsTableStore = defineStore("recordsTableStore", () => {
         } else if (id === "record_date") {
             dateStart.value = undefined;
             dateEnd.value = undefined;
+        } else if (id === "classe") {
+            classeMin.value = undefined;
+            classeMax.value = undefined;
+        } else if (id === "anneeDeCreation") {
+            creationYearMin.value = undefined;
+            creationYearMax.value = undefined;
         }
     }
 
@@ -178,6 +220,10 @@ export const useRecordsTableStore = defineStore("recordsTableStore", () => {
             debouncedTemperatureMax,
             debouncedDateStart,
             debouncedDateEnd,
+            debouncedClasseMin,
+            debouncedClasseMax,
+            debouncedCreationYearMin,
+            debouncedCreationYearMax,
         ],
         () => {
             page.value = 1;
@@ -232,6 +278,26 @@ export const useRecordsTableStore = defineStore("recordsTableStore", () => {
         if (debouncedDateEnd.value) {
             const end = dateToStringYMD(debouncedDateEnd.value);
             result = result.filter((r) => r.record_date <= end);
+        }
+        if (debouncedClasseMin.value) {
+            const min = Number(debouncedClasseMin.value);
+            result = result.filter((r) => r.classe_recente >= min);
+        }
+        if (debouncedClasseMax.value) {
+            const max = Number(debouncedClasseMax.value);
+            result = result.filter((r) => r.classe_recente <= max);
+        }
+        if (debouncedCreationYearMin.value) {
+            const min = Number(debouncedCreationYearMin.value);
+            result = result.filter(
+                (r) => new Date(r.date_de_creation).getFullYear() >= min,
+            );
+        }
+        if (debouncedCreationYearMax.value) {
+            const max = Number(debouncedCreationYearMax.value);
+            result = result.filter(
+                (r) => new Date(r.date_de_creation).getFullYear() <= max,
+            );
         }
 
         return result;

--- a/frontend/app/stores/recordsTableStore.ts
+++ b/frontend/app/stores/recordsTableStore.ts
@@ -23,6 +23,7 @@ type RecordsFilters = {
     record_date?: DateFilterValue;
     classe?: RangeFilterValue;
     anneeDeCreation?: RangeFilterValue;
+    altitude?: RangeFilterValue;
 };
 
 export const periodOptions = [
@@ -67,6 +68,8 @@ export const useRecordsTableStore = defineStore("recordsTableStore", () => {
     const classeMax = ref<string | undefined>(undefined);
     const creationYearMin = ref<string | undefined>(undefined);
     const creationYearMax = ref<string | undefined>(undefined);
+    const altMin = ref<string | undefined>(undefined);
+    const altMax = ref<string | undefined>(undefined);
 
     const debouncedStationIds = refDebounced(stationIds, debounceDuration);
     const debouncedDepartments = refDebounced(departments, debounceDuration);
@@ -90,6 +93,8 @@ export const useRecordsTableStore = defineStore("recordsTableStore", () => {
         creationYearMax,
         debounceDuration,
     );
+    const debouncedAltMin = refDebounced(altMin, debounceDuration);
+    const debouncedAltMax = refDebounced(altMax, debounceDuration);
 
     // Static options for the Département dropdown
     const staticOptions = {
@@ -136,6 +141,13 @@ export const useRecordsTableStore = defineStore("recordsTableStore", () => {
                 max: creationYearMax.value,
             };
         }
+        if (altMin.value || altMax.value) {
+            result.altitude = {
+                type: "number-range",
+                min: altMin.value,
+                max: altMax.value,
+            };
+        }
 
         return result;
     });
@@ -158,6 +170,9 @@ export const useRecordsTableStore = defineStore("recordsTableStore", () => {
             } else if (id === "anneeDeCreation") {
                 creationYearMin.value = value.min;
                 creationYearMax.value = value.max;
+            } else if (id === "altitude") {
+                altMin.value = value.min;
+                altMax.value = value.max;
             }
         } else if (value.type === "date-range") {
             if (id === "record_date") {
@@ -185,6 +200,9 @@ export const useRecordsTableStore = defineStore("recordsTableStore", () => {
         } else if (id === "anneeDeCreation") {
             creationYearMin.value = undefined;
             creationYearMax.value = undefined;
+        } else if (id === "altitude") {
+            altMin.value = undefined;
+            altMax.value = undefined;
         }
     }
 
@@ -224,6 +242,8 @@ export const useRecordsTableStore = defineStore("recordsTableStore", () => {
             debouncedClasseMax,
             debouncedCreationYearMin,
             debouncedCreationYearMax,
+            debouncedAltMin,
+            debouncedAltMax,
         ],
         () => {
             page.value = 1;
@@ -298,6 +318,14 @@ export const useRecordsTableStore = defineStore("recordsTableStore", () => {
             result = result.filter(
                 (r) => new Date(r.date_de_creation).getFullYear() <= max,
             );
+        }
+        if (debouncedAltMin.value) {
+            const min = Number(debouncedAltMin.value);
+            result = result.filter((r) => r.alt >= min);
+        }
+        if (debouncedAltMax.value) {
+            const max = Number(debouncedAltMax.value);
+            result = result.filter((r) => r.alt <= max);
         }
 
         return result;

--- a/frontend/app/types/api.ts
+++ b/frontend/app/types/api.ts
@@ -115,6 +115,10 @@ export interface TemperatureDeviationParams {
     deviation_max?: number;
     altitude_min?: number;
     altitude_max?: number;
+    classe_recente_min?: number;
+    classe_recente_max?: number;
+    date_de_creation_min?: string;
+    date_de_creation_max?: string;
     ordering?: string;
     limit?: number;
     offset?: number;
@@ -156,6 +160,8 @@ export interface TemperatureDeviationStation {
     lon: number;
     department: string;
     region: string;
+    classe_recente: number;
+    date_de_creation: string;
 }
 
 export interface TemperatureDeviationResponse {
@@ -304,6 +310,8 @@ export interface TemperatureRecordFlatEntry {
     lat: number;
     lon: number;
     alt: number;
+    classe_recente: number;
+    date_de_creation: string;
 }
 
 export interface TemperatureRecordStation {


### PR DESCRIPTION
## Type de PR
- [ ] Bugfix
- [x] Feature
- [ ] Refactor
- [ ] Chore / Tech debt
- [ ] Documentation
- [ ] Autre (à préciser)

## Objectif
Ajoute les colonnes classe et année de création dans les tableaux deviation et records.

## Contexte
Suite à enrichissement du endpoint on peut ajouter en front

## Changements
- ajout des colonnes
- gestion des filtres
- le tri est ok en record car il est géré coté front (pour deviation il faut un travailen backend)
- uniformisation des styles de tableaux

<img width="838" height="424" alt="image" src="https://github.com/user-attachments/assets/6d15c871-34cd-4e80-8e17-65e4e800cff7" />


## Décisions techniques
<!-- Choix structurants, arbitrages, compromis. -->
<!-- Ce qui aurait pu être fait autrement. -->

## Impacts
- [ ] API / contrat
- [ ] Modèle de données / DB
- [ ] Calculs métier
- [ ] Performance
- [ ] Sécurité
- [ ] Infra / déploiement
- [ ] Aucun impact transverse identifié

## Tests
<!-- Décris ce qui a été fait dans cette PR pour vérifier le comportement introduit ou modifié. -->
- [ ] Tests unitaires
- [ ] Tests d’intégration
- [x] Tests manuels
- [ ] Non applicable (à justifier)

## Points d’attention pour la review
<!-- Parties sensibles du code, dette technique introduite, risques. -->

## Suivi
- [ ] Migration à prévoir
- [ ] Documentation à mettre à jour
- [ ] Tâche(s) de suivi à créer
