### PR TITLE
feat: home: display equal when no variation

### DIFF
--- a/frontend/app/components/home/Card.vue
+++ b/frontend/app/components/home/Card.vue
@@ -59,7 +59,7 @@ const isOpen = ref(false);
                     <slot name="kpi-context-box" />
                 </span>
             </div>
-            <div v-if="$slots['kpi-context-text']" class="mt-2">
+            <div v-if="$slots['kpi-context-text']" class="mt-3">
                 <div
                     class="kpi-context-text text-xs text-slate-600 dark:text-slate-300 leading-none w-full"
                 >
@@ -67,7 +67,9 @@ const isOpen = ref(false);
                 </div>
             </div>
             <div v-if="$slots['variation']" class="flex items-center mt-2">
-                <div class="text-xs text-blue-700 dark:text-blue-350 w-full">
+                <div
+                    class="text-xs text-blue-700 dark:text-blue-350 leading-none w-full"
+                >
                     <slot name="variation" />
                 </div>
             </div>

--- a/frontend/app/components/home/HotColdRatioCard.vue
+++ b/frontend/app/components/home/HotColdRatioCard.vue
@@ -61,11 +61,13 @@ const hotPercent = computed(() =>
                 class="font-semibold"
             />
             <span
+                v-if="props.variation !== 0"
                 class="text-sm font-semibold"
-                :class="props.variation <= 0 ? 'text-blue-600' : 'text-red-450'"
+                :class="props.variation < 0 ? 'text-blue-600' : 'text-red-450'"
             >
                 {{ props.variation > 0 ? "+" : "" }}{{ props.variation }} points
             </span>
+            <span v-else class="text-sm font-semibold text-blue-600"> = </span>
             vs. période précédente
         </template>
         <template #kpi-context-text>

--- a/frontend/app/components/home/ImportantInformationSection/ITNCard.vue
+++ b/frontend/app/components/home/ImportantInformationSection/ITNCard.vue
@@ -2,7 +2,7 @@
 import type { NationalIndicatorParams } from "~/types/api";
 import Card from "../Card.vue";
 
-const { yesterday } = useCustomDate();
+const { yesterday, yesterdayLastYear } = useCustomDate();
 
 const yesterdayParams = computed<NationalIndicatorParams>(() => ({
     date_start: dateToStringYMD(yesterday.value),
@@ -19,6 +19,29 @@ const yesterdayTemperature = computed(() => {
 const gap = computed(() => {
     const result = yesterdayData.value?.time_series[0];
     return result ? result.temperature - result.baseline_mean : undefined;
+});
+
+const yesterdayLastYearParams = computed<NationalIndicatorParams>(() => ({
+    date_start: dateToStringYMD(yesterdayLastYear.value),
+    date_end: dateToStringYMD(yesterdayLastYear.value),
+    granularity: "day",
+    slice_type: "full",
+}));
+
+const { data: yesterdayLastYearData } = useNationalIndicator(
+    yesterdayLastYearParams,
+    true,
+);
+
+const yesterdayLastYearTemperature = computed(
+    () => yesterdayLastYearData.value?.time_series[0]?.temperature,
+);
+const temperatureChangeYearOverYear = computed<number | undefined>(() => {
+    if (!yesterdayTemperature.value || !yesterdayLastYearTemperature.value) {
+        return undefined;
+    }
+
+    return yesterdayLastYearTemperature.value - yesterdayTemperature.value;
 });
 </script>
 <template>
@@ -40,8 +63,39 @@ const gap = computed(() => {
             </p>
         </template>
         <template v-if="gap" #kpi-context-box>
-            {{ gap != null && gap > 0 ? "+" : "" }}{{ gap?.toFixed(1) }}°C vs
+            {{ gap?.toFixed(1) === "0.0" ? "= " : gap > 0 ? "+" : ""
+            }}{{ gap?.toFixed(1) === "0.0" ? "" : gap?.toFixed(1) + "°C " }}vs
             normale 1991-2020
+        </template>
+        <template #variation>
+            <UIcon
+                v-if="(temperatureChangeYearOverYear ?? 0) < 0"
+                name="i-lucide-arrow-down-right font-semibold"
+                class="text-blue-600"
+            />
+            <UIcon
+                v-if="(temperatureChangeYearOverYear ?? 0) > 0"
+                name="i-lucide-arrow-up-right font-semibold"
+                class="text-red-450"
+            />
+            <span
+                v-if="temperatureChangeYearOverYear?.toFixed(1) !== '0.0'"
+                class="text-sm font-semibold"
+                :class="
+                    (temperatureChangeYearOverYear ?? 0) <= 0
+                        ? 'text-blue-600'
+                        : 'text-red-450'
+                "
+            >
+                {{ temperatureChangeYearOverYear?.toFixed(1) }}°C
+            </span>
+            <span v-else class="text-sm font-semibold text-blue-600">=</span>
+            vs
+            {{
+                toValue(yesterdayLastYear).toLocaleDateString("fr-FR", {
+                    dateStyle: "long",
+                })
+            }}
         </template>
     </Card>
 </template>

--- a/frontend/app/components/home/Last365DaysSection/Itn365Cards.vue
+++ b/frontend/app/components/home/Last365DaysSection/Itn365Cards.vue
@@ -73,9 +73,18 @@ const coldDiff = computed(() => {
                         v-if="deviationFromNormal != null"
                         #kpi-context-box
                     >
-                        {{ deviationFromNormal >= 0 ? "+" : ""
-                        }}{{ deviationFromNormal.toFixed(1) }}°C vs normale
-                        1991-2020
+                        {{
+                            deviationFromNormal.toFixed(1) === "0.0"
+                                ? "= "
+                                : deviationFromNormal > 0
+                                  ? "+"
+                                  : ""
+                        }}
+                        {{
+                            deviationFromNormal.toFixed(1) === "0.0"
+                                ? ""
+                                : deviationFromNormal.toFixed(1) + "°C "
+                        }}vs normale 1991-2020
                     </template>
                     <template #kpi-context-text>
                         en moyenne ces 365 derniers jours
@@ -98,8 +107,13 @@ const coldDiff = computed(() => {
                             :class="
                                 itnDiff < 0 ? 'text-blue-400' : 'text-red-400'
                             "
-                        >
-                            {{ itnDiff.toFixed(1) }}°C
+                            >{{
+                                itnDiff.toFixed(1) !== "0.0"
+                                    ? (itnDiff > 0 ? "+" : "") +
+                                      itnDiff.toFixed(1) +
+                                      "°C"
+                                    : "="
+                            }}
                         </span>
                         vs. 365 jours précédents
                     </template>
@@ -143,9 +157,15 @@ const coldDiff = computed(() => {
                             "
                             class="text-red-400 font-semibold"
                         />
-                        <span class="text-sm font-semibold text-red-400">
-                            {{ hotDiff }} jours
+                        <span
+                            v-if="hotDiff !== 0"
+                            class="text-sm font-semibold text-red-400"
+                        >
+                            {{ hotDiff > 0 ? "+" : "" }}{{ hotDiff }} jours
                         </span>
+                        <span v-else class="text-sm font-semibold text-red-400"
+                            >=</span
+                        >
                         vs. 365 jours précédents
                     </template>
                 </Card>
@@ -178,9 +198,15 @@ const coldDiff = computed(() => {
                             "
                             class="text-blue-400 font-semibold"
                         />
-                        <span class="text-sm font-semibold text-blue-400">
-                            {{ coldDiff }} jours
+                        <span
+                            v-if="coldDiff !== 0"
+                            class="text-sm font-semibold text-blue-400"
+                        >
+                            {{ coldDiff > 0 ? "+" : "" }}{{ coldDiff }} jours
                         </span>
+                        <span v-else class="text-sm font-semibold text-blue-400"
+                            >=</span
+                        >
                         vs. 365 jours précédents
                     </template>
                 </Card>

--- a/frontend/app/components/home/TemperatureRecord.vue
+++ b/frontend/app/components/home/TemperatureRecord.vue
@@ -46,8 +46,13 @@ const props = defineProps<Props>();
                     :name="'i-lucide-arrow-down-right'"
                     class="text-blue-600"
                 />
-                <span class="text-sm font-semibold text-blue-600">
-                    {{ props.difference }}
+                <span
+                    class="text-sm font-semibold"
+                    :class="
+                        props.type === 'hot' ? 'text-rose-600' : 'text-blue-600'
+                    "
+                >
+                    {{ props.difference !== 0 ? props.difference : "=" }}
                 </span>
                 <span class="text-sm"> vs {{ props.compareTo }} </span>
             </template>


### PR DESCRIPTION
## Type de PR
- [x] Bugfix
- [ ] Feature
- [ ] Refactor
- [ ] Chore / Tech debt
- [ ] Documentation
- [ ] Autre (à préciser)

## Objectif
- Afficher un `=` quand la variation est de 0, sur les KPI de la page d'accueil
- J'ai remis une partie du code sur la Card de l'ITN car ça avait été supprimé (problème de rebase ?) 

## Contexte
https://github.com/dataforgoodfr/14_ValorisationDonneeMeteo/issues/503

## Changements
-

## Décisions techniques
<!-- Choix structurants, arbitrages, compromis. -->
<!-- Ce qui aurait pu être fait autrement. -->

## Impacts
- [ ] API / contrat
- [ ] Modèle de données / DB
- [ ] Calculs métier
- [ ] Performance
- [ ] Sécurité
- [ ] Infra / déploiement
- [ ] Aucun impact transverse identifié

## Tests
<!-- Décris ce qui a été fait dans cette PR pour vérifier le comportement introduit ou modifié. -->
- [ ] Tests unitaires
- [ ] Tests d’intégration
- [ ] Tests manuels
- [ ] Non applicable (à justifier)

## Points d’attention pour la review
<!-- Parties sensibles du code, dette technique introduite, risques. -->

## Suivi
- [ ] Migration à prévoir
- [ ] Documentation à mettre à jour
- [ ] Tâche(s) de suivi à créer
