### PR TITLE
fix(record): remove api call during SSR

### DIFF
--- a/frontend/app/composables/useTemperature.ts
+++ b/frontend/app/composables/useTemperature.ts
@@ -31,9 +31,7 @@ export function useTemperatureDeviation(
         );
     });
 
-    const isEnabled = computed(() =>
-        enabled !== undefined ? toValue(enabled) : true,
-    );
+    const isEnabled = computed(() => toValue(enabled) ?? true);
 
     const result = useApiFetch<TemperatureDeviationResponse>(
         "/temperature/deviation",
@@ -73,9 +71,7 @@ export function useTemperatureDeviationGraph(
         );
     });
 
-    const isEnabled = computed(() =>
-        enabled !== undefined ? toValue(enabled) : true,
-    );
+    const isEnabled = computed(() => toValue(enabled) ?? true);
 
     const result = useApiFetch<TemperatureDeviationGraphResponse>(
         "/temperature/deviation/graph",
@@ -107,9 +103,7 @@ export function useTemperatureRecordsGraph(
 ) {
     const { useApiFetch } = useApiClient();
 
-    const isEnabled = computed(() =>
-        enabled !== undefined ? toValue(enabled) : true,
-    );
+    const isEnabled = computed(() => toValue(enabled) ?? true);
 
     const result = useApiFetch<TemperatureRecordsGraphResponse>(
         "/temperature/records/graph",
@@ -146,9 +140,7 @@ export function useTemperatureRecords(
 ) {
     const { useApiFetch } = useApiClient();
 
-    const isEnabled = computed(() =>
-        enabled !== undefined ? toValue(enabled) : true,
-    );
+    const isEnabled = computed(() => toValue(enabled) ?? true);
 
     const result = useApiFetch<TemperatureRecordsPaginatedResponse>(
         "/temperature/records",

--- a/frontend/app/composables/useTemperature.ts
+++ b/frontend/app/composables/useTemperature.ts
@@ -50,7 +50,7 @@ export function useTemperatureDeviation(
             if (enabled && hasParams) {
                 result.execute();
             } else if (!hasParams) {
-                result.data.value = undefined;
+                result.clear();
             }
         },
         { immediate: true, deep: true },
@@ -92,7 +92,7 @@ export function useTemperatureDeviationGraph(
             if (enabled && hasParams) {
                 result.execute();
             } else if (!hasParams) {
-                result.data.value = undefined;
+                result.clear();
             }
         },
         { immediate: true },
@@ -146,31 +146,28 @@ export function useTemperatureRecords(
 ) {
     const { useApiFetch } = useApiClient();
 
-    if (enabled === undefined) {
-        return useApiFetch<TemperatureRecordsPaginatedResponse>(
-            "/temperature/records",
-            {
-                query: params,
-            },
-        );
-    }
-
-    const isEnabled = toRef(enabled);
+    const isEnabled = computed(() =>
+        enabled !== undefined ? toValue(enabled) : true,
+    );
 
     const result = useApiFetch<TemperatureRecordsPaginatedResponse>(
         "/temperature/records",
         {
             query: params,
-            immediate: isEnabled.value,
+            immediate: false,
             watch: false,
         },
     );
 
-    watch([isEnabled, params], () => {
-        if (isEnabled.value) {
-            result.execute();
-        }
-    });
+    watch(
+        [isEnabled, params],
+        ([enabled]) => {
+            if (enabled) {
+                result.execute();
+            }
+        },
+        { immediate: true },
+    );
 
     return result;
 }

--- a/frontend/app/composables/useTemperature.ts
+++ b/frontend/app/composables/useTemperature.ts
@@ -136,32 +136,16 @@ export function useTemperatureExtremes(
 
 export function useTemperatureRecords(
     params: MaybeRef<TemperatureRecordsParams>,
-    enabled?: MaybeRef<boolean>,
 ) {
     const { useApiFetch } = useApiClient();
 
-    const isEnabled = computed(() => toValue(enabled) ?? true);
-
-    const result = useApiFetch<TemperatureRecordsPaginatedResponse>(
+    return useApiFetch<TemperatureRecordsPaginatedResponse>(
         "/temperature/records",
         {
             query: params,
-            immediate: false,
-            watch: false,
+            server: false,
         },
     );
-
-    watch(
-        [isEnabled, params],
-        ([enabled]) => {
-            if (enabled) {
-                result.execute();
-            }
-        },
-        { immediate: true },
-    );
-
-    return result;
 }
 
 export function useCumulativeRecords(


### PR DESCRIPTION
## Type de PR
- [x] Bugfix
- [ ] Feature
- [ ] Refactor
- [ ] Chore / Tech debt
- [ ] Documentation
- [ ] Autre (à préciser)

## Objectif

Corriger le crash de la page records au premier chargement, qui affichait une erreur 404 à la place des données chaudes.

## Contexte

Lors de la navigation vers /records, useTemperatureRecords déclenchait un fetch côté serveur (SSR). 
Dans l'environnement beta, le serveur Nuxt ne peut pas joindre l'API, ce qui sérialisait une erreur 404 dans le payload d'hydratation. Le client héritait de cet état d'erreur sans retenter jusqu'à ce que l'utilisateur change un paramètre (ex: basculer sur "Froid" puis "Chaud"), ce qui forçait un nouveau fetch côté client, lui réussissant.

Closes #521 

## Changements

useTemperatureRecords : ajout de server: false pour désactiver le fetch SSR. Suppression du paramètre enabled jamais utilisé et du watcher manuel devenu inutile.
Corrige au passage deux erreurs TS préexistantes (result.data.value = undefined → result.clear())

## Décisions techniques

server: false est l'option Nuxt explicite prévue pour désactiver le fetch SSR, plus lisible et plus cohérente avec l'intention que immediate: false. Le paramètre enabled a été supprimé car il n'était appelé nulle part dans le codebase.

## Impacts
- [ ] API / contrat
- [ ] Modèle de données / DB
- [ ] Calculs métier
- [ ] Performance
- [ ] Sécurité
- [ ] Infra / déploiement
- [ ] Aucun impact transverse identifié

## Tests
<!-- Décris ce qui a été fait dans cette PR pour vérifier le comportement introduit ou modifié. -->
- [ ] Tests unitaires
- [ ] Tests d’intégration
- [ ] Tests manuels
- [ ] Non applicable (à justifier)

## Points d’attention pour la review
<!-- Parties sensibles du code, dette technique introduite, risques. -->

## Suivi
- [ ] Migration à prévoir
- [ ] Documentation à mettre à jour
- [ ] Tâche(s) de suivi à créer
