### PR TITLE
fix: records: fix y labels when resize page

### DIFF
--- a/frontend/app/components/charts/recordsCharts/recordsPyramidChart.vue
+++ b/frontend/app/components/charts/recordsCharts/recordsPyramidChart.vue
@@ -216,16 +216,18 @@ const option = computed<ECOption>(() => {
 </script>
 
 <template>
-    <VChart
-        :ref="adapter.chartRef"
-        :key="`${adapter.granularity.value}-${adapter.chartType?.value}-${adapter.selectedElements?.value?.map((e) => e.id).join('-')}`"
-        :option="option"
-        :init-options="initOptions"
-        :loading="adapter.pending.value"
-        :loading-options="{
-            text: 'Chargement…',
-            color: mapColors.loadingSpinColor,
-        }"
-        autoresize
-    />
+    <div ref="containerRef">
+        <VChart
+            :ref="adapter.chartRef"
+            :key="`${adapter.granularity.value}-${adapter.chartType?.value}-${adapter.selectedElements?.value?.map((e) => e.id).join('-')}`"
+            :option="option"
+            :init-options="initOptions"
+            :loading="adapter.pending.value"
+            :loading-options="{
+                text: 'Chargement…',
+                color: mapColors.loadingSpinColor,
+            }"
+            autoresize
+        />
+    </div>
 </template>


### PR DESCRIPTION
## Type de PR
- [x] Bugfix
- [ ] Feature
- [ ] Refactor
- [ ] Chore / Tech debt
- [ ] Documentation
- [ ] Autre (à préciser)

## Objectif
Les labels de l'axe y du graph en pyramide de la page des records se décentrait quand on changeait la taille de la page

## Contexte
La div englobante avec la ref avait été supprimée
## Changements
-

## Décisions techniques
<!-- Choix structurants, arbitrages, compromis. -->
<!-- Ce qui aurait pu être fait autrement. -->

## Impacts
- [ ] API / contrat
- [ ] Modèle de données / DB
- [ ] Calculs métier
- [ ] Performance
- [ ] Sécurité
- [ ] Infra / déploiement
- [ ] Aucun impact transverse identifié

## Tests
<!-- Décris ce qui a été fait dans cette PR pour vérifier le comportement introduit ou modifié. -->
- [ ] Tests unitaires
- [ ] Tests d’intégration
- [ ] Tests manuels
- [ ] Non applicable (à justifier)

## Points d’attention pour la review
<!-- Parties sensibles du code, dette technique introduite, risques. -->

## Suivi
- [ ] Migration à prévoir
- [ ] Documentation à mettre à jour
- [ ] Tâche(s) de suivi à créer
