### PR TITLE
Fix: Front/ITN/ Ajout etat pending dans le template (ItnKpiPanel)

### DIFF
--- a/frontend/app/components/charts/ItnKpiPanel.vue
+++ b/frontend/app/components/charts/ItnKpiPanel.vue
@@ -6,28 +6,37 @@
         >
             <template #kpi>
                 <p class="font-semibold text-4xl mb-1 text-red-400">
-                    <span v-if="kpi != null"
+                    <USkeleton v-if="pending" class="size-12 rounded-full" />
+
+                    <span v-else-if="kpi != null"
                         >{{ kpi.itn_mean?.toFixed(1) }} °C</span
                     >
+
                     <span v-else class="text-muted">—</span>
                 </p>
             </template>
-            <template v-if="kpi?.deviation_from_normal != null" #variation>
-                <span class="text-sm">
-                    {{ kpi.deviation_from_normal >= 0 ? "+" : ""
-                    }}{{ kpi.deviation_from_normal.toFixed(1) }} °C
-                </span>
-                <UIcon
-                    v-if="kpi.deviation_from_normal < 0"
-                    name="i-lucide-arrow-down-right"
-                    class="text-blue-400"
-                />
-                <UIcon
-                    v-if="kpi.deviation_from_normal > 0"
-                    name="i-lucide-arrow-up-right"
-                    class="text-red-400"
-                />
-                vs période des normales
+            <template #variation>
+                <USkeleton v-if="pending" class="h-2 w-full" />
+
+                <template v-else-if="kpi?.deviation_from_normal != null">
+                    <span class="text-sm">
+                        {{ kpi.deviation_from_normal >= 0 ? "+" : ""
+                        }}{{ kpi.deviation_from_normal.toFixed(1) }} °C
+                    </span>
+                    <UIcon
+                        v-if="kpi.deviation_from_normal < 0"
+                        name="i-lucide-arrow-down-right"
+                        class="text-blue-400"
+                    />
+                    <UIcon
+                        v-if="kpi.deviation_from_normal > 0"
+                        name="i-lucide-arrow-up-right"
+                        class="text-red-400"
+                    />
+                    vs période des normales
+                </template>
+
+                <span v-else class="text-muted">—</span>
             </template>
         </Card>
 
@@ -37,25 +46,36 @@
         >
             <template #kpi>
                 <p class="font-semibold text-4xl mb-1 text-red-400">
-                    <span v-if="kpi != null">{{ kpi.hot_peak_count }}</span>
+                    <USkeleton v-if="pending" class="size-12 rounded-full" />
+
+                    <span v-else-if="kpi != null">{{
+                        kpi.hot_peak_count
+                    }}</span>
+
                     <span v-else class="text-muted">—</span>
                 </p>
             </template>
-            <template v-if="hotDiff != null" #variation>
-                <span class="text-sm">
-                    {{ hotDiff >= 0 ? "+" : "" }}{{ hotDiff }}
-                </span>
-                <UIcon
-                    v-if="hotDiff < 0"
-                    name="i-lucide-arrow-down-right"
-                    class="text-red-400"
-                />
-                <UIcon
-                    v-if="hotDiff > 0"
-                    name="i-lucide-arrow-up-right"
-                    class="text-red-400"
-                />
-                vs période précédente
+            <template #variation>
+                <USkeleton v-if="pending" class="h-2 w-full" />
+
+                <template v-else-if="hotDiff != null">
+                    <span class="text-sm">
+                        {{ hotDiff >= 0 ? "+" : "" }}{{ hotDiff }}
+                    </span>
+                    <UIcon
+                        v-if="hotDiff < 0"
+                        name="i-lucide-arrow-down-right"
+                        class="text-red-400"
+                    />
+                    <UIcon
+                        v-if="hotDiff > 0"
+                        name="i-lucide-arrow-up-right"
+                        class="text-red-400"
+                    />
+                    vs période précédente
+                </template>
+
+                <span v-else class="text-muted">—</span>
             </template>
         </Card>
 
@@ -65,25 +85,34 @@
         >
             <template #kpi>
                 <p class="font-semibold text-4xl mb-1 text-blue-400">
-                    <span v-if="kpi != null">{{ kpi.cold_peak_count }}</span>
+                    <USkeleton v-if="pending" class="size-12 rounded-full" />
+                    <span v-else-if="kpi != null">{{
+                        kpi.cold_peak_count
+                    }}</span>
                     <span v-else class="text-muted">—</span>
                 </p>
             </template>
-            <template v-if="coldDiff != null" #variation>
-                <span class="text-sm">
-                    {{ coldDiff >= 0 ? "+" : "" }}{{ coldDiff }}
-                </span>
-                <UIcon
-                    v-if="coldDiff < 0"
-                    name="i-lucide-arrow-down-right"
-                    class="text-blue-400"
-                />
-                <UIcon
-                    v-if="coldDiff > 0"
-                    name="i-lucide-arrow-up-right"
-                    class="text-blue-400"
-                />
-                vs période précédente
+            <template #variation>
+                <USkeleton v-if="pending" class="h-2 w-full" />
+
+                <template v-else-if="coldDiff != null">
+                    <span class="text-sm">
+                        {{ coldDiff >= 0 ? "+" : "" }}{{ coldDiff }}
+                    </span>
+                    <UIcon
+                        v-if="coldDiff < 0"
+                        name="i-lucide-arrow-down-right"
+                        class="text-blue-400"
+                    />
+                    <UIcon
+                        v-if="coldDiff > 0"
+                        name="i-lucide-arrow-up-right"
+                        class="text-blue-400"
+                    />
+                    vs période précédente
+                </template>
+
+                <span v-else class="text-muted">—</span>
             </template>
         </Card>
     </div>
@@ -103,7 +132,7 @@ const params = computed<NationalIndicatorKpiParams>(() => ({
     date_end: dateToStringYMD(pickedDateEnd.value),
 }));
 
-const { data: kpi } = useNationalIndicatorKpi(params);
+const { data: kpi, pending } = useNationalIndicatorKpi(params);
 
 const hotDiff = computed(() => {
     if (kpi.value == null) return null;

--- a/frontend/app/components/home/Card.vue
+++ b/frontend/app/components/home/Card.vue
@@ -60,16 +60,16 @@ const isOpen = ref(false);
                 </span>
             </div>
             <div v-if="$slots['kpi-context-text']" class="mt-2">
-                <span
-                    class="kpi-context-text text-xs text-slate-600 dark:text-slate-300 leading-none"
+                <div
+                    class="kpi-context-text text-xs text-slate-600 dark:text-slate-300 leading-none w-full"
                 >
                     <slot name="kpi-context-text" />
-                </span>
+                </div>
             </div>
             <div v-if="$slots['variation']" class="flex items-center mt-2">
-                <span class="text-xs text-blue-700 dark:text-blue-350">
+                <div class="text-xs text-blue-700 dark:text-blue-350 w-full">
                     <slot name="variation" />
-                </span>
+                </div>
             </div>
         </template>
     </UCard>


### PR DESCRIPTION
## Type de PR
- [x] Bugfix
- [ ] Feature
- [ ] Refactor
- [ ] Chore / Tech debt
- [ ] Documentation
- [ ] Autre (à préciser)

## Objectif
Ajout d'un état de loading sur les cards KPI de la page ITN
<img width="324" height="518" alt="Capture d’écran 2026-05-05 à 14 02 40" src="https://github.com/user-attachments/assets/f2a6d48d-6436-4ec7-9e41-0512cef84c26" />

## Contexte
(https://github.com/dataforgoodfr/14_ValorisationDonneeMeteo/issues/501)

Les cards sur la page ITN mettent énormément de temps à charger (22 secondes pour la granularité "year").

## Changements
Ajout d'un état "pending" dans le template de ItnKpiPanel

## Décisions techniques
<!-- Choix structurants, arbitrages, compromis. -->
<!-- Ce qui aurait pu être fait autrement. -->

## Impacts
- [ ] API / contrat
- [ ] Modèle de données / DB
- [ ] Calculs métier
- [ ] Performance
- [ ] Sécurité
- [ ] Infra / déploiement
- [ ] Aucun impact transverse identifié

## Tests
<!-- Décris ce qui a été fait dans cette PR pour vérifier le comportement introduit ou modifié. -->
- [ ] Tests unitaires
- [ ] Tests d’intégration
- [ ] Tests manuels
- [ ] Non applicable (à justifier)

## Points d’attention pour la review
<!-- Parties sensibles du code, dette technique introduite, risques. -->

## Suivi
- [ ] Migration à prévoir
- [ ] Documentation à mettre à jour
- [ ] Tâche(s) de suivi à créer
