### PR TITLE
fix(tooltip): add style to keep bg tooltip

### DIFF
--- a/frontend/app/components/itn/ItnStationMap.vue
+++ b/frontend/app/components/itn/ItnStationMap.vue
@@ -10,11 +10,11 @@
 
 <script setup lang="ts">
 import maplibregl from "maplibre-gl";
-import "maplibre-gl/dist/maplibre-gl.css";
 import * as topojson from "topojson-client";
 import type { FeatureCollection, Geometry } from "geojson";
 import type { ItnStation } from "~/types/api";
 import type { FranceTopology } from "~/types/map";
+import { useMapColors } from "~/constants/colors";
 
 const props = defineProps<{
     stations: ItnStation[];
@@ -29,11 +29,14 @@ const mapContainer = ref<HTMLDivElement | null>(null);
 let map: maplibregl.Map | null = null;
 const mapReady = ref(false);
 
+const mapColors = useMapColors();
+const tooltipBg = computed(() => mapColors.value.background);
+
 const popup = new maplibregl.Popup({
     closeButton: false,
     closeOnClick: false,
     offset: 10,
-    className: "bg-transparent",
+    className: "itn-map-popup",
 });
 
 const BLANK_STYLE: maplibregl.StyleSpecification = {
@@ -222,16 +225,17 @@ watch(
 );
 </script>
 
-<style>
-.maplibregl-popup-content {
-    background: transparent;
-    box-shadow: none;
-    padding: 0;
+<style scoped>
+:deep(.itn-map-popup .maplibregl-popup-content) {
+    background: v-bind(tooltipBg);
+    overflow: hidden;
 }
-.maplibregl-popup-tip {
+
+:deep(.itn-map-popup .maplibregl-popup-tip) {
     display: none;
 }
-.itn-popup-label {
+
+:deep(.itn-popup-label) {
     color: var(--color-blue-450);
     font-weight: 600;
     font-size: var(--text-s);

--- a/frontend/app/components/map/StationMap.vue
+++ b/frontend/app/components/map/StationMap.vue
@@ -34,7 +34,6 @@
 
 <script setup lang="ts">
 import maplibregl from "maplibre-gl";
-import "maplibre-gl/dist/maplibre-gl.css";
 import * as topojson from "topojson-client";
 import type { FeatureCollection, Geometry, Point } from "geojson";
 import type {
@@ -157,6 +156,7 @@ function initLayers() {
         closeButton: false,
         closeOnClick: false,
         offset: 8,
+        className: "station-map-popup",
     });
 
     map.on("mouseenter", "stations-circles", (e) => {
@@ -332,4 +332,16 @@ watch(mapColors, (colors) => {
     map.setPaintProperty("france-dep-border", "line-color", colors.foreground);
     map.setPaintProperty("france-reg-border", "line-color", colors.foreground);
 });
+
+const tooltipBg = computed(() => mapColors.value.background);
 </script>
+
+<style scoped>
+:deep(.station-map-popup .maplibregl-popup-content) {
+    background: v-bind(tooltipBg);
+}
+
+:deep(.station-map-popup .maplibregl-popup-tip) {
+    display: none;
+}
+</style>


### PR DESCRIPTION
## Type de PR
- [x] Bugfix
- [ ] Feature
- [ ] Refactor
- [ ] Chore / Tech debt
- [ ] Documentation
- [ ] Autre (à préciser)

## Objectif
Corriger le fond transparent des tooltips de carte, illisibles en dark mode et après navigation SPA.

## Contexte
Les tooltips MapLibre héritaient du fond blanc par défaut de la lib, non adapté au thème sombre.
Un contournement global avait été tenté (<style> non scoped dans ItnStationMap.vue), mais polluait tous les popups de l'app et causait une régression après navigation SPA.

Closes #512 

## Changements
- ItnStationMap.vue : conversion du <style> global en <style scoped> avec :deep(), className: "itn-map-popup", fond opaque via useMapColors()
 - StationMap.vue : ajout de className: "station-map-popup" + <style scoped> avec fond réactif au thème via v-bind()
 - Suppression des import "maplibre-gl/dist/maplibre-gl.css" redondants (CSS déjà chargé globalement via CDN dans nuxt.config.ts)

## Décisions techniques
Chaque composant carte utilise une className dédiée sur le Popup MapLibre, ce qui permet de cibler ses popups sans affecter les autres. Le fond est injecté via v-bind() dans un <style scoped> plutôt que via des variables CSS globales ou des overrides !important, pour rester réactif au thème et isolé au composant. 

## Impacts
- [ ] API / contrat
- [ ] Modèle de données / DB
- [ ] Calculs métier
- [ ] Performance
- [ ] Sécurité
- [ ] Infra / déploiement
- [ ] Aucun impact transverse identifié

## Tests
<!-- Décris ce qui a été fait dans cette PR pour vérifier le comportement introduit ou modifié. -->
- [ ] Tests unitaires
- [ ] Tests d’intégration
- [ ] Tests manuels
- [ ] Non applicable (à justifier)

## Points d’attention pour la review
<!-- Parties sensibles du code, dette technique introduite, risques. -->

## Suivi
- [ ] Migration à prévoir
- [ ] Documentation à mettre à jour
- [ ] Tâche(s) de suivi à créer
