### PR TITLE
feat/front/utilise standard warming stripe color

### DIFF
--- a/frontend/app/components/map/StationMap.vue
+++ b/frontend/app/components/map/StationMap.vue
@@ -234,7 +234,7 @@ onMounted(async () => {
                     btn.type = "button";
                     btn.title = "Réinitialiser la vue";
                     btn.setAttribute("aria-label", "Réinitialiser la vue");
-                    btn.innerHTML = `<svg xmlns="http://www.w3.org/2000/svg" width="29" height="20" viewBox="0 0 20 20" fill="none"><path d="M3 7V3h4M17 7V3h-4M3 13v4h4M17 13v4h-4" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></svg>`;
+                    btn.innerHTML = `<svg xmlns="http://www.w3.org/2000/svg" width="29" height="20" viewBox="0 0 20 20" fill="none"><path d="M3 7V3h4M17 7V3h-4M3 13v4h4M17 13v4h-4" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></svg>`;
                     btn.onclick = () =>
                         m.fitBounds(
                             [

--- a/frontend/app/constants/colors.ts
+++ b/frontend/app/constants/colors.ts
@@ -31,19 +31,31 @@ export function useMapColors() {
     return computed(() => (cm.value === "dark" ? DARK_COLORS : LIGHT_COLORS));
 }
 
+// Palette warming stripes (RdBu ColorBrewer / showyourstripes.info)
+const WARMING_STRIPES = [
+    "#053061",
+    "#2166ac",
+    "#4393c3",
+    "#92c5de",
+    "#d1e5f0",
+    "#f7f7f7",
+    "#fddbc7",
+    "#f4a582",
+    "#d6604d",
+    "#b2182b",
+    "#67001f",
+];
+
+function makeColorStops(min: number, max: number): [number, string][] {
+    const n = WARMING_STRIPES.length - 1;
+    return WARMING_STRIPES.map((color, i) => [
+        min + (i / n) * (max - min),
+        color,
+    ]);
+}
+
 function makeDeviationColors(min: number, max: number): MapColorConfig {
-    const stops: [number, string][] = [
-        [min, TEMPERATURE_COLORS.cold],
-        [min * 0.6, "hsl(210, 85%, 75%)"],
-        [min * 0.2, "hsl(180, 90%, 85%)"],
-        [min * 0.05, "hsl(160, 95%, 90%)"],
-        [0, "#ffffff"],
-        [max * 0.05, "hsl(50, 96%, 90%)"],
-        [max * 0.2, "hsl(30, 90%, 85%)"],
-        [max * 0.6, "hsl(0, 85%, 75%)"],
-        [max, TEMPERATURE_COLORS.hot],
-    ];
-    return { min, max, stops };
+    return { min, max, stops: makeColorStops(min, max) };
 }
 
 export const DEVIATION_MAP_COLORS = makeDeviationColors(-5, 5);
@@ -52,20 +64,8 @@ export const DEVIATION_MAP_MONTHLY_COLORS = makeDeviationColors(-10, 10);
 const recordsMin = -20;
 const recordsMax = 40;
 
-const recordsStops: [number, string][] = [
-    [-20, TEMPERATURE_COLORS.cold],
-    [-8, "hsl(210, 85%, 75%)"],
-    [0, "hsl(180, 90%, 85%)"],
-    [7, "hsl(160, 95%, 90%)"],
-    [12, "#ffffff"],
-    [18, "hsl(50, 96%, 90%)"],
-    [25, "hsl(30, 90%, 85%)"],
-    [33, "hsl(0, 85%, 75%)"],
-    [40, TEMPERATURE_COLORS.hot],
-];
-
 export const RECORDS_MAP_COLORS = {
     min: recordsMin,
     max: recordsMax,
-    stops: recordsStops,
+    stops: makeColorStops(recordsMin, recordsMax),
 };


### PR DESCRIPTION
## Type de PR
- [ ] Bugfix
- [x] Feature
- [ ] Refactor
- [ ] Chore / Tech debt
- [ ] Documentation
- [ ] Autre (à préciser)

## Objectif
utilise les memes couleuer que les warming stripe de ce site https://showyourstripes.info/

## Contexte
demande de FranceTV: https://showyourstripes.info/

## Changements
- visual map pour all cartes
- visual map pour grapge calendar
- couleur bouton reset dark mode en noir sur fond blanc

## Décisions techniques
<!-- Choix structurants, arbitrages, compromis. -->
<!-- Ce qui aurait pu être fait autrement. -->

## Impacts
- [ ] API / contrat
- [ ] Modèle de données / DB
- [ ] Calculs métier
- [ ] Performance
- [ ] Sécurité
- [ ] Infra / déploiement
- [ ] Aucun impact transverse identifié

## Tests
<!-- Décris ce qui a été fait dans cette PR pour vérifier le comportement introduit ou modifié. -->
- [ ] Tests unitaires
- [ ] Tests d’intégration
- [x] Tests manuels
- [ ] Non applicable (à justifier)

## Points d’attention pour la review
<!-- Parties sensibles du code, dette technique introduite, risques. -->

## Suivi
- [ ] Migration à prévoir
- [ ] Documentation à mettre à jour
- [ ] Tâche(s) de suivi à créer
