### PR TITLE
[FIX][FRONT] improve loaders

### DIFF
--- a/frontend/app/components/map/MapD3.vue
+++ b/frontend/app/components/map/MapD3.vue
@@ -1,5 +1,5 @@
 <template>
-    <div class="flex flex-col gap-2 lg:w-[700px] w-full flex-shrink-0">
+    <div class="flex flex-col gap-2 lg:w-175 w-full shrink-0">
         <Card
             class="w-fit mx-auto"
             :with-border="false"

--- a/frontend/app/components/table/deviation/DeviationTable.vue
+++ b/frontend/app/components/table/deviation/DeviationTable.vue
@@ -188,8 +188,22 @@ const columns = [
             :data="tableData"
             :columns="columns"
             :loading="pending"
+            loading-color="primary"
+            loading-animation="carousel"
             class="flex-1"
-        />
+        >
+            <template #loading>
+                <tr v-for="i in 10" :key="i">
+                    <td
+                        v-for="(_, colIndex) in columns"
+                        :key="colIndex"
+                        class="px-4 py-3"
+                    >
+                        <USkeleton class="h-4 w-full" />
+                    </td>
+                </tr>
+            </template>
+        </UTable>
 
         <div class="flex justify-center border-t border-accented pt-4">
             <UPagination

--- a/frontend/app/components/table/records/recordsTable.vue
+++ b/frontend/app/components/table/records/recordsTable.vue
@@ -186,8 +186,22 @@ const columns = [
             :data="tableData"
             :columns="columns"
             :loading="pending"
+            loading-color="primary"
+            loading-animation="carousel"
             class="flex-1"
-        />
+        >
+            <template #loading>
+                <tr v-for="i in 5" :key="i">
+                    <td
+                        v-for="(_, colIndex) in columns"
+                        :key="colIndex"
+                        class="px-4 py-3"
+                    >
+                        <USkeleton class="h-4 w-full" />
+                    </td>
+                </tr>
+            </template>
+        </UTable>
 
         <div class="flex justify-center border-t border-accented pt-4">
             <UPagination

--- a/frontend/app/pages/ecart-normale.vue
+++ b/frontend/app/pages/ecart-normale.vue
@@ -73,16 +73,7 @@ const infoPanelSections = ecartNormaleSections;
 
             <hr class="border-accented" />
 
-            <div
-                v-if="tableStore.pending"
-                class="flex items-center justify-center min-h-32"
-            >
-                <UIcon
-                    name="i-lucide-loader-circle"
-                    class="animate-spin text-3xl text-muted"
-                />
-            </div>
-            <div v-else class="flex lg:flex-row flex-col items-start gap-8">
+            <div class="flex lg:flex-row flex-col items-start gap-8">
                 <ClientOnly>
                     <MapD3 :date-start="mapDateStart" :date-end="mapDateEnd" />
                 </ClientOnly>

--- a/frontend/app/pages/records.vue
+++ b/frontend/app/pages/records.vue
@@ -75,16 +75,7 @@ const infoPanelSections = recordsSections;
 
             <hr class="border-accented" />
 
-            <div
-                v-if="store.pending"
-                class="flex items-center justify-center min-h-32"
-            >
-                <UIcon
-                    name="i-lucide-loader-circle"
-                    class="animate-spin text-3xl text-muted"
-                />
-            </div>
-            <div v-else class="flex flex-col md:flex-row items-start gap-8">
+            <div class="flex flex-col md:flex-row items-start gap-8">
                 <ClientOnly>
                     <RecordsMap />
                 </ClientOnly>


### PR DESCRIPTION
## Type de PR
- [X] Bugfix
- 
## Objectif
Gérer l'état de chargement de manière plus cohérente dans les sections Carte + tableau
Pages concernées : Records et ecart-normale

## Changements
Gestion séparée des chargements des cartes et des tableaux
Ajout d'un skeleton pour les tables, et d'un spinner pour les cartes.

