### PR TITLE
fix: home: fix responsive for Last 365 Days section

### DIFF
--- a/frontend/app/components/home/Card.vue
+++ b/frontend/app/components/home/Card.vue
@@ -20,6 +20,7 @@ const isOpen = ref(false);
             props.withBorder && 'border border-blue-350',
             props.transparent && 'bg-transparent shadow-none ring-0',
         ]"
+        :ui="{ body: props.transparent ? 'p-0' : '' }"
     >
         <template #default>
             <div
@@ -65,7 +66,7 @@ const isOpen = ref(false);
                     <slot name="kpi-context-text" />
                 </span>
             </div>
-            <div v-if="$slots['variation']" class="flex items-center mt-1">
+            <div v-if="$slots['variation']" class="flex items-center mt-2">
                 <span class="text-xs text-blue-700 dark:text-blue-350">
                     <slot name="variation" />
                 </span>

--- a/frontend/app/components/home/HotColdRatioCard.vue
+++ b/frontend/app/components/home/HotColdRatioCard.vue
@@ -51,6 +51,7 @@ const hotPercent = computed(() =>
         </template>
         <template v-if="props.variation !== undefined" #variation>
             <UIcon
+                v-if="props.variation !== 0"
                 :name="
                     props.variation <= 0
                         ? 'i-lucide-arrow-down-right'

--- a/frontend/app/components/home/Last365DaysSection/Itn365Cards.vue
+++ b/frontend/app/components/home/Last365DaysSection/Itn365Cards.vue
@@ -54,8 +54,8 @@ const coldDiff = computed(() => {
 </script>
 
 <template>
-    <div class="flex items-center flex-col gap-2">
-        <div class="flex gap-40 items-start">
+    <div class="flex items-center flex-col gap-4">
+        <div class="flex gap-2 items-start flex-col md:flex-row md:gap-40">
             <div class="w-fit">
                 <Card title="" tooltip-text="" :show-title="false" transparent>
                     <template #kpi>
@@ -82,6 +82,7 @@ const coldDiff = computed(() => {
                     </template>
                     <template v-if="itnDiff != null" #variation>
                         <UIcon
+                            v-if="itnDiff.toFixed(1) !== '0.0'"
                             :name="
                                 itnDiff < 0
                                     ? 'i-lucide-arrow-down-right'
@@ -98,8 +99,7 @@ const coldDiff = computed(() => {
                                 itnDiff < 0 ? 'text-blue-400' : 'text-red-400'
                             "
                         >
-                            {{ itnDiff >= 0 ? "+" : ""
-                            }}{{ itnDiff.toFixed(1) }}°C
+                            {{ itnDiff.toFixed(1) }}°C
                         </span>
                         vs. 365 jours précédents
                     </template>
@@ -114,7 +114,7 @@ const coldDiff = computed(() => {
             </p>
         </div>
 
-        <div class="flex gap-6">
+        <div class="flex gap-6 flex-col md:flex-row">
             <div class="w-fit">
                 <Card
                     title="Nombre de jours anormalement chauds"
@@ -135,6 +135,7 @@ const coldDiff = computed(() => {
                     </template>
                     <template v-if="hotDiff != null" #variation>
                         <UIcon
+                            v-if="hotDiff.toFixed(1) !== '0.0'"
                             :name="
                                 hotDiff < 0
                                     ? 'i-lucide-arrow-down-right'
@@ -143,7 +144,7 @@ const coldDiff = computed(() => {
                             class="text-red-400 font-semibold"
                         />
                         <span class="text-sm font-semibold text-red-400">
-                            {{ hotDiff >= 0 ? "+" : "" }}{{ hotDiff }} jours
+                            {{ hotDiff }} jours
                         </span>
                         vs. 365 jours précédents
                     </template>
@@ -169,6 +170,7 @@ const coldDiff = computed(() => {
                     </template>
                     <template v-if="coldDiff != null" #variation>
                         <UIcon
+                            v-if="coldDiff !== 0"
                             :name="
                                 coldDiff < 0
                                     ? 'i-lucide-arrow-down-right'
@@ -177,7 +179,7 @@ const coldDiff = computed(() => {
                             class="text-blue-400 font-semibold"
                         />
                         <span class="text-sm font-semibold text-blue-400">
-                            {{ coldDiff >= 0 ? "+" : "" }}{{ coldDiff }} jours
+                            {{ coldDiff }} jours
                         </span>
                         vs. 365 jours précédents
                     </template>

--- a/frontend/app/components/home/Last365DaysSection/LastYearSection.vue
+++ b/frontend/app/components/home/Last365DaysSection/LastYearSection.vue
@@ -22,7 +22,9 @@ const { yesterday, yesterdayLess365Days } = useCustomDate();
         <h2 class="text-blue-700 dark:text-primary pb-2 pt-1">
             RECORDS DE TEMPERATURE
         </h2>
-        <div class="flex gap-6 justify-center items-center">
+        <div
+            class="flex gap-6 justify-center items-center flex-col md:flex-row"
+        >
             <RecordsRatioCard class="flex-1" />
             <!-- commenter en attendant l'implémentation -->
             <!-- <div class="flex flex-col gap-2 w-fit">

--- a/frontend/app/components/home/TodaySection/TodaySection.vue
+++ b/frontend/app/components/home/TodaySection/TodaySection.vue
@@ -104,4 +104,3 @@ const lastYearColdRecordsCount = computed(
         <GoToDataLink :data-url="'/records?preset=today'" />
     </Section>
 </template>
-<style lang="css" scoped></style>


### PR DESCRIPTION
## Type de PR
- [x] Bugfix
- [ ] Feature
- [ ] Refactor
- [ ] Chore / Tech debt
- [ ] Documentation
- [ ] Autre (à préciser)

## Objectif
Amélioration du responsive pour la section "Ces 365 derniers jours" de la page d'accueil

## Contexte
https://github.com/dataforgoodfr/14_ValorisationDonneeMeteo/issues/484

## Changements
-

## Décisions techniques
<!-- Choix structurants, arbitrages, compromis. -->
<!-- Ce qui aurait pu être fait autrement. -->

## Impacts
- [ ] API / contrat
- [ ] Modèle de données / DB
- [ ] Calculs métier
- [ ] Performance
- [ ] Sécurité
- [ ] Infra / déploiement
- [ ] Aucun impact transverse identifié

## Tests
<!-- Décris ce qui a été fait dans cette PR pour vérifier le comportement introduit ou modifié. -->
- [ ] Tests unitaires
- [ ] Tests d’intégration
- [ ] Tests manuels
- [ ] Non applicable (à justifier)

## Points d’attention pour la review
<!-- Parties sensibles du code, dette technique introduite, risques. -->

## Suivi
- [ ] Migration à prévoir
- [ ] Documentation à mettre à jour
- [ ] Tâche(s) de suivi à créer
