### PR TITLE
feat/front: replace ITN extremes shaded area with dashed min/max lines

### DIFF
--- a/frontend/app/components/charts/ItnChart.vue
+++ b/frontend/app/components/charts/ItnChart.vue
@@ -132,8 +132,8 @@ function buildStackedOption(
         const p = baselineByPos.get(pos)!;
         return [
             pos,
-            undefined, // p.baseline_min, // TODO: Enable when extremes are available
-            undefined, // p.baseline_max - p.baseline_min, // TODO: Enable when extremes are available
+            p.baseline_min,
+            p.baseline_max,
             p.baseline_std_dev_lower,
             p.baseline_std_dev_upper - p.baseline_std_dev_lower,
             p.baseline_mean,
@@ -142,25 +142,28 @@ function buildStackedOption(
 
     const baselineSeries: ECOption["series"] = [
         {
+            name: ITN_SERIES.extremes,
             type: "line",
             encode: { x: "position", y: "baseline_min" },
-            stack: "extreme",
-            stackStrategy: "all",
             symbol: "none",
-            lineStyle: { opacity: 0 },
-            areaStyle: { color: "transparent" },
-            tooltip: { show: false },
+            color: itnColors.value.extremes,
+            lineStyle: {
+                type: "dashed",
+                width: 1.5,
+                color: itnColors.value.extremes,
+            },
         },
         {
             name: ITN_SERIES.extremes,
             type: "line",
-            encode: { x: "position", y: "baseline_band" },
-            stack: "extreme",
-            stackStrategy: "all",
+            encode: { x: "position", y: "baseline_max" },
             symbol: "none",
             color: itnColors.value.extremes,
-            lineStyle: { opacity: 0 },
-            areaStyle: { color: itnColors.value.extremes },
+            lineStyle: {
+                type: "dashed",
+                width: 1.5,
+                color: itnColors.value.extremes,
+            },
         },
         {
             type: "line",
@@ -212,7 +215,7 @@ function buildStackedOption(
             dimensions: [
                 "position",
                 "baseline_min",
-                "baseline_band",
+                "baseline_max",
                 "baseline_std_dev_lower",
                 "baseline_std_dev_band",
                 "baseline_mean",
@@ -297,7 +300,6 @@ const option = computed<ECOption>(() => {
                 "baseline_std_dev_band",
                 "baseline_max",
                 "baseline_min",
-                "baseline_band",
                 "hot_red_band",
                 "cold_blue_band",
                 "hot_cold_invisible_band",
@@ -313,9 +315,8 @@ const option = computed<ECOption>(() => {
                     baseline_std_dev_band:
                         point.baseline_std_dev_upper -
                         point.baseline_std_dev_lower,
-                    baseline_max: undefined, // point.baseline_max, // TODO: Enable when extremes are available
-                    baseline_min: undefined, // point.baseline_min, // TODO: Enable when extremes are available
-                    baseline_band: undefined, // point.baseline_max - point.baseline_min, // TODO: Enable when extremes are available
+                    baseline_max: point.baseline_max,
+                    baseline_min: point.baseline_min,
                     cold_blue_band:
                         point.baseline_mean -
                         Math.min(point.temperature, point.baseline_mean),
@@ -355,28 +356,31 @@ const option = computed<ECOption>(() => {
             },
         },
         series: [
-            // extreme - Invisible base — pushes the band up to start at lower bound
-            {
-                type: "line",
-                encode: { x: "date", y: "baseline_min" },
-                stack: "extreme",
-                stackStrategy: "all",
-                symbol: "none",
-                lineStyle: { opacity: 0 },
-                areaStyle: { color: "transparent" },
-                tooltip: { show: false },
-            },
-            // extreme - baseline_band
+            // extreme min - dashed line
             {
                 name: ITN_SERIES.extremes,
                 type: "line",
-                encode: { x: "date", y: "baseline_band" },
-                stack: "extreme",
-                stackStrategy: "all",
+                encode: { x: "date", y: "baseline_min" },
                 symbol: "none",
                 color: itnColors.value.extremes,
-                lineStyle: { opacity: 0 },
-                areaStyle: { color: itnColors.value.extremes },
+                lineStyle: {
+                    type: "dashed",
+                    width: 1.5,
+                    color: itnColors.value.extremes,
+                },
+            },
+            // extreme max - dashed line
+            {
+                name: ITN_SERIES.extremes,
+                type: "line",
+                encode: { x: "date", y: "baseline_max" },
+                symbol: "none",
+                color: itnColors.value.extremes,
+                lineStyle: {
+                    type: "dashed",
+                    width: 1.5,
+                    color: itnColors.value.extremes,
+                },
             },
             // ecart-type - Invisible base — pushes the band up to start at lower bound
             {

--- a/frontend/app/components/charts/tooltipFormatters/itnChartTooltipFormatter.test.ts
+++ b/frontend/app/components/charts/tooltipFormatters/itnChartTooltipFormatter.test.ts
@@ -160,12 +160,8 @@ describe("itnChartTooltipFormatter", () => {
             },
         ];
         const result = itnChartTooltipFormatter(params, "day");
-        // TODO: Enable when extremes are available
-        // expect(result).toBe(
-        //     "lun. 23 mars 2026<br/>ITN : 17.3°C<br/>ITN des normales : 18.5°C<br/>dummy-markerExtrêmes : [12.6°C – 24.4°C]<br/>dummy-markerÉcart-type : [16.9°C – 20.1°C]",
-        // );
         expect(result).toBe(
-            "lun. 23 mars 2026<br/>ITN : 17.3°C<br/>ITN des normales : 18.5°C<br/>dummy-markerÉcart-type : [16.9°C – 20.1°C]",
+            "lun. 23 mars 2026<br/>ITN : 17.3°C<br/>ITN des normales : 18.5°C<br/>dummy-markerExtrêmes : [12.6°C – 24.4°C]<br/>dummy-markerÉcart-type : [16.9°C – 20.1°C]",
         );
     });
 
@@ -253,12 +249,8 @@ describe("itnChartTooltipFormatter", () => {
             },
         ];
         const result = itnChartTooltipFormatter(params, "month");
-        // TODO: Enable when extremes are available
-        // expect(result).toBe(
-        //     "mars 2026<br/>ITN : 18.0°C<br/>ITN des normales : 17.9°C<br/>dummy-markerExtrêmes : [11.1°C – 24.4°C]<br/>dummy-markerÉcart-type : [16.2°C – 19.6°C]",
-        // );
         expect(result).toBe(
-            "mars 2026<br/>ITN : 18.0°C<br/>ITN des normales : 17.9°C<br/>dummy-markerÉcart-type : [16.2°C – 19.6°C]",
+            "mars 2026<br/>ITN : 18.0°C<br/>ITN des normales : 17.9°C<br/>dummy-markerExtrêmes : [11.1°C – 24.4°C]<br/>dummy-markerÉcart-type : [16.2°C – 19.6°C]",
         );
     });
 
@@ -346,12 +338,8 @@ describe("itnChartTooltipFormatter", () => {
             },
         ];
         const result = itnChartTooltipFormatter(params, "year");
-        // TODO: Enable when extremes are available
-        // expect(result).toBe(
-        //     '2026<br/>ITN : 15.5°C<br/>ITN des normales : 15.4°C<br/>dummy-markerExtrêmes : [4.7°C – 24.4°C]<br/>Écart-type : [13.7°C – 17.2°C]',
-        // );
         expect(result).toBe(
-            "2026<br/>ITN : 15.5°C<br/>ITN des normales : 15.4°C<br/>dummy-markerÉcart-type : [13.7°C – 17.2°C]",
+            "2026<br/>ITN : 15.5°C<br/>ITN des normales : 15.4°C<br/>dummy-markerExtrêmes : [4.7°C – 24.4°C]<br/>dummy-markerÉcart-type : [13.7°C – 17.2°C]",
         );
     });
 

--- a/frontend/app/components/charts/tooltipFormatters/itnChartTooltipFormatter.ts
+++ b/frontend/app/components/charts/tooltipFormatters/itnChartTooltipFormatter.ts
@@ -35,7 +35,7 @@ export function itnChartTooltipFormatter(
         formattedDate,
         `${find(ITN_SERIES.temperature)?.marker ?? ""}${ITN_SERIES.temperature} : ${fmt(d.temperature as number)}`,
         `${find(ITN_SERIES.baseline)?.marker ?? ""}${ITN_SERIES.baseline} : ${fmt(d.baseline_mean as number)}`,
-        // `${find(ITN_SERIES.extremes)?.marker ?? ""}${ITN_SERIES.extremes} : [${fmt(d.baseline_min as number)} – ${fmt(d.baseline_max as number)}]`, // TODO: Enable when extremes are available
+        `${find(ITN_SERIES.extremes)?.marker ?? ""}${ITN_SERIES.extremes} : [${fmt(d.baseline_min as number)} – ${fmt(d.baseline_max as number)}]`,
         `${find(ITN_SERIES.stdDev)?.marker ?? ""}${ITN_SERIES.stdDev} : [${fmt(d.baseline_std_dev_lower as number)} – ${fmt(d.baseline_std_dev_upper as number)}]`,
     ].join("<br/>");
 }

--- a/frontend/app/constants/itn.ts
+++ b/frontend/app/constants/itn.ts
@@ -282,7 +282,7 @@ export const ITN_SERIES = {
 };
 
 const ITN_LIGHT_COLORS = {
-    extremes: "rgba(100, 100, 100, 0.20)",
+    extremes: "rgba(100, 100, 100, 0.75)",
     ecartType: "rgba(175, 175, 175, 1)",
     hotBand: TEMPERATURE_COLORS.hot,
     coldBand: TEMPERATURE_COLORS.cold,
@@ -291,7 +291,7 @@ const ITN_LIGHT_COLORS = {
 };
 
 const ITN_DARK_COLORS = {
-    extremes: "rgb(132, 145, 167, 0.2)",
+    extremes: "rgba(132, 145, 167, 0.85)",
     ecartType: "rgb(132, 145, 167, 0.5)",
     hotBand: TEMPERATURE_COLORS.hot,
     coldBand: TEMPERATURE_COLORS.cold,


### PR DESCRIPTION
## Type de PR
- [ ] Bugfix
- [x] Feature
- [ ] Refactor
- [ ] Chore / Tech debt
- [ ] Documentation
- [ ] Autre (à préciser)

## Objectif
Ajoute les valeurs extremes de l'itn en pointillé

## Contexte
après la mise à jour de l'endpoint on peut afficher les valeur min/max de l'itn

## Changements
-

## Décisions techniques
<!-- Choix structurants, arbitrages, compromis. -->
<!-- Ce qui aurait pu être fait autrement. -->

## Impacts
- [ ] API / contrat
- [ ] Modèle de données / DB
- [ ] Calculs métier
- [ ] Performance
- [ ] Sécurité
- [ ] Infra / déploiement
- [ ] Aucun impact transverse identifié

## Tests
<!-- Décris ce qui a été fait dans cette PR pour vérifier le comportement introduit ou modifié. -->
- [ ] Tests unitaires
- [ ] Tests d’intégration
- [ ] Tests manuels
- [ ] Non applicable (à justifier)

## Points d’attention pour la review
<!-- Parties sensibles du code, dette technique introduite, risques. -->

## Suivi
- [ ] Migration à prévoir
- [ ] Documentation à mettre à jour
- [ ] Tâche(s) de suivi à créer
