### PR TITLE
fix(map): enhance France map zoom

### DIFF
--- a/frontend/app/components/home/Last30DaysSection/HomeDeviationMap.vue
+++ b/frontend/app/components/home/Last30DaysSection/HomeDeviationMap.vue
@@ -5,6 +5,7 @@
         :tooltip-formatter="tooltipFormatter"
         legend-label="Température (°C)"
         aspect-ratio="1"
+        :fit-padding="{ top: 10, right: 10, bottom: 10, left: 10 }"
     />
 </template>
 

--- a/frontend/app/components/map/StationMap.vue
+++ b/frontend/app/components/map/StationMap.vue
@@ -58,8 +58,19 @@ const props = withDefaults(
         height?: string;
         aspectRatio?: string;
         showControls?: boolean;
+        fitPadding?: {
+            top: number;
+            right: number;
+            bottom: number;
+            left: number;
+        };
     }>(),
-    { height: "700px", aspectRatio: undefined, showControls: true },
+    {
+        height: "700px",
+        aspectRatio: undefined,
+        showControls: true,
+        fitPadding: () => ({ top: -10, right: 50, bottom: 50, left: 40 }),
+    },
 );
 
 const legendGradient = computed(() =>
@@ -257,7 +268,7 @@ onMounted(async () => {
                 [9.6, 51.1],
             ],
             {
-                padding: { top: -10, right: 50, bottom: 50, left: 40 },
+                padding: props.fitPadding,
                 duration: 0,
             },
         );


### PR DESCRIPTION
## Type de PR
- [x] Bugfix
- [ ] Feature
- [ ] Refactor
- [ ] Chore / Tech debt
- [ ] Documentation
- [ ] Autre (à préciser)

## Objectif
La map de la France est un peu trop petite sur la page d'accueil

## Contexte


## Changements
[StationMap.vue](vscode-webview://1vrf6t27q4lk2navga3ck56jkkcvhrup9ifvr98ofibdeusoauep/frontend/app/components/map/StationMap.vue) : ajout d'une prop fitPadding (défaut { top: -10, right: 50, bottom: 50, left: 40 } pour préserver le comportement existant sur les autres pages), utilisée dans le fitBounds initial.
[HomeDeviationMap.vue](vscode-webview://1vrf6t27q4lk2navga3ck56jkkcvhrup9ifvr98ofibdeusoauep/frontend/app/components/home/Last30DaysSection/HomeDeviationMap.vue) : passage de :fit-padding="{ top: 10, right: 10, bottom: 10, left: 10 }" pour que France remplisse quasi toute la carte au chargement.

## Décisions techniques
<!-- Choix structurants, arbitrages, compromis. -->
<!-- Ce qui aurait pu être fait autrement. -->

## Impacts
- [ ] API / contrat
- [ ] Modèle de données / DB
- [ ] Calculs métier
- [ ] Performance
- [ ] Sécurité
- [ ] Infra / déploiement
- [ ] Aucun impact transverse identifié

## Tests
<!-- Décris ce qui a été fait dans cette PR pour vérifier le comportement introduit ou modifié. -->
- [ ] Tests unitaires
- [ ] Tests d’intégration
- [ ] Tests manuels
- [ ] Non applicable (à justifier)

## Points d’attention pour la review
<!-- Parties sensibles du code, dette technique introduite, risques. -->

## Suivi
- [ ] Migration à prévoir
- [ ] Documentation à mettre à jour
- [ ] Tâche(s) de suivi à créer
