### PR TITLE
ajoute bouton pour exporter liste record battu

### DIFF
--- a/frontend/app/components/home/Last30DaysSection/LastMonthSection.vue
+++ b/frontend/app/components/home/Last30DaysSection/LastMonthSection.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import type { TemperatureRecordsGraphParams, TypeRecords } from "~/types/api";
 import GoToDataLink from "../GoToDataLink.vue";
+import RecordsBattusExportBar from "../RecordsBattusExportBar.vue";
 import ExtremeCard from "../ExtremeCard.vue";
 import Section from "../Section.vue";
 import TemperatureRecord from "../TemperatureRecord.vue";
@@ -206,6 +207,10 @@ const lastYearColdRecordsCount = computed(
                 compare-to="année dernière"
             />
         </div>
-        <GoToDataLink :data-url="'/temperature/records?preset=30d#table'" />
+        <RecordsBattusExportBar
+            :date-start="dateStart"
+            :date-end="dateEnd"
+            data-url="/temperature/records?preset=30d#table"
+        />
     </Section>
 </template>

--- a/frontend/app/components/home/Last30DaysSection/LastMonthSection.vue
+++ b/frontend/app/components/home/Last30DaysSection/LastMonthSection.vue
@@ -207,10 +207,15 @@ const lastYearColdRecordsCount = computed(
                 compare-to="année dernière"
             />
         </div>
-        <RecordsBattusExportBar
-            :date-start="dateStart"
-            :date-end="dateEnd"
-            data-url="/temperature/records?preset=30d#table"
-        />
+        <div class="flex items-center justify-between gap-2">
+            <RecordsBattusExportBar
+                :date-start="dateStart"
+                :date-end="dateEnd"
+            />
+            <GoToDataLink
+                class="shrink-0"
+                :data-url="'/temperature/records?preset=30d#table'"
+            />
+        </div>
     </Section>
 </template>

--- a/frontend/app/components/home/Last365DaysSection/LastYearSection.vue
+++ b/frontend/app/components/home/Last365DaysSection/LastYearSection.vue
@@ -1,11 +1,15 @@
 <script setup lang="ts">
 import Section from "../Section.vue";
 import GoToDataLink from "../GoToDataLink.vue";
+import RecordsBattusExportBar from "../RecordsBattusExportBar.vue";
 import RecordsRatioCard from "./RecordsRatioCard.vue";
 import Itn365Cards from "./Itn365Cards.vue";
 // import ExtremeCard from "../ExtremeCard.vue";
 
 const { yesterday, yesterdayLess365Days } = useCustomDate();
+
+const dateStart = computed(() => dateToStringYMD(yesterdayLess365Days.value));
+const dateEnd = computed(() => dateToStringYMD(yesterday.value));
 </script>
 
 <template>
@@ -32,6 +36,10 @@ const { yesterday, yesterdayLess365Days } = useCustomDate();
                 <ExtremeCard hot-cold="cold" :disabled="true" />
             </div> -->
         </div>
-        <GoToDataLink :data-url="'/temperature/records?preset=365d#table'" />
+        <RecordsBattusExportBar
+            :date-start="dateStart"
+            :date-end="dateEnd"
+            data-url="/temperature/records?preset=365d#table"
+        />
     </Section>
 </template>

--- a/frontend/app/components/home/Last365DaysSection/LastYearSection.vue
+++ b/frontend/app/components/home/Last365DaysSection/LastYearSection.vue
@@ -36,10 +36,15 @@ const dateEnd = computed(() => dateToStringYMD(yesterday.value));
                 <ExtremeCard hot-cold="cold" :disabled="true" />
             </div> -->
         </div>
-        <RecordsBattusExportBar
-            :date-start="dateStart"
-            :date-end="dateEnd"
-            data-url="/temperature/records?preset=365d#table"
-        />
+        <div class="flex items-center justify-between gap-2">
+            <RecordsBattusExportBar
+                :date-start="dateStart"
+                :date-end="dateEnd"
+            />
+            <GoToDataLink
+                class="shrink-0"
+                :data-url="'/temperature/records?preset=365d#table'"
+            />
+        </div>
     </Section>
 </template>

--- a/frontend/app/components/home/RecordsBattusExportBar.vue
+++ b/frontend/app/components/home/RecordsBattusExportBar.vue
@@ -1,35 +1,29 @@
 <script setup lang="ts">
-import GoToDataLink from "./GoToDataLink.vue";
-
 const props = defineProps<{
     dateStart: string;
     dateEnd: string;
-    dataUrl: string;
 }>();
 
 const { exportRecords } = useExportRecordsBattus();
 </script>
 
 <template>
-    <div class="flex items-center justify-between gap-2">
-        <div class="flex gap-4">
-            <ULink
-                as="button"
-                class="flex items-start gap-0 text-red-500 font-semibold pt-3 pb-1 max-w-52"
-                @click="exportRecords('hot', props.dateStart, props.dateEnd)"
-            >
-                <UIcon name="i-lucide-download" class="shrink-0 mt-0.5" />
-                <span>Exporter la liste des records de chaleur</span>
-            </ULink>
-            <ULink
-                as="button"
-                class="flex items-start gap-0 text-blue-500 font-semibold pt-3 pb-1 max-w-52"
-                @click="exportRecords('cold', props.dateStart, props.dateEnd)"
-            >
-                <UIcon name="i-lucide-download" class="shrink-0 mt-0.5" />
-                <span>Exporter la liste des records de froid</span>
-            </ULink>
-        </div>
-        <GoToDataLink class="shrink-0" :data-url="props.dataUrl" />
+    <div class="flex gap-4">
+        <ULink
+            as="button"
+            class="flex items-start gap-0 text-red-500 font-semibold pt-3 pb-1 max-w-52"
+            @click="exportRecords('hot', props.dateStart, props.dateEnd)"
+        >
+            <UIcon name="i-lucide-download" class="shrink-0 mt-0.5" />
+            <span>Exporter la liste des records de chaleur</span>
+        </ULink>
+        <ULink
+            as="button"
+            class="flex items-start gap-0 text-blue-500 font-semibold pt-3 pb-1 max-w-52"
+            @click="exportRecords('cold', props.dateStart, props.dateEnd)"
+        >
+            <UIcon name="i-lucide-download" class="shrink-0 mt-0.5" />
+            <span>Exporter la liste des records de froid</span>
+        </ULink>
     </div>
 </template>

--- a/frontend/app/components/home/RecordsBattusExportBar.vue
+++ b/frontend/app/components/home/RecordsBattusExportBar.vue
@@ -1,0 +1,35 @@
+<script setup lang="ts">
+import GoToDataLink from "./GoToDataLink.vue";
+
+const props = defineProps<{
+    dateStart: string;
+    dateEnd: string;
+    dataUrl: string;
+}>();
+
+const { exportRecords } = useExportRecordsBattus();
+</script>
+
+<template>
+    <div class="flex items-center justify-between gap-2">
+        <div class="flex gap-4">
+            <ULink
+                as="button"
+                class="flex items-start gap-0 text-red-500 font-semibold pt-3 pb-1 max-w-52"
+                @click="exportRecords('hot', props.dateStart, props.dateEnd)"
+            >
+                <UIcon name="i-lucide-download" class="shrink-0 mt-0.5" />
+                <span>Exporter la liste des records de chaleur</span>
+            </ULink>
+            <ULink
+                as="button"
+                class="flex items-start gap-0 text-blue-500 font-semibold pt-3 pb-1 max-w-52"
+                @click="exportRecords('cold', props.dateStart, props.dateEnd)"
+            >
+                <UIcon name="i-lucide-download" class="shrink-0 mt-0.5" />
+                <span>Exporter la liste des records de froid</span>
+            </ULink>
+        </div>
+        <GoToDataLink class="shrink-0" :data-url="props.dataUrl" />
+    </div>
+</template>

--- a/frontend/app/composables/useExportRecordsBattus.ts
+++ b/frontend/app/composables/useExportRecordsBattus.ts
@@ -1,0 +1,40 @@
+import type {
+    TemperatureRecordsPaginatedResponse,
+    TypeRecords,
+} from "~/types/api";
+
+export function useExportRecordsBattus() {
+    const { apiFetch } = useApiClient();
+
+    async function exportRecords(
+        typeRecords: TypeRecords,
+        dateStart: string,
+        dateEnd: string,
+    ) {
+        if (!import.meta.client) return;
+
+        const data = await apiFetch<TemperatureRecordsPaginatedResponse>(
+            "/temperature/records",
+            {
+                query: {
+                    type_records: typeRecords,
+                    date_start: dateStart,
+                    date_end: dateEnd,
+                    page_size: 9999,
+                },
+            },
+        );
+
+        const label = typeRecords === "hot" ? "chaud" : "froid";
+        downloadCSV(
+            buildRecordsCsv(data.results, "Record (°C)"),
+            useFormatFileName(
+                `records-battus-${label}`,
+                `${dateStart}_${dateEnd}`,
+                "csv",
+            ),
+        );
+    }
+
+    return { exportRecords };
+}

--- a/frontend/app/composables/useExportRecordsBattus.ts
+++ b/frontend/app/composables/useExportRecordsBattus.ts
@@ -18,6 +18,7 @@ export function useExportRecordsBattus() {
             {
                 query: {
                     type_records: typeRecords,
+                    period_type: "month",
                     date_start: dateStart,
                     date_end: dateEnd,
                     page_size: 9999,

--- a/frontend/app/utils/deviationCsv.test.ts
+++ b/frontend/app/utils/deviationCsv.test.ts
@@ -3,7 +3,7 @@ import { buildDeviationCsv } from "./deviationCsv";
 import type { TemperatureDeviationStation } from "~/types/api";
 
 const HEADERS =
-    "Station,Département,Région,Écart à la normale (°C),Température Moyenne (°C)";
+    "Station,Département,Région,Écart à la normale (°C),Température Moyenne (°C),Classe,Année de création";
 
 function makeStation(
     overrides: Partial<TemperatureDeviationStation> = {},
@@ -19,6 +19,8 @@ function makeStation(
         alt: 35,
         lat: 48.85,
         lon: 2.35,
+        classe_recente: 1,
+        date_de_creation: "1872-01-01",
         ...overrides,
     };
 }
@@ -30,7 +32,9 @@ describe("buildDeviationCsv", () => {
 
     test("une station — ligne correcte", () => {
         const result = buildDeviationCsv([makeStation()]);
-        expect(result).toBe(`${HEADERS}\nParis,Paris,Île-de-France,1.5,12.3`);
+        expect(result).toBe(
+            `${HEADERS}\nParis,Paris,Île-de-France,1.5,12.3,1,1872`,
+        );
     });
 
     test("plusieurs stations — plusieurs lignes", () => {
@@ -46,10 +50,12 @@ describe("buildDeviationCsv", () => {
                 region: "Auvergne-Rhône-Alpes",
                 deviation: -0.3,
                 temperature_mean: 11.1,
+                classe_recente: 2,
+                date_de_creation: "1920-03-15",
             }),
         ]);
         expect(result).toBe(
-            `${HEADERS}\nParis,Paris,Île-de-France,1.5,12.3\nLyon,Rhône,Auvergne-Rhône-Alpes,-0.3,11.1`,
+            `${HEADERS}\nParis,Paris,Île-de-France,1.5,12.3,1,1872\nLyon,Rhône,Auvergne-Rhône-Alpes,-0.3,11.1,2,1920`,
         );
     });
 
@@ -58,7 +64,7 @@ describe("buildDeviationCsv", () => {
             makeStation({ station_name: "Paris, 7e" }),
         ]);
         expect(result).toBe(
-            `${HEADERS}\n"Paris, 7e",Paris,Île-de-France,1.5,12.3`,
+            `${HEADERS}\n"Paris, 7e",Paris,Île-de-France,1.5,12.3,1,1872`,
         );
     });
 });

--- a/frontend/app/utils/deviationCsv.ts
+++ b/frontend/app/utils/deviationCsv.ts
@@ -7,6 +7,8 @@ const HEADERS = [
     "Région",
     "Écart à la normale (°C)",
     "Température Moyenne (°C)",
+    "Classe",
+    "Année de création",
 ].join(",");
 
 export function buildDeviationCsv(
@@ -20,6 +22,8 @@ export function buildDeviationCsv(
                 escapeCsvValue(s.region),
                 s.deviation?.toFixed(1) ?? "",
                 s.temperature_mean?.toFixed(1) ?? "",
+                s.classe_recente,
+                new Date(s.date_de_creation).getFullYear(),
             ].join(","),
         )
         .join("\n");

--- a/frontend/app/utils/recordsCsv.test.ts
+++ b/frontend/app/utils/recordsCsv.test.ts
@@ -12,22 +12,25 @@ const makeRecord = (
     record_date: "2019-06-28",
     lat: 0,
     lon: 0,
-    alt: 0,
+    alt: 75,
+    classe_recente: 1,
+    date_de_creation: "1872-01-01",
     ...overrides,
 });
+
+const HEADERS =
+    "Station,Département,Record absolu (°C),Date du record,Classe,Altitude (m),Année de création";
 
 describe("buildRecordsCsv", () => {
     test("tableau vide retourne uniquement les en-têtes", () => {
         const result = buildRecordsCsv([]);
-        expect(result).toBe(
-            "Station,Département,Record absolu(°C),Date du record\n",
-        );
+        expect(result).toBe(`${HEADERS}\n`);
     });
 
     test("une ligne simple", () => {
         const result = buildRecordsCsv([makeRecord()]);
         expect(result).toBe(
-            "Station,Département,Record absolu(°C),Date du record\nParis-Montsouris,75,42.6,2019-06-28",
+            `${HEADERS}\nParis-Montsouris,75,42.6,2019-06-28,1,75,1872`,
         );
     });
 
@@ -39,12 +42,15 @@ describe("buildRecordsCsv", () => {
                 department: "69",
                 record_value: -15.2,
                 record_date: "1985-01-05",
+                alt: 200,
+                classe_recente: 2,
+                date_de_creation: "1920-03-15",
             }),
         ]);
         const lines = result.split("\n");
         expect(lines).toHaveLength(3);
-        expect(lines[1]).toBe("Paris-Montsouris,75,42.6,2019-06-28");
-        expect(lines[2]).toBe("Lyon-Bron,69,-15.2,1985-01-05");
+        expect(lines[1]).toBe("Paris-Montsouris,75,42.6,2019-06-28,1,75,1872");
+        expect(lines[2]).toBe("Lyon-Bron,69,-15.2,1985-01-05,2,200,1920");
     });
 
     test("nom de station avec virgule est entouré de guillemets", () => {
@@ -52,5 +58,12 @@ describe("buildRecordsCsv", () => {
             makeRecord({ station_name: "Saint-Jean, Haute-Loire" }),
         ]);
         expect(result).toContain('"Saint-Jean, Haute-Loire"');
+    });
+
+    test("valueLabel personnalisé remplace le header de valeur", () => {
+        const result = buildRecordsCsv([makeRecord()], "Record battu (°C)");
+        expect(result.startsWith("Station,Département,Record battu (°C)")).toBe(
+            true,
+        );
     });
 });

--- a/frontend/app/utils/recordsCsv.ts
+++ b/frontend/app/utils/recordsCsv.ts
@@ -1,14 +1,19 @@
 import type { TemperatureRecordFlatEntry } from "~/types/api";
 import { escapeCsvValue } from "./string";
 
-const HEADERS = [
-    "Station",
-    "Département",
-    "Record absolu(°C)",
-    "Date du record",
-].join(",");
-
-export function buildRecordsCsv(records: TemperatureRecordFlatEntry[]): string {
+export function buildRecordsCsv(
+    records: TemperatureRecordFlatEntry[],
+    valueLabel = "Record absolu (°C)",
+): string {
+    const headers = [
+        "Station",
+        "Département",
+        valueLabel,
+        "Date du record",
+        "Classe",
+        "Altitude (m)",
+        "Année de création",
+    ].join(",");
     const rows = records
         .map((s) =>
             [
@@ -16,8 +21,11 @@ export function buildRecordsCsv(records: TemperatureRecordFlatEntry[]): string {
                 escapeCsvValue(s.department),
                 s.record_value,
                 s.record_date,
+                s.classe_recente,
+                s.alt,
+                new Date(s.date_de_creation).getFullYear(),
             ].join(","),
         )
         .join("\n");
-    return `${HEADERS}\n${rows}`;
+    return `${headers}\n${rows}`;
 }


### PR DESCRIPTION
## Type de PR
- [ ] Bugfix
- [x] Feature
- [ ] Refactor
- [ ] Chore / Tech debt
- [ ] Documentation
- [ ] Autre (à préciser)

## Objectif
Ajouter cta pour exprter liste records battus

## Contexte
US: https://github.com/dataforgoodfr/14_ValorisationDonneeMeteo/issues/570

## Changements
- crée composant pour exporter table record
- Ajoute colonne classe , date de créatonn lors de l'export des tables
- AJouter cta dans les section ces 30 derniers jours et 365 derniers jours pour exporter csv

<img width="1566" height="319" alt="image" src="https://github.com/user-attachments/assets/07ccc150-7a45-4a54-bf1e-60849007224b" />


## Décisions techniques
<!-- Choix structurants, arbitrages, compromis. -->
<!-- Ce qui aurait pu être fait autrement. -->

## Impacts
- [ ] API / contrat
- [ ] Modèle de données / DB
- [ ] Calculs métier
- [ ] Performance
- [ ] Sécurité
- [ ] Infra / déploiement
- [ ] Aucun impact transverse identifié

## Tests
<!-- Décris ce qui a été fait dans cette PR pour vérifier le comportement introduit ou modifié. -->
- [ ] Tests unitaires
- [ ] Tests d’intégration
- [ ] Tests manuels
- [ ] Non applicable (à justifier)

## Points d’attention pour la review
<!-- Parties sensibles du code, dette technique introduite, risques. -->

## Suivi
- [ ] Migration à prévoir
- [ ] Documentation à mettre à jour
- [ ] Tâche(s) de suivi à créer
