### PR TITLE
fix: deviation: fix html chart export in darkmode

### DIFF
--- a/frontend/app/components/ui/commons/exportMenu.vue
+++ b/frontend/app/components/ui/commons/exportMenu.vue
@@ -4,6 +4,7 @@ import type { SelectBarAdapter } from "./selectBar/types";
 import { useMapColors } from "~/constants/colors";
 
 const mapColors = useMapColors();
+const colorMode = useColorMode();
 
 const adapter = inject<SelectBarAdapter>("selectBarAdapter")!;
 const { exportConfig, chartRef, granularity, pickedDateStart, pickedDateEnd } =
@@ -119,7 +120,7 @@ function exportAsHTML() {
     <meta charset="utf-8">
     <title>${exportConfig.chartName.toUpperCase()}</title>
     <${scriptTag} src="https://cdn.jsdelivr.net/npm/echarts/dist/echarts.min.js"></${scriptTag}>
-    <style>html { margin: 0; padding: 0; width: 100%; height: 100vh; }, body { display: flex; align-items: center; margin: 0; padding: 0; width: 100%; height: 100vh; } #chart { margin: 20px; width: auto; height: calc(100vh - 40px); }</style>
+    <style>html { background-color: ${colorMode.value === "dark" ? "#1a2130" : "#fff"}; margin: 0; padding: 0; width: 100%; height: 100vh; }, body {  display: flex; align-items: center; margin: 0; padding: 0; width: 100%; height: 100vh; } #chart { margin: 20px; width: auto; height: calc(100vh - 40px); }</style>
 </head>
 <body>
     <div id="chart"></div>


### PR DESCRIPTION
## Type de PR
- [x] Bugfix
- [ ] Feature
- [ ] Refactor
- [ ] Chore / Tech debt
- [ ] Documentation
- [ ] Autre (à préciser)

## Objectif
Lors de l'export du graph d'écart à la normale, en dark mode, le fond était blan, comme la police. On ne voyait donc pas les textes, j'ai changé  la couleur de fond de l'export en dark mode

## Contexte
https://github.com/dataforgoodfr/14_ValorisationDonneeMeteo/issues/566
## Changements
-

## Décisions techniques
<!-- Choix structurants, arbitrages, compromis. -->
<!-- Ce qui aurait pu être fait autrement. -->

## Impacts
- [ ] API / contrat
- [ ] Modèle de données / DB
- [ ] Calculs métier
- [ ] Performance
- [ ] Sécurité
- [ ] Infra / déploiement
- [ ] Aucun impact transverse identifié

## Tests
<!-- Décris ce qui a été fait dans cette PR pour vérifier le comportement introduit ou modifié. -->
- [ ] Tests unitaires
- [ ] Tests d’intégration
- [ ] Tests manuels
- [ ] Non applicable (à justifier)

## Points d’attention pour la review
<!-- Parties sensibles du code, dette technique introduite, risques. -->

## Suivi
- [ ] Migration à prévoir
- [ ] Documentation à mettre à jour
- [ ] Tâche(s) de suivi à créer
