### PR TITLE
Feature/ecart normale mensuel

### DIFF
--- a/frontend/app/components/home/Last30DaysSection/HomeDeviationMap.vue
+++ b/frontend/app/components/home/Last30DaysSection/HomeDeviationMap.vue
@@ -4,8 +4,7 @@
         :color-config="DEVIATION_MAP_MONTHLY_COLORS"
         :tooltip-formatter="tooltipFormatter"
         legend-label="Température (°C)"
-        height="380px"
-        :show-controls="false"
+        aspect-ratio="1"
     />
 </template>
 

--- a/frontend/app/components/home/Last30DaysSection/HomeDeviationMap.vue
+++ b/frontend/app/components/home/Last30DaysSection/HomeDeviationMap.vue
@@ -9,7 +9,11 @@
 </template>
 
 <script setup lang="ts">
-import type { DeviationMapParams, MappableStation } from "~/types/api";
+import type {
+    DeviationMapParams,
+    MappableStation,
+    MapTooltipFormatter,
+} from "~/types/api";
 import { DEVIATION_MAP_MONTHLY_COLORS } from "~/constants/colors";
 import { formatDeviationMapTooltip } from "~/components/map/tooltipFormatters/deviationMapTooltipFormatter";
 import StationMap from "~/components/map/StationMap.vue";
@@ -37,12 +41,8 @@ const mappableStations = computed<MappableStation[]>(
         })) ?? [],
 );
 
-const tooltipFormatter = (properties: {
-    station_name: string;
-    value: number;
-    record_date: string | null;
-    department: string | null;
-}) => formatDeviationMapTooltip(properties.station_name, properties.value);
+const tooltipFormatter: MapTooltipFormatter = (properties) =>
+    formatDeviationMapTooltip(properties.station_name, properties.value);
 
 onMounted(async () => {
     await fetchStations();

--- a/frontend/app/components/home/Last30DaysSection/HomeDeviationMap.vue
+++ b/frontend/app/components/home/Last30DaysSection/HomeDeviationMap.vue
@@ -1,0 +1,53 @@
+<template>
+    <StationMap
+        :stations="mappableStations"
+        :color-config="DEVIATION_MAP_MONTHLY_COLORS"
+        :tooltip-formatter="tooltipFormatter"
+        legend-label="Température (°C)"
+        height="380px"
+        :show-controls="false"
+    />
+</template>
+
+<script setup lang="ts">
+import type { DeviationMapParams, MappableStation } from "~/types/api";
+import { DEVIATION_MAP_MONTHLY_COLORS } from "~/constants/colors";
+import { formatDeviationMapTooltip } from "~/components/map/tooltipFormatters/deviationMapTooltipFormatter";
+import StationMap from "~/components/map/StationMap.vue";
+const props = defineProps<{
+    dateStart: string;
+    dateEnd: string;
+}>();
+
+const params = computed<DeviationMapParams>(() => ({
+    date_start: props.dateStart,
+    date_end: props.dateEnd,
+    limit: 99999,
+}));
+
+const { data: stationsData, execute: fetchStations } =
+    useTemperatureDeviationMap(params, "home-deviation-map");
+
+const mappableStations = computed<MappableStation[]>(
+    () =>
+        stationsData.value?.stations.map((s) => ({
+            lat: s.lat,
+            lon: s.lon,
+            station_name: s.station_name,
+            value: s.deviation,
+        })) ?? [],
+);
+
+const tooltipFormatter = (properties: {
+    station_name: string;
+    value: number;
+    record_date: string | null;
+    department: string | null;
+}) => formatDeviationMapTooltip(properties.station_name, properties.value);
+
+onMounted(async () => {
+    await fetchStations();
+});
+
+watch(params, async () => await fetchStations(), { deep: true });
+</script>

--- a/frontend/app/components/home/Last30DaysSection/LastMonthSection.vue
+++ b/frontend/app/components/home/Last30DaysSection/LastMonthSection.vue
@@ -142,14 +142,14 @@ const lastYearColdRecordsCount = computed(
                 ECART DE TEMPÉRATURE A LA NORMALE
             </h2>
             <div
-                class="flex flex-col md:flex-row gap-6 mt-2 mb-4 md:items-start"
+                class="flex flex-col lg:flex-row gap-4 mt-2 mb-4 lg:items-start"
             >
                 <HomeDeviationMap
                     :date-start="dateStart"
                     :date-end="dateEnd"
-                    class="w-full md:w-91 md:shrink-0"
+                    class="w-full max-w-sm lg:w-72 lg:max-w-none lg:shrink-0"
                 />
-                <div class="flex flex-col gap-3">
+                <div class="flex flex-col gap-3 flex-1 min-w-0">
                     <p class="text-sm text-muted">
                         Stations avec écart le plus important
                     </p>

--- a/frontend/app/components/home/Last30DaysSection/LastMonthSection.vue
+++ b/frontend/app/components/home/Last30DaysSection/LastMonthSection.vue
@@ -4,17 +4,21 @@ import GoToDataLink from "../GoToDataLink.vue";
 import ExtremeCard from "../ExtremeCard.vue";
 import Section from "../Section.vue";
 import TemperatureRecord from "../TemperatureRecord.vue";
+import HomeDeviationMap from "./HomeDeviationMap.vue";
 
 const { yesterday, yesterdayLess30Days } = useCustomDate();
 
+const dateStart = computed(() => dateToStringYMD(yesterdayLess30Days.value));
+const dateEnd = computed(() => dateToStringYMD(yesterday.value));
+
 function getYesterdayLastYear(yesterday: Date): Date {
-    const yesterdayLastYear = yesterday;
+    const yesterdayLastYear = new Date(yesterday);
     yesterdayLastYear.setFullYear(yesterdayLastYear.getFullYear() - 1);
     return yesterdayLastYear;
 }
 
 function getLastYearLast30Days(yesterday: Date): Date {
-    const lastYearLast30Days = yesterday;
+    const lastYearLast30Days = new Date(yesterday);
     lastYearLast30Days.setDate(lastYearLast30Days.getDate() - 30);
     return lastYearLast30Days;
 }
@@ -137,33 +141,43 @@ const lastYearColdRecordsCount = computed(
             <h2 class="text-blue-700 dark:text-primary pb-2">
                 ECART DE TEMPÉRATURE A LA NORMALE
             </h2>
-            <div class="flex flex-col w-fit gap-2 mt-2">
-                <ExtremeCard
-                    hot-cold="hot"
-                    :loading="hotDeviationStatus === 'pending'"
-                    :temperature="
-                        hotStation
-                            ? formatDeviation(hotStation.deviation)
-                            : undefined
-                    "
-                    :city="hotStation?.station_name"
-                    :department-string="hotStation?.region"
-                    :department-number="hotStation?.department"
+            <div class="flex gap-6 mt-2 mb-4 items-start">
+                <HomeDeviationMap
+                    :date-start="dateStart"
+                    :date-end="dateEnd"
+                    class="w-91 shrink-0"
                 />
-                <ExtremeCard
-                    hot-cold="cold"
-                    :loading="coldDeviationStatus === 'pending'"
-                    :temperature="
-                        coldStation
-                            ? formatDeviation(coldStation.deviation)
-                            : undefined
-                    "
-                    :city="coldStation?.station_name"
-                    :department-string="coldStation?.region"
-                    :department-number="coldStation?.department"
-                />
+                <div class="flex flex-col gap-3">
+                    <p class="text-sm text-muted">
+                        Stations avec écart le plus important
+                    </p>
+                    <ExtremeCard
+                        hot-cold="hot"
+                        :loading="hotDeviationStatus === 'pending'"
+                        :temperature="
+                            hotStation
+                                ? formatDeviation(hotStation.deviation)
+                                : undefined
+                        "
+                        :city="hotStation?.station_name"
+                        :department-string="hotStation?.region"
+                        :department-number="hotStation?.department"
+                    />
+                    <ExtremeCard
+                        hot-cold="cold"
+                        :loading="coldDeviationStatus === 'pending'"
+                        :temperature="
+                            coldStation
+                                ? formatDeviation(coldStation.deviation)
+                                : undefined
+                        "
+                        :city="coldStation?.station_name"
+                        :department-string="coldStation?.region"
+                        :department-number="coldStation?.department"
+                    />
+                    <GoToDataLink :data-url="'/ecart-normale'" />
+                </div>
             </div>
-            <GoToDataLink :data-url="'/ecart-normale'" />
             <div class="border-b to-slate-200" />
             <h2 class="text-blue-700 dark:text-primary pb-2 pt-1">
                 RECORDS MENSUELS DE TEMPÉRATURE

--- a/frontend/app/components/home/Last30DaysSection/LastMonthSection.vue
+++ b/frontend/app/components/home/Last30DaysSection/LastMonthSection.vue
@@ -141,11 +141,13 @@ const lastYearColdRecordsCount = computed(
             <h2 class="text-blue-700 dark:text-primary pb-2">
                 ECART DE TEMPÉRATURE A LA NORMALE
             </h2>
-            <div class="flex gap-6 mt-2 mb-4 items-start">
+            <div
+                class="flex flex-col md:flex-row gap-6 mt-2 mb-4 md:items-start"
+            >
                 <HomeDeviationMap
                     :date-start="dateStart"
                     :date-end="dateEnd"
-                    class="w-91 shrink-0"
+                    class="w-full md:w-91 md:shrink-0"
                 />
                 <div class="flex flex-col gap-3">
                     <p class="text-sm text-muted">

--- a/frontend/app/components/home/Last30DaysSection/LastMonthSection.vue
+++ b/frontend/app/components/home/Last30DaysSection/LastMonthSection.vue
@@ -147,7 +147,7 @@ const lastYearColdRecordsCount = computed(
                 <HomeDeviationMap
                     :date-start="dateStart"
                     :date-end="dateEnd"
-                    class="w-full max-w-sm lg:w-72 lg:max-w-none lg:shrink-0"
+                    class="w-full max-w-sm lg:flex-1 lg:max-w-none"
                 />
                 <div class="flex flex-col gap-3 flex-1 min-w-0">
                     <p class="text-sm text-muted">

--- a/frontend/app/components/map/StationMap.vue
+++ b/frontend/app/components/map/StationMap.vue
@@ -1,9 +1,11 @@
 <template>
-    <div class="relative">
-        <div ref="mapContainer" class="w-full h-[700px]" />
+    <div class="flex flex-col gap-2">
         <div
-            class="absolute bottom-4 left-1/2 -translate-x-1/2 flex flex-col items-center gap-1 pointer-events-none"
-        >
+            ref="mapContainer"
+            class="w-full rounded-lg overflow-hidden"
+            :style="{ height }"
+        />
+        <div class="flex flex-col items-center gap-1">
             <span class="text-xs" :style="{ color: mapColors.foreground }">{{
                 legendLabel
             }}</span>
@@ -16,7 +18,8 @@
                 }"
             />
             <div
-                class="flex justify-between w-full text-xs"
+                class="flex justify-between text-xs"
+                style="width: 160px"
                 :style="{ color: mapColors.foreground }"
             >
                 <span>{{ colorConfig.min }}°C</span>
@@ -26,7 +29,6 @@
                 >
             </div>
         </div>
-        <MapAttribution class="mt-2" />
     </div>
 </template>
 
@@ -47,12 +49,17 @@ import { breakpointsTailwind, useBreakpoints } from "@vueuse/core";
 const mapColors = useMapColors();
 const breakpoints = useBreakpoints(breakpointsTailwind);
 
-const props = defineProps<{
-    stations: MappableStation[];
-    colorConfig: MapColorConfig;
-    tooltipFormatter: MapTooltipFormatter;
-    legendLabel: string;
-}>();
+const props = withDefaults(
+    defineProps<{
+        stations: MappableStation[];
+        colorConfig: MapColorConfig;
+        tooltipFormatter: MapTooltipFormatter;
+        legendLabel: string;
+        height?: string;
+        showControls?: boolean;
+    }>(),
+    { height: "700px", showControls: true },
+);
 
 const legendGradient = computed(() =>
     props.colorConfig.stops.map(([, color]) => color).join(", "),
@@ -197,47 +204,49 @@ onMounted(async () => {
                   [12, 53],
               ],
         attributionControl: false,
-        interactive: true,
+        interactive: props.showControls,
     });
 
-    map.addControl(
-        new maplibregl.NavigationControl({ showCompass: false }),
-        "top-right",
-    );
+    if (props.showControls) {
+        map.addControl(
+            new maplibregl.NavigationControl({ showCompass: false }),
+            "top-right",
+        );
 
-    map.addControl(
-        {
-            onAdd(m) {
-                const el = document.createElement("div");
-                el.className = "maplibregl-ctrl maplibregl-ctrl-group";
-                const btn = document.createElement("button");
-                btn.type = "button";
-                btn.title = "Réinitialiser la vue";
-                btn.setAttribute("aria-label", "Réinitialiser la vue");
-                btn.innerHTML = `<svg xmlns="http://www.w3.org/2000/svg" width="29" height="20" viewBox="0 0 20 20" fill="none"><path d="M3 7V3h4M17 7V3h-4M3 13v4h4M17 13v4h-4" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></svg>`;
-                btn.onclick = () =>
-                    m.fitBounds(
-                        [
-                            [-5.2, 41.3],
-                            [9.6, 51.1],
-                        ],
-                        {
-                            padding: {
-                                top: 50,
-                                right: 50,
-                                bottom: 50,
-                                left: 40,
+        map.addControl(
+            {
+                onAdd(m) {
+                    const el = document.createElement("div");
+                    el.className = "maplibregl-ctrl maplibregl-ctrl-group";
+                    const btn = document.createElement("button");
+                    btn.type = "button";
+                    btn.title = "Réinitialiser la vue";
+                    btn.setAttribute("aria-label", "Réinitialiser la vue");
+                    btn.innerHTML = `<svg xmlns="http://www.w3.org/2000/svg" width="29" height="20" viewBox="0 0 20 20" fill="none"><path d="M3 7V3h4M17 7V3h-4M3 13v4h4M17 13v4h-4" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></svg>`;
+                    btn.onclick = () =>
+                        m.fitBounds(
+                            [
+                                [-5.2, 41.3],
+                                [9.6, 51.1],
+                            ],
+                            {
+                                padding: {
+                                    top: 50,
+                                    right: 50,
+                                    bottom: 50,
+                                    left: 40,
+                                },
+                                duration: 500,
                             },
-                            duration: 500,
-                        },
-                    );
-                el.appendChild(btn);
-                return el;
+                        );
+                    el.appendChild(btn);
+                    return el;
+                },
+                onRemove() {},
             },
-            onRemove() {},
-        },
-        "top-right",
-    );
+            "top-right",
+        );
+    }
 
     map.once("load", () => {
         map!.resize();

--- a/frontend/app/components/map/StationMap.vue
+++ b/frontend/app/components/map/StationMap.vue
@@ -3,7 +3,7 @@
         <div
             ref="mapContainer"
             class="w-full rounded-lg overflow-hidden"
-            :style="{ height }"
+            :style="aspectRatio ? { aspectRatio } : { height }"
         />
         <div class="flex flex-col items-center gap-1">
             <span class="text-xs" :style="{ color: mapColors.foreground }">{{
@@ -56,9 +56,10 @@ const props = withDefaults(
         tooltipFormatter: MapTooltipFormatter;
         legendLabel: string;
         height?: string;
+        aspectRatio?: string;
         showControls?: boolean;
     }>(),
-    { height: "700px", showControls: true },
+    { height: "700px", aspectRatio: undefined, showControls: true },
 );
 
 const legendGradient = computed(() =>

--- a/frontend/app/constants/colors.ts
+++ b/frontend/app/constants/colors.ts
@@ -1,3 +1,5 @@
+import type { MapColorConfig } from "~/types/api";
+
 export const TEMPERATURE_COLORS = {
     cold: "#1976D2",
     hot: "#d32F2F",
@@ -25,22 +27,19 @@ export function useMapColors() {
     return computed(() => (cm.value === "dark" ? DARK_COLORS : LIGHT_COLORS));
 }
 
-function makeDeviationColors(min: number, max: number) {
-    return {
-        min,
-        max,
-        stops: [
-            [min, TEMPERATURE_COLORS.cold],
-            [min * 0.6, "hsl(210, 85%, 75%)"],
-            [min * 0.2, "hsl(180, 90%, 85%)"],
-            [min * 0.05, "hsl(160, 95%, 90%)"],
-            [0, "#ffffff"],
-            [max * 0.05, "hsl(50, 96%, 90%)"],
-            [max * 0.2, "hsl(30, 90%, 85%)"],
-            [max * 0.6, "hsl(0, 85%, 75%)"],
-            [max, TEMPERATURE_COLORS.hot],
-        ] as [number, string][],
-    };
+function makeDeviationColors(min: number, max: number): MapColorConfig {
+    const stops: [number, string][] = [
+        [min, TEMPERATURE_COLORS.cold],
+        [min * 0.6, "hsl(210, 85%, 75%)"],
+        [min * 0.2, "hsl(180, 90%, 85%)"],
+        [min * 0.05, "hsl(160, 95%, 90%)"],
+        [0, "#ffffff"],
+        [max * 0.05, "hsl(50, 96%, 90%)"],
+        [max * 0.2, "hsl(30, 90%, 85%)"],
+        [max * 0.6, "hsl(0, 85%, 75%)"],
+        [max, TEMPERATURE_COLORS.hot],
+    ];
+    return { min, max, stops };
 }
 
 export const DEVIATION_MAP_COLORS = makeDeviationColors(-5, 5);

--- a/frontend/app/constants/colors.ts
+++ b/frontend/app/constants/colors.ts
@@ -25,26 +25,26 @@ export function useMapColors() {
     return computed(() => (cm.value === "dark" ? DARK_COLORS : LIGHT_COLORS));
 }
 
-const deviationMin = -5;
-const deviationMax = 5;
+function makeDeviationColors(min: number, max: number) {
+    return {
+        min,
+        max,
+        stops: [
+            [min, TEMPERATURE_COLORS.cold],
+            [min * 0.6, "hsl(210, 85%, 75%)"],
+            [min * 0.2, "hsl(180, 90%, 85%)"],
+            [min * 0.05, "hsl(160, 95%, 90%)"],
+            [0, "#ffffff"],
+            [max * 0.05, "hsl(50, 96%, 90%)"],
+            [max * 0.2, "hsl(30, 90%, 85%)"],
+            [max * 0.6, "hsl(0, 85%, 75%)"],
+            [max, TEMPERATURE_COLORS.hot],
+        ] as [number, string][],
+    };
+}
 
-const deviationStops: [number, string][] = [
-    [deviationMin, TEMPERATURE_COLORS.cold],
-    [deviationMin * 0.6, "hsl(210, 85%, 75%)"],
-    [deviationMin * 0.2, "hsl(180, 90%, 85%)"],
-    [deviationMin * 0.05, "hsl(160, 95%, 90%)"],
-    [0, "#ffffff"],
-    [deviationMax * 0.05, "hsl(50, 96%, 90%)"],
-    [deviationMax * 0.2, "hsl(30, 90%, 85%)"],
-    [deviationMax * 0.6, "hsl(0, 85%, 75%)"],
-    [deviationMax, TEMPERATURE_COLORS.hot],
-];
-
-export const DEVIATION_MAP_COLORS = {
-    min: deviationMin,
-    max: deviationMax,
-    stops: deviationStops,
-};
+export const DEVIATION_MAP_COLORS = makeDeviationColors(-5, 5);
+export const DEVIATION_MAP_MONTHLY_COLORS = makeDeviationColors(-10, 10);
 
 const recordsMin = -20;
 const recordsMax = 40;


### PR DESCRIPTION
## Type de PR
- [ ] Bugfix
- [x] Feature
- [ ] Refactor
- [ ] Chore / Tech debt
- [ ] Documentation
- [ ] Autre (à préciser)


 ## Objectif
 Afficher une carte des écarts à la normale mensuels dans la section
 "Ces 30 derniers jours" de la page d'accueil, pour visualiser la
 répartition géographique des anomalies de température en France métropolitaine.
 
 ## Contexte
 Closes #254 
 
 La section "Ces 30 derniers jours" existait déjà avec des KPI chauds/froids.
 Cette story ajoute la carte spatiale manquante, en réutilisant le composant
 `StationMap` déjà utilisé sur la page Écart à la normale (#218).
 
 ## Changements
 - **`HomeDeviationMap.vue`** (nouveau) : composant wrapper qui récupère les
   données de l'endpoint `/temperature/deviation` et les passe à `StationMap`
 - **`LastMonthSection.vue`** : intègre `HomeDeviationMap` dans la section
   "Écart de température à la normale", aux côtés des cartes stations
   chaude/froide extrêmes
 - **`StationMap.vue`** : ajout des props `height` et `showControls` pour
   permettre une version compacte et non-interactive dans la home ; ajout du
   support mobile (bounds élargis sur petit écran)
 - **`colors.ts`** : refactorisation de `DEVIATION_MAP_COLORS` via
   `makeDeviationColors()` + ajout de `DEVIATION_MAP_MONTHLY_COLORS`
   (échelle -10°C → +10°C) adaptée à la granularité mensuelle
 
 ## Décisions techniques
 - `StationMap` a été rendu configurable (`height`, `showControls`) plutôt
   que dupliqué, pour éviter la divergence entre la vue dédiée et la version
   home compacte.
 - L'échelle de couleurs mensuelle (`±10°C`) est distincte de l'échelle
   journalière (`±5°C`) : les anomalies mensuelles ont une amplitude plus
   faible, une même échelle aurait saturé les couleurs.

## Impacts
- [ ] API / contrat
- [ ] Modèle de données / DB
- [ ] Calculs métier
- [ ] Performance
- [ ] Sécurité
- [ ] Infra / déploiement
- [ ] Aucun impact transverse identifié

## Tests
<!-- Décris ce qui a été fait dans cette PR pour vérifier le comportement introduit ou modifié. -->
- [ ] Tests unitaires
- [ ] Tests d’intégration
- [ ] Tests manuels
- [ ] Non applicable (à justifier)

## Points d’attention pour la review
<!-- Parties sensibles du code, dette technique introduite, risques. -->

## Suivi
- [ ] Migration à prévoir
- [ ] Documentation à mettre à jour
- [ ] Tâche(s) de suivi à créer
