### PR TITLE
feat/backend/make_month/season_optional

### DIFF
--- a/backend/openapi/target-specs/openapi.yaml
+++ b/backend/openapi/target-specs/openapi.yaml
@@ -688,13 +688,25 @@ paths:
 
         - l'année de fermeture de la station (`date_de_fermeture_min` / `date_de_fermeture_max`)
 
+        **Comportement de `period_type`**
+
+        - `all_time` (défaut) : record absolu toutes périodes confondues.
+        - `month` + `month=N` (1–12) : record du mois N uniquement.
+        - `month` sans `month` : records de **tous les mois** (une ligne par station et par mois).
+        - `season` + `season=<saison>` : record de la saison indiquée.
+        - `season` sans `season` : records de **toutes les saisons** (une ligne par station et par saison).
+
         Exemples de requêtes :
 
         - `period_type=all_time&type_records=hot&sort=-record_value`
 
         - `period_type=month&month=7&type_records=hot&page=1&page_size=50`
 
+        - `period_type=month&type_records=hot` (tous les mois)
+
         - `period_type=season&season=summer&type_records=cold&sort=station_name`
+
+        - `period_type=season&type_records=cold` (toutes les saisons)
 
         - `period_type=all_time&type_records=hot&sort=-record_value,station_name`
 
@@ -708,8 +720,8 @@ paths:
           description: |
             Découpage temporel des records :
             - `all_time` : records sans découpage temporel (défaut)
-            - `month` : records pour un mois donné (paramètre `month` requis)
-            - `season` : records pour une saison donnée (paramètre `season` requis)
+            - `month` : records pour un mois. Si `month` est absent, retourne tous les mois.
+            - `season` : records pour une saison. Si `season` est absente, retourne toutes les saisons.
           schema:
             type: string
             enum: [all_time, month, season]
@@ -718,7 +730,7 @@ paths:
           in: query
           required: false
           description: |
-            Numéro du mois (1-12). Requis si `period_type=month`.
+            Numéro du mois (1-12). Optionnel si `period_type=month` — si absent, retourne les records de tous les mois.
           schema:
             type: integer
             minimum: 1
@@ -728,7 +740,7 @@ paths:
           in: query
           required: false
           description: |
-            Saison. Requis si `period_type=season`.
+            Saison. Optionnel si `period_type=season` — si absente, retourne les records de toutes les saisons.
             - `spring` : printemps (mars–mai)
             - `summer` : été (juin–août)
             - `autumn` : automne (septembre–novembre)

--- a/backend/openapi/target-specs/openapi.yaml
+++ b/backend/openapi/target-specs/openapi.yaml
@@ -690,7 +690,7 @@ paths:
 
         **Comportement de `period_type`**
 
-        - `all_time` (défaut) : record absolu toutes périodes confondues.
+        - `all_time` (défaut) : liste des records battus progressifs toutes périodes confondues (le dernier par station correspond au record absolu actuel).
         - `month` + `month=N` (1–12) : record du mois N uniquement.
         - `month` sans `month` : records de **tous les mois** (une ligne par station et par mois).
         - `season` + `season=<saison>` : record de la saison indiquée.

--- a/backend/weather/data_sources/timescale.py
+++ b/backend/weather/data_sources/timescale.py
@@ -894,9 +894,9 @@ def _territoire_clause_named(
 def _temperature_records_period_clause(
     request: TemperatureRecordsRequest,
 ) -> tuple[str, list]:
-    if request.period_type == "month":
+    if request.period_type == "month" and request.month is not None:
         return 'EXTRACT(MONTH FROM q."AAAAMMJJ") = %s', [request.month]
-    elif request.period_type == "season":
+    elif request.period_type == "season" and request.season is not None:
         months = list(SEASON_MONTHS[request.season])
         placeholders = ", ".join(["%s"] * len(months))
         return f'EXTRACT(MONTH FROM q."AAAAMMJJ") IN ({placeholders})', months
@@ -908,11 +908,11 @@ def _temperature_records_period_clause_named(
     request: TemperatureRecordsRequest,
 ) -> tuple[str, dict]:
     """Variante de _temperature_records_period_clause avec placeholders nommés %(…)s."""
-    if request.period_type == "month":
+    if request.period_type == "month" and request.month is not None:
         return 'EXTRACT(MONTH FROM q."AAAAMMJJ") = %(period_month)s', {
             "period_month": request.month
         }
-    elif request.period_type == "season":
+    elif request.period_type == "season" and request.season is not None:
         months = list(SEASON_MONTHS[request.season])
         named = {f"period_season_{i}": m for i, m in enumerate(months)}
         placeholders = ", ".join(f"%(period_season_{i})s" for i in range(len(months)))
@@ -938,13 +938,6 @@ class MaterializedTemperatureRecordsDataSource:
     ) -> list[TemperatureRecordEntry]:
         record_type = "TX" if request.type_records == "hot" else "TN"
 
-        if request.period_type == "month":
-            period_value: str | None = str(request.month)
-        elif request.period_type == "season":
-            period_value = request.season
-        else:
-            period_value = None
-
         sort_parts = [s.strip() for s in request.sort.split(",")]
 
         field_mapping = {
@@ -966,16 +959,24 @@ class MaterializedTemperatureRecordsDataSource:
             order_sql = ", ".join(order_clauses)
         else:
             order_sql = "record_value DESC, station_name ASC, record_date ASC"
+
         clauses = [
             "record_type = %(record_type)s",
             "period_type = %(period_type)s",
-            "period_value IS NOT DISTINCT FROM %(period_value)s",
         ]
         params: dict = {
             "record_type": record_type,
             "period_type": request.period_type,
-            "period_value": period_value,
         }
+
+        if request.period_type == "month" and request.month is not None:
+            clauses.append("period_value = %(period_value)s")
+            params["period_value"] = str(request.month)
+        elif request.period_type == "season" and request.season is not None:
+            clauses.append("period_value = %(period_value)s")
+            params["period_value"] = request.season
+        elif request.period_type == "all_time":
+            clauses.append("period_value IS NULL")
 
         if request.date_start:
             clauses.append("record_date >= %(date_start)s")
@@ -1100,6 +1101,10 @@ class HybridTemperatureRecordsDataSource(TemperatureRecordsDataSource):
         except Exception:
             return self._paginate(mv_entries, request)
         if cutoff is None:
+            return self._paginate(mv_entries, request)
+        if (request.period_type == "month" and request.month is None) or (
+            request.period_type == "season" and request.season is None
+        ):
             return self._paginate(mv_entries, request)
         hot_results = self._fetch_records_after_cutoff(request, cutoff)
         all_entries = mv_entries + hot_results

--- a/backend/weather/serializers.py
+++ b/backend/weather/serializers.py
@@ -442,21 +442,10 @@ class TemperatureRecordsQuerySerializer(serializers.Serializer):
         return value
 
     def validate(self, attrs) -> dict:
-        period_type = attrs.get("period_type", "all_time")
-        month = attrs.get("month")
-        season = attrs.get("season")
         date_start = attrs.get("date_start")
         date_end = attrs.get("date_end")
         territoire = attrs.get("territoire", "france")
         territoire_id = attrs.get("territoire_id")
-
-        if period_type == "month" and month is None:
-            raise serializers.ValidationError({"month": "Requis si period_type=month."})
-
-        if period_type == "season" and season is None:
-            raise serializers.ValidationError(
-                {"season": "Requis si period_type=season."}
-            )
 
         if (date_start is None) != (date_end is None):
             raise serializers.ValidationError(

--- a/backend/weather/services/temperature_records/use_case.py
+++ b/backend/weather/services/temperature_records/use_case.py
@@ -12,17 +12,4 @@ def get_temperature_records(
     request: TemperatureRecordsRequest,
     data_source: TemperatureRecordsDataSource,
 ) -> TemperatureRecordsResult:
-    """
-    Valide la requête et délègue au data source.
-
-    Raises ValueError si:
-    - period_type == "month" et month est None
-    - period_type == "season" et season est None
-    """
-    if request.period_type == "month" and request.month is None:
-        raise ValueError("month is required when period_type is 'month'")
-
-    if request.period_type == "season" and request.season is None:
-        raise ValueError("season is required when period_type is 'season'")
-
     return data_source.fetch_records(request)

--- a/backend/weather/tests/integration/test_hybrid_temperature_records_datasource.py
+++ b/backend/weather/tests/integration/test_hybrid_temperature_records_datasource.py
@@ -223,6 +223,62 @@ def test_season_filter_respected():
 
 
 @pytest.mark.django_db
+def test_all_months_mode_skips_cutoff_returns_mv_only():
+    """period_type='month' sans month → mode 'tous les mois', l'enrichissement post-cutoff est ignoré."""
+    code = "76116011"
+    insert_station(code, "Station Hybrid 11", departement=76)
+    insert_mv_record(
+        code, "Station Hybrid 11", "month", "7", "TX", 38.0, dt.date(2003, 7, 15)
+    )
+    insert_mv_record(
+        code, "Station Hybrid 11", "month", "8", "TX", 35.0, dt.date(2001, 8, 10)
+    )
+    set_cutoff(dt.date(2025, 12, 31))
+
+    # Donnée post-cutoff qui battrait le record de juillet — ne doit PAS apparaître
+    insert_quotidienne(dt.date(2026, 7, 1), code, tx=50.0)
+
+    ds = HybridTemperatureRecordsDataSource()
+    result = ds.fetch_records(
+        TemperatureRecordsRequest(period_type="month", type_records="hot", month=None)
+    )
+
+    entries = [e for e in result.entries if e.station_id.strip() == code]
+    values = [e.record_value for e in entries]
+    # Seules les données MV (38.0 et 35.0), pas les 50.0 post-cutoff
+    assert 50.0 not in values
+    assert 38.0 in values
+    assert 35.0 in values
+
+
+@pytest.mark.django_db
+def test_all_seasons_mode_skips_cutoff_returns_mv_only():
+    """period_type='season' sans season → mode 'toutes les saisons', l'enrichissement post-cutoff est ignoré."""
+    code = "76116012"
+    insert_station(code, "Station Hybrid 12", departement=76)
+    insert_mv_record(
+        code, "Station Hybrid 12", "season", "summer", "TX", 40.0, dt.date(2003, 8, 12)
+    )
+    insert_mv_record(
+        code, "Station Hybrid 12", "season", "winter", "TX", 12.0, dt.date(2010, 1, 5)
+    )
+    set_cutoff(dt.date(2025, 12, 31))
+
+    insert_quotidienne(dt.date(2026, 7, 1), code, tx=55.0)
+
+    ds = HybridTemperatureRecordsDataSource()
+    result = ds.fetch_records(
+        TemperatureRecordsRequest(period_type="season", type_records="hot", season=None)
+    )
+
+    entries = [e for e in result.entries if e.station_id.strip() == code]
+    values = [e.record_value for e in entries]
+    assert 55.0 not in values
+    assert 40.0 in values
+    assert 12.0 in values
+
+
+@pytest.mark.django_db
 def test_meta_table_absent_falls_back_to_mv():
     """Erreur DB sur la méta table → pas d'exception, retourne les données MV seules."""
     code = "76116010"

--- a/backend/weather/tests/integration/test_hybrid_temperature_records_datasource.py
+++ b/backend/weather/tests/integration/test_hybrid_temperature_records_datasource.py
@@ -279,6 +279,75 @@ def test_all_seasons_mode_skips_cutoff_returns_mv_only():
 
 
 @pytest.mark.django_db
+def test_all_months_date_filter_excludes_outside_range():
+    """Export use case : month=None + date_start/date_end → seuls les records dans la fenêtre."""
+    code = "76116013"
+    insert_station(code, "Station Export Date", departement=76)
+
+    # Record dans la fenêtre (2024-06)
+    insert_mv_record(
+        code, "Station Export Date", "month", "6", "TX", 38.0, dt.date(2024, 6, 15)
+    )
+    # Record hors fenêtre (2003-07)
+    insert_mv_record(
+        code, "Station Export Date", "month", "7", "TX", 42.0, dt.date(2003, 7, 15)
+    )
+
+    ds = HybridTemperatureRecordsDataSource()
+    result = ds.fetch_records(
+        TemperatureRecordsRequest(
+            period_type="month",
+            type_records="hot",
+            month=None,
+            date_start=dt.date(2024, 1, 1),
+            date_end=dt.date(2024, 12, 31),
+        )
+    )
+
+    entries = [e for e in result.entries if e.station_id.strip() == code]
+    values = {e.record_value for e in entries}
+    assert 38.0 in values
+    assert 42.0 not in values
+
+
+@pytest.mark.django_db
+def test_after_cutoff_date_filter_excludes_outside_range():
+    """date_start/date_end filtre aussi les records post-cutoff hors de la fenêtre."""
+    code = "76116014"
+    insert_station(code, "Station Post Cutoff Date", departement=76)
+    insert_mv_record(
+        code,
+        "Station Post Cutoff Date",
+        "all_time",
+        None,
+        "TX",
+        38.0,
+        dt.date(2003, 7, 15),
+    )
+    set_cutoff(dt.date(2025, 12, 31))
+
+    # Record post-cutoff hors fenêtre (avant date_start) — ne bat pas le seed
+    insert_quotidienne(dt.date(2026, 1, 5), code, tx=35.0)
+    # Record post-cutoff dans la fenêtre — bat le seed de 38.0
+    insert_quotidienne(dt.date(2026, 6, 10), code, tx=45.0)
+
+    ds = HybridTemperatureRecordsDataSource()
+    result = ds.fetch_records(
+        TemperatureRecordsRequest(
+            period_type="all_time",
+            type_records="hot",
+            date_start=dt.date(2026, 6, 1),
+            date_end=dt.date(2026, 12, 31),
+        )
+    )
+
+    entries = [e for e in result.entries if e.station_id.strip() == code]
+    values = {e.record_value for e in entries}
+    assert 45.0 in values
+    assert 35.0 not in values
+
+
+@pytest.mark.django_db
 def test_meta_table_absent_falls_back_to_mv():
     """Erreur DB sur la méta table → pas d'exception, retourne les données MV seules."""
     code = "76116010"

--- a/backend/weather/tests/integration/test_temperature_records_endpoint.py
+++ b/backend/weather/tests/integration/test_temperature_records_endpoint.py
@@ -92,32 +92,36 @@ def test_get_records_season_happy_path(client: APIClient):
     assert isinstance(body, dict)
 
 
-def test_get_records_returns_400_if_period_type_month_without_month(
+@pytest.mark.usefixtures("fake_temperature_records_dep")
+def test_get_records_returns_200_if_period_type_month_without_month(
     client: APIClient,
 ):
+    """period_type=month sans month spécifique → tous les mois, HTTP 200."""
     resp = client.get(
         "/api/v1/temperature/records",
         {"period_type": "month", "type_records": "hot"},
     )
 
-    assert resp.status_code == 400
+    assert resp.status_code == 200
     body = resp.json()
-    assert body["error"]["code"] == "INVALID_PARAMETER"
-    assert "month" in body["error"]["details"]
+    assert isinstance(body, dict)
+    assert "results" in body
 
 
-def test_get_records_returns_400_if_period_type_season_without_season(
+@pytest.mark.usefixtures("fake_temperature_records_dep")
+def test_get_records_returns_200_if_period_type_season_without_season(
     client: APIClient,
 ):
+    """period_type=season sans saison spécifique → toutes les saisons, HTTP 200."""
     resp = client.get(
         "/api/v1/temperature/records",
         {"period_type": "season", "type_records": "cold"},
     )
 
-    assert resp.status_code == 400
+    assert resp.status_code == 200
     body = resp.json()
-    assert body["error"]["code"] == "INVALID_PARAMETER"
-    assert "season" in body["error"]["details"]
+    assert isinstance(body, dict)
+    assert "results" in body
 
 
 def test_get_records_returns_400_if_unknown_period_type(client: APIClient):

--- a/backend/weather/tests/integration/test_temperature_records_timescale_datasource.py
+++ b/backend/weather/tests/integration/test_temperature_records_timescale_datasource.py
@@ -5,10 +5,11 @@ import datetime as dt
 import pytest
 
 from weather.data_sources.timescale import (
+    MaterializedTemperatureRecordsDataSource,
     TimescaleTemperatureRecordsDataSource,
 )
 from weather.services.temperature_records.types import TemperatureRecordsRequest
-from weather.tests.conftest import insert_quotidienne
+from weather.tests.conftest import insert_mv_record, insert_quotidienne
 from weather.tests.helpers.stations import insert_station
 
 # =========================
@@ -292,29 +293,47 @@ def test_fetch_records_sorting_by_station_name_desc():
 
 @pytest.mark.django_db
 def test_fetch_records_all_months_returns_records_for_each_month():
-    """period_type='month' sans month → retourne les records de tous les mois."""
+    """period_type='month' sans month → retourne les records de tous les mois via la MV."""
     station_code = "99011001"
 
     insert_station(
         station_code, "Station All Months", departement=99, lat=48.0, lon=2.0, alt=100.0
     )
 
-    # Juillet : record à 40.0
-    insert_quotidienne(dt.date(2003, 7, 15), station_code, tx=40.0, tn=20.0)
-    # Août : record à 38.0
-    insert_quotidienne(dt.date(2001, 8, 10), station_code, tx=38.0, tn=19.0)
-    # Janvier : record à 5.0
-    insert_quotidienne(dt.date(1990, 1, 20), station_code, tx=5.0, tn=-2.0)
+    insert_mv_record(
+        station_code,
+        "Station All Months",
+        "month",
+        "7",
+        "TX",
+        40.0,
+        dt.date(2003, 7, 15),
+    )
+    insert_mv_record(
+        station_code,
+        "Station All Months",
+        "month",
+        "8",
+        "TX",
+        38.0,
+        dt.date(2001, 8, 10),
+    )
+    insert_mv_record(
+        station_code,
+        "Station All Months",
+        "month",
+        "1",
+        "TX",
+        5.0,
+        dt.date(1990, 1, 20),
+    )
 
-    ds = TimescaleTemperatureRecordsDataSource()
+    ds = MaterializedTemperatureRecordsDataSource()
     req = TemperatureRecordsRequest(period_type="month", type_records="hot", month=None)
     result = ds.fetch_records(req)
 
-    station_entries = [
-        e for e in result.entries if e.station_id.strip() == station_code
-    ]
+    station_entries = [e for e in result if e.station_id.strip() == station_code]
     values = {e.record_value for e in station_entries}
-    # Les trois records de mois différents doivent tous être présents
     assert 40.0 in values
     assert 38.0 in values
     assert 5.0 in values
@@ -322,7 +341,7 @@ def test_fetch_records_all_months_returns_records_for_each_month():
 
 @pytest.mark.django_db
 def test_fetch_records_all_seasons_returns_records_for_each_season():
-    """period_type='season' sans season → retourne les records de toutes les saisons."""
+    """period_type='season' sans season → retourne les records de toutes les saisons via la MV."""
     station_code = "99012001"
 
     insert_station(
@@ -334,20 +353,32 @@ def test_fetch_records_all_seasons_returns_records_for_each_season():
         alt=100.0,
     )
 
-    # Été (août) : record à 42.0
-    insert_quotidienne(dt.date(2003, 8, 12), station_code, tx=42.0, tn=22.0)
-    # Hiver (janvier) : record à 8.0
-    insert_quotidienne(dt.date(2010, 1, 5), station_code, tx=8.0, tn=-5.0)
+    insert_mv_record(
+        station_code,
+        "Station All Seasons",
+        "season",
+        "summer",
+        "TX",
+        42.0,
+        dt.date(2003, 8, 12),
+    )
+    insert_mv_record(
+        station_code,
+        "Station All Seasons",
+        "season",
+        "winter",
+        "TX",
+        8.0,
+        dt.date(2010, 1, 5),
+    )
 
-    ds = TimescaleTemperatureRecordsDataSource()
+    ds = MaterializedTemperatureRecordsDataSource()
     req = TemperatureRecordsRequest(
         period_type="season", type_records="hot", season=None
     )
     result = ds.fetch_records(req)
 
-    station_entries = [
-        e for e in result.entries if e.station_id.strip() == station_code
-    ]
+    station_entries = [e for e in result if e.station_id.strip() == station_code]
     values = {e.record_value for e in station_entries}
     assert 42.0 in values
     assert 8.0 in values

--- a/backend/weather/tests/integration/test_temperature_records_timescale_datasource.py
+++ b/backend/weather/tests/integration/test_temperature_records_timescale_datasource.py
@@ -382,3 +382,54 @@ def test_fetch_records_all_seasons_returns_records_for_each_season():
     values = {e.record_value for e in station_entries}
     assert 42.0 in values
     assert 8.0 in values
+
+
+@pytest.mark.django_db
+def test_fetch_records_date_filter_excludes_outside_range():
+    """date_start/date_end filtre les records dont record_date est hors fenêtre."""
+    station_code = "99013001"
+
+    insert_station(
+        station_code,
+        "Station Date Filter",
+        departement=99,
+        lat=48.0,
+        lon=2.0,
+        alt=100.0,
+    )
+
+    # Record dans la fenêtre (2024-06-15)
+    insert_mv_record(
+        station_code,
+        "Station Date Filter",
+        "month",
+        "6",
+        "TX",
+        38.0,
+        dt.date(2024, 6, 15),
+    )
+    # Record hors fenêtre (2003-07-15)
+    insert_mv_record(
+        station_code,
+        "Station Date Filter",
+        "month",
+        "7",
+        "TX",
+        42.0,
+        dt.date(2003, 7, 15),
+    )
+
+    ds = MaterializedTemperatureRecordsDataSource()
+    req = TemperatureRecordsRequest(
+        period_type="month",
+        type_records="hot",
+        month=None,
+        date_start=dt.date(2024, 1, 1),
+        date_end=dt.date(2024, 12, 31),
+    )
+    result = ds.fetch_records(req)
+
+    station_entries = [e for e in result if e.station_id.strip() == station_code]
+    values = {e.record_value for e in station_entries}
+    assert 38.0 in values
+    assert 42.0 not in values

--- a/backend/weather/tests/integration/test_temperature_records_timescale_datasource.py
+++ b/backend/weather/tests/integration/test_temperature_records_timescale_datasource.py
@@ -288,3 +288,66 @@ def test_fetch_records_sorting_by_station_name_desc():
 
     names = [e.station_name for e in result.entries if e.station_id in [s1, s2]]
     assert names == ["Zubiri", "Antibes"]
+
+
+@pytest.mark.django_db
+def test_fetch_records_all_months_returns_records_for_each_month():
+    """period_type='month' sans month → retourne les records de tous les mois."""
+    station_code = "99011001"
+
+    insert_station(
+        station_code, "Station All Months", departement=99, lat=48.0, lon=2.0, alt=100.0
+    )
+
+    # Juillet : record à 40.0
+    insert_quotidienne(dt.date(2003, 7, 15), station_code, tx=40.0, tn=20.0)
+    # Août : record à 38.0
+    insert_quotidienne(dt.date(2001, 8, 10), station_code, tx=38.0, tn=19.0)
+    # Janvier : record à 5.0
+    insert_quotidienne(dt.date(1990, 1, 20), station_code, tx=5.0, tn=-2.0)
+
+    ds = TimescaleTemperatureRecordsDataSource()
+    req = TemperatureRecordsRequest(period_type="month", type_records="hot", month=None)
+    result = ds.fetch_records(req)
+
+    station_entries = [
+        e for e in result.entries if e.station_id.strip() == station_code
+    ]
+    values = {e.record_value for e in station_entries}
+    # Les trois records de mois différents doivent tous être présents
+    assert 40.0 in values
+    assert 38.0 in values
+    assert 5.0 in values
+
+
+@pytest.mark.django_db
+def test_fetch_records_all_seasons_returns_records_for_each_season():
+    """period_type='season' sans season → retourne les records de toutes les saisons."""
+    station_code = "99012001"
+
+    insert_station(
+        station_code,
+        "Station All Seasons",
+        departement=99,
+        lat=48.0,
+        lon=2.0,
+        alt=100.0,
+    )
+
+    # Été (août) : record à 42.0
+    insert_quotidienne(dt.date(2003, 8, 12), station_code, tx=42.0, tn=22.0)
+    # Hiver (janvier) : record à 8.0
+    insert_quotidienne(dt.date(2010, 1, 5), station_code, tx=8.0, tn=-5.0)
+
+    ds = TimescaleTemperatureRecordsDataSource()
+    req = TemperatureRecordsRequest(
+        period_type="season", type_records="hot", season=None
+    )
+    result = ds.fetch_records(req)
+
+    station_entries = [
+        e for e in result.entries if e.station_id.strip() == station_code
+    ]
+    values = {e.record_value for e in station_entries}
+    assert 42.0 in values
+    assert 8.0 in values

--- a/backend/weather/tests/unit/test_temperature_records_query_serializer.py
+++ b/backend/weather/tests/unit/test_temperature_records_query_serializer.py
@@ -34,20 +34,20 @@ def test_records_query_serializer_all_time_happy_path():
     assert s.is_valid(), s.errors
 
 
-def test_records_query_serializer_rejects_month_missing_when_period_type_month():
+def test_records_query_serializer_accepts_month_missing_when_period_type_month():
     s = TemperatureRecordsQuerySerializer(
         data={"period_type": "month", "type_records": "hot"}
     )
-    assert not s.is_valid()
-    assert "month" in s.errors
+    assert s.is_valid(), s.errors
+    assert s.validated_data.get("month") is None
 
 
-def test_records_query_serializer_rejects_season_missing_when_period_type_season():
+def test_records_query_serializer_accepts_season_missing_when_period_type_season():
     s = TemperatureRecordsQuerySerializer(
         data={"period_type": "season", "type_records": "cold"}
     )
-    assert not s.is_valid()
-    assert "season" in s.errors
+    assert s.is_valid(), s.errors
+    assert s.validated_data.get("season") is None
 
 
 def test_records_query_serializer_rejects_unknown_period_type():

--- a/backend/weather/views.py
+++ b/backend/weather/views.py
@@ -218,10 +218,18 @@ class TemperatureRecordsAPIView(APIView):
             "- le découpage temporel (`period_type`) : tous les temps, par mois ou par saison\n"
             "- le type de record (`hot` ou `cold`)\n"
             "- le tri des résultats (`sort`)\n\n"
+            "**Comportement de `period_type`**\n\n"
+            "- `all_time` (défaut) : record absolu toutes périodes confondues.\n"
+            "- `month` + `month=N` (1–12) : record du mois N uniquement.\n"
+            "- `month` sans `month` : records de **tous les mois** (une ligne par station et par mois).\n"
+            "- `season` + `season=<saison>` : record de la saison indiquée.\n"
+            "- `season` sans `season` : records de **toutes les saisons** (une ligne par station et par saison).\n\n"
             "Exemples de requêtes :\n"
             "- `period_type=all_time&type_records=hot&sort=-record_value`\n"
             "- `period_type=month&month=7&type_records=hot&page=1&page_size=50`\n"
+            "- `period_type=month&type_records=hot` (tous les mois)\n"
             "- `period_type=season&season=summer&type_records=cold&sort=station_name`\n"
+            "- `period_type=season&type_records=cold` (toutes les saisons)\n"
             "- `period_type=all_time&type_records=hot&sort=-record_value,station_name`"
         ),
         parameters=[

--- a/backend/weather/views.py
+++ b/backend/weather/views.py
@@ -204,7 +204,7 @@ class TemperatureDeviationGraphAPIView(APIView):
 class TemperatureRecordsAPIView(APIView):
     """
     GET /api/v1/temperature/records
-    Retourne les records absolus de température par station.
+    Retourne les records battus de température par station (liste progressive, pas uniquement le record absolu).
     """
 
     authentication_classes = []
@@ -219,7 +219,7 @@ class TemperatureRecordsAPIView(APIView):
             "- le type de record (`hot` ou `cold`)\n"
             "- le tri des résultats (`sort`)\n\n"
             "**Comportement de `period_type`**\n\n"
-            "- `all_time` (défaut) : record absolu toutes périodes confondues.\n"
+            "- `all_time` (défaut) : liste des records battus progressifs toutes périodes confondues (le dernier par station correspond au record absolu actuel).\n"
             "- `month` + `month=N` (1–12) : record du mois N uniquement.\n"
             "- `month` sans `month` : records de **tous les mois** (une ligne par station et par mois).\n"
             "- `season` + `season=<saison>` : record de la saison indiquée.\n"


### PR DESCRIPTION
## Type de PR
- [ ] Bugfix
- [x] Feature
- [ ] Refactor
- [ ] Chore / Tech debt
- [ ] Documentation
- [ ] Autre (à préciser)

## Objectif
Retourner les records mensuels/saisonnier de tous les mois/saisons par defaut

## Contexte
US: https://github.com/dataforgoodfr/14_ValorisationDonneeMeteo/issues/571

## Changements
- comme pour temperature/records/graph : rend month/season optionnel
- update swagger
- update test

## Décisions techniques
<!-- Choix structurants, arbitrages, compromis. -->
<!-- Ce qui aurait pu être fait autrement. -->

## Impacts
- [ ] API / contrat
- [ ] Modèle de données / DB
- [ ] Calculs métier
- [ ] Performance
- [ ] Sécurité
- [ ] Infra / déploiement
- [ ] Aucun impact transverse identifié

## Tests
<!-- Décris ce qui a été fait dans cette PR pour vérifier le comportement introduit ou modifié. -->
- [x] Tests unitaires
- [x] Tests d’intégration
- [ ] Tests manuels
- [ ] Non applicable (à justifier)

## Points d’attention pour la review
<!-- Parties sensibles du code, dette technique introduite, risques. -->

## Suivi
- [ ] Migration à prévoir
- [ ] Documentation à mettre à jour
- [ ] Tâche(s) de suivi à créer
