### PR TITLE
Feat/front/add reset button

### DIFF
--- a/frontend/app/components/table/TableEmptyState.vue
+++ b/frontend/app/components/table/TableEmptyState.vue
@@ -1,0 +1,19 @@
+<script setup lang="ts">
+import { EXPORT_BTN_UI } from "~/constants/tableUtils";
+
+defineProps<{ hasActiveFilters: boolean }>();
+const emit = defineEmits<{ reset: [] }>();
+</script>
+
+<template>
+    <div class="flex flex-col items-center gap-3 py-8 text-muted">
+        <span>Aucune donnée affichée.</span>
+        <UButton
+            v-if="hasActiveFilters"
+            label="Réinitialiser les filtres"
+            icon="i-lucide-filter-x"
+            :ui="EXPORT_BTN_UI"
+            @click="emit('reset')"
+        />
+    </div>
+</template>

--- a/frontend/app/components/table/deviation/DeviationTable.vue
+++ b/frontend/app/components/table/deviation/DeviationTable.vue
@@ -3,7 +3,6 @@ import { h } from "vue";
 import { UBadge, UButton } from "#components";
 import {
     CENTERED_TD,
-    EXPORT_BTN_UI,
     makeSortableColFactory,
     REGION_META,
     STATION_META,
@@ -173,16 +172,10 @@ const columns = [
                 </tr>
             </template>
             <template #empty>
-                <div class="flex flex-col items-center gap-3 py-8 text-muted">
-                    <span>Aucune donnée affichée.</span>
-                    <UButton
-                        v-if="hasActiveFilters"
-                        label="Réinitialiser les filtres"
-                        icon="i-lucide-filter-x"
-                        :ui="EXPORT_BTN_UI"
-                        @click="resetFilters"
-                    />
-                </div>
+                <TableEmptyState
+                    :has-active-filters="hasActiveFilters"
+                    @reset="resetFilters"
+                />
             </template>
         </UTable>
 

--- a/frontend/app/components/table/deviation/DeviationTable.vue
+++ b/frontend/app/components/table/deviation/DeviationTable.vue
@@ -34,7 +34,9 @@ const {
     dateEnd,
     ordering,
     pending,
+    hasActiveFilters,
 } = storeToRefs(store);
+const { resetFilters } = store;
 
 const { setOrdering } = store;
 
@@ -168,6 +170,18 @@ const columns = [
                         <USkeleton class="h-4 w-full" />
                     </td>
                 </tr>
+            </template>
+            <template #empty>
+                <div class="flex flex-col items-center gap-3 py-8 text-muted">
+                    <span>Aucune donnée affichée.</span>
+                    <UButton
+                        v-if="hasActiveFilters"
+                        label="Réinitialiser les filtres"
+                        icon="i-lucide-filter-x"
+                        :ui="EXPORT_BTN_UI"
+                        @click="resetFilters"
+                    />
+                </div>
             </template>
         </UTable>
 

--- a/frontend/app/components/table/deviation/DeviationTable.vue
+++ b/frontend/app/components/table/deviation/DeviationTable.vue
@@ -3,6 +3,7 @@ import { h } from "vue";
 import { UBadge, UButton } from "#components";
 import {
     CENTERED_TD,
+    EXPORT_BTN_UI,
     makeSortableColFactory,
     REGION_META,
     STATION_META,

--- a/frontend/app/components/table/records/recordsTable.vue
+++ b/frontend/app/components/table/records/recordsTable.vue
@@ -5,7 +5,6 @@ import { storeToRefs } from "pinia";
 import { useRecordsTableStore } from "~/stores/recordsTableStore";
 import {
     CENTERED_COL,
-    EXPORT_BTN_UI,
     REGION_META,
     STATION_META,
     TABLE_HEADER_BTN_MULTILINE_CLASS,
@@ -176,16 +175,10 @@ const columns = [
                 </tr>
             </template>
             <template #empty>
-                <div class="flex flex-col items-center gap-3 py-8 text-muted">
-                    <span>Aucune donnée affichée.</span>
-                    <UButton
-                        v-if="hasActiveFilters"
-                        label="Réinitialiser les filtres"
-                        icon="i-lucide-filter-x"
-                        :ui="EXPORT_BTN_UI"
-                        @click="resetFilters"
-                    />
-                </div>
+                <TableEmptyState
+                    :has-active-filters="hasActiveFilters"
+                    @reset="resetFilters"
+                />
             </template>
         </UTable>
 

--- a/frontend/app/components/table/records/recordsTable.vue
+++ b/frontend/app/components/table/records/recordsTable.vue
@@ -24,7 +24,9 @@ const {
     pending,
     error,
     ordering,
+    hasActiveFilters,
 } = storeToRefs(store);
+const { resetFilters } = store;
 
 // Track the record type that corresponds to the data currently displayed,
 // so the badge color only flips once the new data has arrived.
@@ -171,6 +173,18 @@ const columns = [
                         <USkeleton class="h-4 w-full" />
                     </td>
                 </tr>
+            </template>
+            <template #empty>
+                <div class="flex flex-col items-center gap-3 py-8 text-muted">
+                    <span>Aucune donnée affichée.</span>
+                    <UButton
+                        v-if="hasActiveFilters"
+                        label="Réinitialiser les filtres"
+                        icon="i-lucide-filter-x"
+                        :ui="EXPORT_BTN_UI"
+                        @click="resetFilters"
+                    />
+                </div>
             </template>
         </UTable>
 

--- a/frontend/app/components/table/records/recordsTable.vue
+++ b/frontend/app/components/table/records/recordsTable.vue
@@ -5,6 +5,7 @@ import { storeToRefs } from "pinia";
 import { useRecordsTableStore } from "~/stores/recordsTableStore";
 import {
     CENTERED_COL,
+    EXPORT_BTN_UI,
     REGION_META,
     STATION_META,
     TABLE_HEADER_BTN_MULTILINE_CLASS,

--- a/frontend/app/stores/deviationTableStore.ts
+++ b/frontend/app/stores/deviationTableStore.ts
@@ -120,6 +120,23 @@ export const useDeviationTableStore = defineStore("deviationTableStore", () => {
         }
     }
 
+    function resetFilters() {
+        stationIds.value = [];
+        departmentsFilter.value = [];
+        regionsFilter.value = [];
+        deviationMin.value = undefined;
+        deviationMax.value = undefined;
+        temperatureMeanMin.value = undefined;
+        temperatureMeanMax.value = undefined;
+        classeFilter.value = [];
+        creationYearMin.value = undefined;
+        creationYearMax.value = undefined;
+    }
+
+    const hasActiveFilters = computed(
+        () => Object.keys(filters.value).length > 0,
+    );
+
     function clearFilter(id: string) {
         if (id === "name") {
             stationIds.value = [];
@@ -242,6 +259,8 @@ export const useDeviationTableStore = defineStore("deviationTableStore", () => {
         staticOptions,
         setFilter,
         clearFilter,
+        resetFilters,
+        hasActiveFilters,
         deviationData,
         exportParams,
         pending,

--- a/frontend/app/stores/recordsTableStore.ts
+++ b/frontend/app/stores/recordsTableStore.ts
@@ -209,6 +209,25 @@ export const useRecordsTableStore = defineStore("recordsTableStore", () => {
         }
     }
 
+    function resetFilters() {
+        page.value = 1;
+        stationIds.value = [];
+        departments.value = [];
+        temperatureMin.value = undefined;
+        temperatureMax.value = undefined;
+        dateStart.value = undefined;
+        dateEnd.value = undefined;
+        classeFilter.value = [];
+        creationYearMin.value = undefined;
+        creationYearMax.value = undefined;
+        altMin.value = undefined;
+        altMax.value = undefined;
+    }
+
+    const hasActiveFilters = computed(
+        () => Object.keys(filters.value).length > 0,
+    );
+
     // Build API params from periodSelection
     const params = computed<TemperatureRecordsParams>(() => {
         const result: TemperatureRecordsParams = {
@@ -353,5 +372,7 @@ export const useRecordsTableStore = defineStore("recordsTableStore", () => {
         dateStart,
         dateEnd,
         ordering,
+        resetFilters,
+        hasActiveFilters,
     };
 });


### PR DESCRIPTION
## Type de PR
- [ ] Bugfix
- [x] Feature
- [ ] Refactor
- [ ] Chore / Tech debt
- [ ] Documentation
- [ ] Autre (à préciser)

## Objectif
Ajouter un bouton reset filter si aucune donnée affichée à cause des filtres

## Contexte
US: https://github.com/dataforgoodfr/14_ValorisationDonneeMeteo/issues/555

## Changements
- ajoute reset filter logique

<img width="907" height="301" alt="image" src="https://github.com/user-attachments/assets/d07e1ab7-a904-4ec2-b7f9-423c162149c1" />


## Décisions techniques
<!-- Choix structurants, arbitrages, compromis. -->
<!-- Ce qui aurait pu être fait autrement. -->

## Impacts
- [ ] API / contrat
- [ ] Modèle de données / DB
- [ ] Calculs métier
- [ ] Performance
- [ ] Sécurité
- [ ] Infra / déploiement
- [ ] Aucun impact transverse identifié

## Tests
<!-- Décris ce qui a été fait dans cette PR pour vérifier le comportement introduit ou modifié. -->
- [ ] Tests unitaires
- [ ] Tests d’intégration
- [x] Tests manuels
- [ ] Non applicable (à justifier)

## Points d’attention pour la review
<!-- Parties sensibles du code, dette technique introduite, risques. -->

## Suivi
- [ ] Migration à prévoir
- [ ] Documentation à mettre à jour
- [ ] Tâche(s) de suivi à créer
