### PR TITLE
fix: wrap the Export button on small screens

### DIFF
--- a/frontend/app/components/ui/commons/selectBar/selectBar.vue
+++ b/frontend/app/components/ui/commons/selectBar/selectBar.vue
@@ -107,7 +107,7 @@ const granularityValues = computed(() => [
         />
 
         <!-- Paramètre d'analyse + Export -->
-        <div class="flex flex-1 gap-6 items-center">
+        <div class="flex flex-1 gap-6 items-center flex-wrap">
             <template
                 v-if="
                     (adapter.features.hasSliceType &&
@@ -183,7 +183,7 @@ const granularityValues = computed(() => [
                     </div>
                 </div>
             </template>
-            <ExportMenu v-if="adapter.features.hasExport" class="ml-auto" />
+            <ExportMenu v-if="adapter.features.hasExport" class="md:ml-auto" />
         </div>
     </div>
 </template>


### PR DESCRIPTION
## Type de PR
- [ ] Bugfix
- [ ] Feature
- [ ] Refactor
- [ ] Chore / Tech debt
- [ ] Documentation
- [ ] Autre (à préciser)

## Objectif

 En sélectionnant une période de moyenne et d'analyse pour les 3 graphes (deviation, records, itn) le bouton export est accessible en mobile

## Contexte

https://github.com/dataforgoodfr/14_ValorisationDonneeMeteo/issues/493

## Changements
-

## Décisions techniques
<!-- Choix structurants, arbitrages, compromis. -->
<!-- Ce qui aurait pu être fait autrement. -->

## Impacts
- [ ] API / contrat
- [ ] Modèle de données / DB
- [ ] Calculs métier
- [ ] Performance
- [ ] Sécurité
- [ ] Infra / déploiement
- [ ] Aucun impact transverse identifié

## Tests
<!-- Décris ce qui a été fait dans cette PR pour vérifier le comportement introduit ou modifié. -->
- [ ] Tests unitaires
- [ ] Tests d’intégration
- [x] Tests manuels
- [ ] Non applicable (à justifier)

## Points d’attention pour la review
<!-- Parties sensibles du code, dette technique introduite, risques. -->

## Suivi
- [ ] Migration à prévoir
- [ ] Documentation à mettre à jour
- [ ] Tâche(s) de suivi à créer
