### PR TITLE
fix: deviation: display negative deviation in blue

### DIFF
--- a/frontend/app/components/map/MapD3.vue
+++ b/frontend/app/components/map/MapD3.vue
@@ -7,10 +7,17 @@
             tooltip-text="Ecart à la normale moyen en France métropolitaine sur la période sélectionnée."
         >
             <template #kpi>
-                <p class="font-semibold text-4xl mb-1 text-red-400">
-                    <span v-if="kpi?.deviation_from_normal != null">
-                        {{ kpi.deviation_from_normal >= 0 ? "+" : ""
-                        }}{{ kpi.deviation_from_normal.toFixed(1) }} °C
+                <p
+                    class="font-semibold text-4xl mb-1"
+                    :class="
+                        deviation && deviation > 0
+                            ? 'text-red-400'
+                            : 'text-blue-400'
+                    "
+                >
+                    <span v-if="deviation != null">
+                        {{ deviation > 0 ? "+" : ""
+                        }}{{ deviation.toFixed(1) }} °C
                     </span>
                     <span v-else class="text-muted">—</span>
                 </p>
@@ -52,6 +59,8 @@ const paramsItn = computed<NationalIndicatorKpiParams>(() => ({
 }));
 
 const { data: kpi } = useNationalIndicatorKpi(paramsItn);
+
+const deviation = computed(() => kpi.value?.deviation_from_normal);
 
 const params = computed<DeviationMapParams>(() => ({
     date_start: props.dateStart,


### PR DESCRIPTION
## Type de PR
- [x] Bugfix
- [ ] Feature
- [ ] Refactor
- [ ] Chore / Tech debt
- [ ] Documentation
- [ ] Autre (à préciser)

## Objectif
Afficher en bleu les écarts négatifs sur la page Ecart à la normale dans l'encart au dessus de la Carte

<img width="837" height="437" alt="Capture d’écran 2026-05-06 à 09 48 16" src="https://github.com/user-attachments/assets/d63f0bd4-a0da-4f93-81c9-0f96d2acfe86" />

## Contexte
https://github.com/dataforgoodfr/14_ValorisationDonneeMeteo/issues/498

## Changements
-



## Décisions techniques
<!-- Choix structurants, arbitrages, compromis. -->
<!-- Ce qui aurait pu être fait autrement. -->

## Impacts
- [ ] API / contrat
- [ ] Modèle de données / DB
- [ ] Calculs métier
- [ ] Performance
- [ ] Sécurité
- [ ] Infra / déploiement
- [ ] Aucun impact transverse identifié

## Tests
<!-- Décris ce qui a été fait dans cette PR pour vérifier le comportement introduit ou modifié. -->
- [ ] Tests unitaires
- [ ] Tests d’intégration
- [ ] Tests manuels
- [ ] Non applicable (à justifier)

## Points d’attention pour la review
<!-- Parties sensibles du code, dette technique introduite, risques. -->

## Suivi
- [ ] Migration à prévoir
- [ ] Documentation à mettre à jour
- [ ] Tâche(s) de suivi à créer
