### PR TITLE
fix: home: display variation even if 0

### DIFF
--- a/frontend/app/components/home/TemperatureRecord.vue
+++ b/frontend/app/components/home/TemperatureRecord.vue
@@ -35,10 +35,7 @@ const props = defineProps<Props>();
             <template v-if="props.period" #kpi-context-text>
                 {{ props.period }}
             </template>
-            <template
-                v-if="props.difference !== undefined && props.difference !== 0"
-                #variation
-            >
+            <template v-if="props.difference !== undefined" #variation>
                 <UIcon
                     v-if="props.difference > 0"
                     :name="'i-lucide-arrow-up-right'"


### PR DESCRIPTION
## Type de PR
- [x] Bugfix
- [ ] Feature
- [ ] Refactor
- [ ] Chore / Tech debt
- [ ] Documentation
- [ ] Autre (à préciser)

## Objectif
Afficher la variation sur les card de records battus, même si c'est 0

## Contexte
https://github.com/dataforgoodfr/14_ValorisationDonneeMeteo/issues/475

## Changements
-

## Décisions techniques
<!-- Choix structurants, arbitrages, compromis. -->
<!-- Ce qui aurait pu être fait autrement. -->

## Impacts
- [ ] API / contrat
- [ ] Modèle de données / DB
- [ ] Calculs métier
- [ ] Performance
- [ ] Sécurité
- [ ] Infra / déploiement
- [ ] Aucun impact transverse identifié

## Tests
<!-- Décris ce qui a été fait dans cette PR pour vérifier le comportement introduit ou modifié. -->
- [ ] Tests unitaires
- [ ] Tests d’intégration
- [ ] Tests manuels
- [ ] Non applicable (à justifier)

## Points d’attention pour la review
<!-- Parties sensibles du code, dette technique introduite, risques. -->

## Suivi
- [ ] Migration à prévoir
- [ ] Documentation à mettre à jour
- [ ] Tâche(s) de suivi à créer
