### PR TITLE
Feat/itn/show 3 years when switching to stacked

### DIFF
--- a/frontend/app/components/ui/commons/selectBar/stackedYearPicker.vue
+++ b/frontend/app/components/ui/commons/selectBar/stackedYearPicker.vue
@@ -31,11 +31,20 @@ const label = computed(() => {
         .sort((a, b) => a - b)
         .join(", ");
 });
+
+const open = ref(false);
+
+// Open the popover when switching the chartType to "stacked", to prompt the user to select years.
+// This relies on the fact that the component is unmounted and remounted when switching the chartType, which is currently the case in SelectBar.vue.
+// See the US here: https://github.com/dataforgoodfr/14_ValorisationDonneeMeteo/issues/527.
+onMounted(() => {
+    open.value = true;
+});
 </script>
 
 <template>
     <UFormField label="Années" name="stacked-years">
-        <UPopover :content="{ align: 'start' }">
+        <UPopover v-model:open="open" :content="{ align: 'start' }">
             <UButton
                 color="neutral"
                 variant="outline"

--- a/frontend/app/stores/itnStore.ts
+++ b/frontend/app/stores/itnStore.ts
@@ -35,7 +35,13 @@ export const useItnStore = defineStore("itnStore", () => {
     const chartType = ref<ChartType>("line");
 
     // Stacked mode: années sélectionnées et données fusionnées
-    const selectedYears = ref<number[]>([new Date().getFullYear()]);
+    const currentYear = new Date().getFullYear();
+    // Show the last 3 years by default to show the user the value of the stacked mode.
+    const selectedYears = ref<number[]>([
+        currentYear - 2,
+        currentYear - 1,
+        currentYear,
+    ]);
     const stackedData = ref<NationalIndicatorResponse | null>(null);
     const stackedPending = ref(false);
     const stackedDataCache = new Map<number, NationalIndicatorResponse>();


### PR DESCRIPTION
## Type de PR
- [ ] Bugfix
- [x] Feature
- [ ] Refactor
- [ ] Chore / Tech debt
- [ ] Documentation
- [ ] Autre (à préciser)

## Objectif

 Afficher l'année en cours, l'année N-1 et l'année N-2 quand l'utilsiateur switch en mode stacked sur graphe ITN.

## Contexte

https://github.com/dataforgoodfr/14_ValorisationDonneeMeteo/issues/527

## Changements
- Afficher automatiquement les 3 dernières années quand on active le mode stacked.
- Ouvrir le popover de sélection des années quand on active le mode stacked.

## Décisions techniques
<!-- Choix structurants, arbitrages, compromis. -->
<!-- Ce qui aurait pu être fait autrement. -->

## Impacts
- [ ] API / contrat
- [ ] Modèle de données / DB
- [ ] Calculs métier
- [ ] Performance
- [ ] Sécurité
- [ ] Infra / déploiement
- [ ] Aucun impact transverse identifié

## Tests
<!-- Décris ce qui a été fait dans cette PR pour vérifier le comportement introduit ou modifié. -->
- [ ] Tests unitaires
- [ ] Tests d’intégration
- [x] Tests manuels
- [ ] Non applicable (à justifier)

## Points d’attention pour la review
<!-- Parties sensibles du code, dette technique introduite, risques. -->

## Suivi
- [ ] Migration à prévoir
- [ ] Documentation à mettre à jour
- [ ] Tâche(s) de suivi à créer
