### PR TITLE
Fix/itn/kpi data

### DIFF
--- a/frontend/app/components/charts/ItnKpiPanel.vue
+++ b/frontend/app/components/charts/ItnKpiPanel.vue
@@ -6,8 +6,11 @@
         >
             <template #kpi>
                 <p class="font-semibold text-4xl mb-1 text-red-400">
-                    <USkeleton v-if="pending" class="size-12 rounded-full" />
-
+                    <UIcon
+                        v-if="pending"
+                        name="i-lucide-loader-circle"
+                        class="animate-spin text-5xl text-muted"
+                    />
                     <span v-else-if="kpi != null"
                         >{{ kpi.itn_mean?.toFixed(1) }} °C</span
                     >
@@ -46,7 +49,11 @@
         >
             <template #kpi>
                 <p class="font-semibold text-4xl mb-1 text-red-400">
-                    <USkeleton v-if="pending" class="size-12 rounded-full" />
+                    <UIcon
+                        v-if="pending"
+                        name="i-lucide-loader-circle"
+                        class="animate-spin text-5xl text-muted"
+                    />
 
                     <span v-else-if="kpi != null">{{
                         kpi.hot_peak_count
@@ -85,7 +92,11 @@
         >
             <template #kpi>
                 <p class="font-semibold text-4xl mb-1 text-blue-400">
-                    <USkeleton v-if="pending" class="size-12 rounded-full" />
+                    <UIcon
+                        v-if="pending"
+                        name="i-lucide-loader-circle"
+                        class="animate-spin text-5xl text-muted"
+                    />
                     <span v-else-if="kpi != null">{{
                         kpi.cold_peak_count
                     }}</span>

--- a/frontend/app/composables/useApiClient.ts
+++ b/frontend/app/composables/useApiClient.ts
@@ -32,9 +32,10 @@ export function useApiClient() {
         );
 
         const result = useApiFetch<T>(endpoint, {
-            query: params,
+            query: computed(() => toValue(params)),
             immediate: false,
             watch: false,
+            key: `${toValue(endpoint)}-${Math.random()}`, // Bypass useFetch cache sharing between pages
         });
 
         watch(


### PR DESCRIPTION
## Type de PR
- [x] Bugfix
- [ ] Feature
- [ ] Refactor
- [ ] Chore / Tech debt
- [ ] Documentation
- [ ] Autre (à préciser)

## Objectif
Les pages Home et ITN partage une même requête. Au changement de page Home -> ITN, les kpi ne se mettaient plus à jour. La requête gardait les queries de la page précédente malgré le changement de params. 

## Contexte
(https://github.com/dataforgoodfr/14_ValorisationDonneeMeteo/issues/502)

## Changements
On force nuxt a récréer une nouvelle requête.
+
Ajout d'un loader pour que le chargement soit plus visible.

<img width="265" height="539" alt="Capture d’écran 2026-05-06 à 13 43 22" src="https://github.com/user-attachments/assets/e3e7e044-8404-4ecb-9f61-37c0f0210662" />


## Décisions techniques
<!-- Choix structurants, arbitrages, compromis. -->
<!-- Ce qui aurait pu être fait autrement. -->

## Impacts
- [ ] API / contrat
- [ ] Modèle de données / DB
- [ ] Calculs métier
- [ ] Performance
- [ ] Sécurité
- [ ] Infra / déploiement
- [ ] Aucun impact transverse identifié

## Tests
<!-- Décris ce qui a été fait dans cette PR pour vérifier le comportement introduit ou modifié. -->
- [ ] Tests unitaires
- [ ] Tests d’intégration
- [x] Tests manuels
- [ ] Non applicable (à justifier)

## Points d’attention pour la review
<!-- Parties sensibles du code, dette technique introduite, risques. -->

## Suivi
- [ ] Migration à prévoir
- [ ] Documentation à mettre à jour
- [ ] Tâche(s) de suivi à créer
