### PR TITLE
fix: make the export button consistent with the other pages

### DIFF
--- a/frontend/app/components/table/deviation/DeviationTable.vue
+++ b/frontend/app/components/table/deviation/DeviationTable.vue
@@ -162,14 +162,15 @@ const columns = [
 
 <template>
     <div class="flex flex-col gap-4 w-full overflow-x-auto">
-        <div class="flex items-end justify-between gap-4">
-            <DayPicker
-                v-if="props.showFilters"
-                v-model:start-date="dateStart"
-                v-model:end-date="dateEnd"
-                :min-date="dates.absoluteMinDataDate.value"
-                :max-date="dates.yesterday.value"
-            />
+        <DayPicker
+            v-if="props.showFilters"
+            v-model:start-date="dateStart"
+            v-model:end-date="dateEnd"
+            :min-date="dates.absoluteMinDataDate.value"
+            :max-date="dates.yesterday.value"
+        />
+        <div class="flex flex-col lg:flex-row items-end justify-between gap-4">
+            <DeviationFilterBar />
             <UButton
                 label="Exporter CSV"
                 icon="i-lucide-download"
@@ -178,8 +179,6 @@ const columns = [
                 @click="exportCSV"
             />
         </div>
-
-        <DeviationFilterBar />
 
         <div v-if="error" class="px-4 py-3 bg-error/10 text-error rounded">
             Erreur de chargement : {{ error }}


### PR DESCRIPTION
## Type de PR
- [x] Bugfix
- [ ] Feature
- [ ] Refactor
- [ ] Chore / Tech debt
- [ ] Documentation
- [ ] Autre (à préciser)

## Objectif

Le bouton Export est mal placé sur la page Ecart à la normale.

## Contexte

https://github.com/dataforgoodfr/14_ValorisationDonneeMeteo/issues/485

## Changements

Utilisation de la même structure entre la page Records et la page Ecart à la normale pour le bouton Export et la barre de filtres.

Page Ecart à la normale avant mon fix :

<img width="1724" height="780" alt="Image" src="https://github.com/user-attachments/assets/1183b675-2981-4b22-96f3-704921169ef6" />

Bouton Export sur la page Records :

<img width="1727" height="778" alt="Image" src="https://github.com/user-attachments/assets/2f2fed2e-c27f-4c36-a80a-70d5fdb28ba2" />

Page Ecart à la normale après mon fix :

<img width="1723" height="779" alt="Image" src="https://github.com/user-attachments/assets/ff39c7a0-3c1c-4f67-9f3d-3c66e0e0eb79" />

## Décisions techniques
<!-- Choix structurants, arbitrages, compromis. -->
<!-- Ce qui aurait pu être fait autrement. -->

## Impacts
- [ ] API / contrat
- [ ] Modèle de données / DB
- [ ] Calculs métier
- [ ] Performance
- [ ] Sécurité
- [ ] Infra / déploiement
- [ ] Aucun impact transverse identifié

## Tests
<!-- Décris ce qui a été fait dans cette PR pour vérifier le comportement introduit ou modifié. -->
- [ ] Tests unitaires
- [ ] Tests d’intégration
- [x] Tests manuels
- [ ] Non applicable (à justifier)

## Points d’attention pour la review
<!-- Parties sensibles du code, dette technique introduite, risques. -->

## Suivi
- [ ] Migration à prévoir
- [ ] Documentation à mettre à jour
- [ ] Tâche(s) de suivi à créer
