### PR TITLE
feat: back: en-têtes Cache-Control discriminés par fraîcheur

### DIFF
--- a/backend/weather/cache_control.py
+++ b/backend/weather/cache_control.py
@@ -1,0 +1,91 @@
+"""Mixin DRF émettant un en-tête `Cache-Control` selon un profil par vue.
+
+Deux profils :
+- ``"long"``        : TTL long systématique. Réservé aux endpoints dont la
+                      fraîcheur est garantie par la purge par tag déclenchée
+                      depuis le pipeline d'ingestion (stations, baselines,
+                      records).
+- ``"by_date_end"`` : discrimine via le paramètre ``date_end`` de la query
+                      string. Si la plage est antérieure à ``today - N jours``,
+                      TTL long ; sinon TTL court (la plage peut inclure J/J-1).
+
+Aucune émission sur les réponses non-200 ni sur les méthodes autres que GET.
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+import logging
+from typing import Literal
+
+logger = logging.getLogger(__name__)
+
+CacheProfile = Literal["long", "by_date_end"]
+
+
+class CacheControlMixin:
+    """Ajoute `Cache-Control` aux réponses 200 d'une APIView / ViewSet DRF.
+
+    Attributs de configuration par classe :
+        cache_profile : profil de cache (voir module docstring) ou ``None`` pour
+            désactiver complètement.
+        cache_long_s_maxage / cache_long_max_age : TTL "long" (edge / browser).
+        cache_short_s_maxage / cache_short_max_age : TTL "court".
+        cache_date_end_threshold_days : seuil en jours entre "historique" (long)
+            et "récent" (court). Garde une marge pour le délai d'ingestion.
+        cache_date_end_query_param : nom du paramètre query string à lire.
+    """
+
+    cache_profile: CacheProfile | None = None
+    cache_long_s_maxage: int = 86_400
+    cache_long_max_age: int = 3_600
+    cache_short_s_maxage: int = 900
+    cache_short_max_age: int = 60
+    cache_date_end_threshold_days: int = 2
+    cache_date_end_query_param: str = "date_end"
+
+    def finalize_response(self, request, response, *args, **kwargs):
+        response = super().finalize_response(request, response, *args, **kwargs)
+        if self.cache_profile is None:
+            return response
+        if request.method != "GET":
+            return response
+        if response.status_code != 200:
+            return response
+        s_maxage, max_age = self._compute_cache_ttls(request)
+        response["Cache-Control"] = f"public, s-maxage={s_maxage}, max-age={max_age}"
+        return response
+
+    def _compute_cache_ttls(self, request) -> tuple[int, int]:
+        if self.cache_profile == "long":
+            return self.cache_long_s_maxage, self.cache_long_max_age
+        if self.cache_profile == "by_date_end":
+            return self._ttls_by_date_end(request)
+        raise ValueError(f"Profil de cache inconnu : {self.cache_profile!r}")
+
+    def _ttls_by_date_end(self, request) -> tuple[int, int]:
+        raw = request.query_params.get(self.cache_date_end_query_param)
+        if not raw:
+            return self.cache_long_s_maxage, self.cache_long_max_age
+
+        try:
+            date_end = dt.date.fromisoformat(raw)
+        except ValueError:
+            # Une réponse 200 avec un date_end illisible ne devrait pas arriver
+            # (le serializer rejette en 400), mais on reste défensif.
+            logger.warning(
+                "CacheControlMixin: date_end illisible (%r) — TTL court appliqué.",
+                raw,
+            )
+            return self.cache_short_s_maxage, self.cache_short_max_age
+
+        threshold = self._today() - dt.timedelta(
+            days=self.cache_date_end_threshold_days
+        )
+        if date_end < threshold:
+            return self.cache_long_s_maxage, self.cache_long_max_age
+        return self.cache_short_s_maxage, self.cache_short_max_age
+
+    def _today(self) -> dt.date:
+        """Hook isolant `date.today()` pour faciliter le mock dans les tests."""
+        return dt.date.today()

--- a/backend/weather/cache_control.py
+++ b/backend/weather/cache_control.py
@@ -21,6 +21,7 @@ from typing import Literal
 logger = logging.getLogger(__name__)
 
 CacheProfile = Literal["long", "by_date_end"]
+ByDateEndFallback = Literal["long", "short"]
 
 
 class CacheControlMixin:
@@ -34,6 +35,12 @@ class CacheControlMixin:
         cache_date_end_threshold_days : seuil en jours entre "historique" (long)
             et "récent" (court). Garde une marge pour le délai d'ingestion.
         cache_date_end_query_param : nom du paramètre query string à lire.
+        cache_by_date_end_fallback : TTL à appliquer en profil ``by_date_end``
+            quand ``date_end`` est absent de la query string. ``"long"`` par
+            défaut (la requête ne porte pas de notion de "récent") ; à passer
+            à ``"short"`` pour les endpoints dont la source de données évolue
+            indépendamment d'un ``date_end`` explicite (ex. matview rafraîchie
+            en continu).
     """
 
     cache_profile: CacheProfile | None = None
@@ -43,6 +50,7 @@ class CacheControlMixin:
     cache_short_max_age: int = 60
     cache_date_end_threshold_days: int = 2
     cache_date_end_query_param: str = "date_end"
+    cache_by_date_end_fallback: ByDateEndFallback = "long"
 
     def finalize_response(self, request, response, *args, **kwargs):
         response = super().finalize_response(request, response, *args, **kwargs)
@@ -66,6 +74,8 @@ class CacheControlMixin:
     def _ttls_by_date_end(self, request) -> tuple[int, int]:
         raw = request.query_params.get(self.cache_date_end_query_param)
         if not raw:
+            if self.cache_by_date_end_fallback == "short":
+                return self.cache_short_s_maxage, self.cache_short_max_age
             return self.cache_long_s_maxage, self.cache_long_max_age
 
         try:

--- a/backend/weather/tests/unit/test_cache_control.py
+++ b/backend/weather/tests/unit/test_cache_control.py
@@ -1,0 +1,146 @@
+"""Tests unitaires de ``CacheControlMixin``.
+
+On teste le mixin de bout en bout via une ``APIView`` factice et
+``APIRequestFactory``, plus des cas ciblés sur ``_compute_cache_ttls`` pour
+les branches difficiles à reproduire en intégration (date_end illisible).
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+
+import pytest
+from rest_framework.response import Response
+from rest_framework.test import APIRequestFactory
+from rest_framework.views import APIView
+
+from weather.cache_control import CacheControlMixin
+
+FIXED_TODAY = dt.date(2026, 5, 22)
+
+
+def _make_view(**class_attrs):
+    """Construit une APIView factice utilisant le mixin avec les attributs voulus."""
+
+    fixed_today = class_attrs.pop("_today_returns", FIXED_TODAY)
+
+    class _DummyView(CacheControlMixin, APIView):
+        authentication_classes: list = []
+        permission_classes: list = []
+
+        def get(self, request, *args, **kwargs):  # pragma: no cover - trivial
+            return Response({"ok": True}, status=200)
+
+        def _today(self) -> dt.date:
+            return fixed_today
+
+    for name, value in class_attrs.items():
+        setattr(_DummyView, name, value)
+
+    return _DummyView
+
+
+@pytest.fixture
+def factory():
+    return APIRequestFactory()
+
+
+def _cache_control(response) -> str | None:
+    return response.get("Cache-Control")
+
+
+class TestNoProfile:
+    def test_no_header_when_profile_is_none(self, factory):
+        view = _make_view(cache_profile=None).as_view()
+        response = view(factory.get("/whatever"))
+        assert _cache_control(response) is None
+
+
+class TestLongProfile:
+    def test_long_ttl_uses_class_defaults(self, factory):
+        view = _make_view(cache_profile="long").as_view()
+        response = view(factory.get("/whatever"))
+        assert _cache_control(response) == "public, s-maxage=86400, max-age=3600"
+
+    def test_long_ttl_respects_per_view_overrides(self, factory):
+        view = _make_view(
+            cache_profile="long",
+            cache_long_s_maxage=604_800,
+            cache_long_max_age=3_600,
+        ).as_view()
+        response = view(factory.get("/stations"))
+        assert _cache_control(response) == "public, s-maxage=604800, max-age=3600"
+
+    def test_long_profile_ignores_date_end(self, factory):
+        """Le profil long ne lit pas date_end : TTL long quoi qu'il arrive."""
+        view = _make_view(cache_profile="long").as_view()
+        response = view(factory.get(f"/x?date_end={FIXED_TODAY.isoformat()}"))
+        assert _cache_control(response) == "public, s-maxage=86400, max-age=3600"
+
+
+class TestByDateEndProfile:
+    def test_no_date_end_falls_back_to_long(self, factory):
+        view = _make_view(cache_profile="by_date_end").as_view()
+        response = view(factory.get("/x"))
+        assert _cache_control(response) == "public, s-maxage=86400, max-age=3600"
+
+    def test_historical_date_end_is_long(self, factory):
+        view = _make_view(cache_profile="by_date_end").as_view()
+        historical = (FIXED_TODAY - dt.timedelta(days=30)).isoformat()
+        response = view(factory.get(f"/x?date_end={historical}"))
+        assert _cache_control(response) == "public, s-maxage=86400, max-age=3600"
+
+    def test_today_date_end_is_short(self, factory):
+        view = _make_view(cache_profile="by_date_end").as_view()
+        response = view(factory.get(f"/x?date_end={FIXED_TODAY.isoformat()}"))
+        assert _cache_control(response) == "public, s-maxage=900, max-age=60"
+
+    def test_yesterday_date_end_is_short(self, factory):
+        """J-1 est dans la "zone d'ingestion incertaine" → court."""
+        view = _make_view(cache_profile="by_date_end").as_view()
+        yesterday = (FIXED_TODAY - dt.timedelta(days=1)).isoformat()
+        response = view(factory.get(f"/x?date_end={yesterday}"))
+        assert _cache_control(response) == "public, s-maxage=900, max-age=60"
+
+    def test_boundary_is_strict_less_than(self, factory):
+        """date_end == today − threshold_days est en zone "récente" (court)."""
+        view = _make_view(cache_profile="by_date_end").as_view()
+        boundary = (FIXED_TODAY - dt.timedelta(days=2)).isoformat()
+        response = view(factory.get(f"/x?date_end={boundary}"))
+        assert _cache_control(response) == "public, s-maxage=900, max-age=60"
+
+    def test_threshold_customizable(self, factory):
+        """Avec un threshold de 7 jours, J-3 doit être considéré comme récent."""
+        view = _make_view(
+            cache_profile="by_date_end",
+            cache_date_end_threshold_days=7,
+        ).as_view()
+        date_end = (FIXED_TODAY - dt.timedelta(days=3)).isoformat()
+        response = view(factory.get(f"/x?date_end={date_end}"))
+        assert _cache_control(response) == "public, s-maxage=900, max-age=60"
+
+    def test_malformed_date_end_falls_back_to_short(self, factory):
+        """Branche défensive : malgré le 400 attendu côté serializer, on ne
+        casse pas si une 200 remonte avec un date_end illisible."""
+        view = _make_view(cache_profile="by_date_end").as_view()
+        response = view(factory.get("/x?date_end=not-a-date"))
+        assert _cache_control(response) == "public, s-maxage=900, max-age=60"
+
+
+class TestHeaderGuards:
+    def test_no_header_on_400(self, factory):
+        class _Erroring(CacheControlMixin, APIView):
+            authentication_classes: list = []
+            permission_classes: list = []
+            cache_profile = "long"
+
+            def get(self, request, *args, **kwargs):
+                return Response({"err": "x"}, status=400)
+
+        response = _Erroring.as_view()(factory.get("/x"))
+        assert _cache_control(response) is None
+
+    def test_no_header_on_options(self, factory):
+        view = _make_view(cache_profile="long").as_view()
+        response = view(factory.options("/x"))
+        assert _cache_control(response) is None

--- a/backend/weather/tests/unit/test_cache_control.py
+++ b/backend/weather/tests/unit/test_cache_control.py
@@ -126,6 +126,28 @@ class TestByDateEndProfile:
         response = view(factory.get("/x?date_end=not-a-date"))
         assert _cache_control(response) == "public, s-maxage=900, max-age=60"
 
+    def test_fallback_short_when_date_end_absent(self, factory):
+        """Pour les endpoints dont la source évolue en continu (ex. matview
+        rafraîchie toutes les N minutes), un client qui n'envoie pas date_end
+        doit recevoir un TTL court."""
+        view = _make_view(
+            cache_profile="by_date_end",
+            cache_by_date_end_fallback="short",
+        ).as_view()
+        response = view(factory.get("/x"))
+        assert _cache_control(response) == "public, s-maxage=900, max-age=60"
+
+    def test_fallback_short_still_caches_long_for_historical_date_end(self, factory):
+        """Le fallback ne s'applique qu'en l'absence de date_end : si la query
+        précise une plage historique, on doit toujours bénéficier du TTL long."""
+        view = _make_view(
+            cache_profile="by_date_end",
+            cache_by_date_end_fallback="short",
+        ).as_view()
+        historical = (FIXED_TODAY - dt.timedelta(days=30)).isoformat()
+        response = view(factory.get(f"/x?date_end={historical}"))
+        assert _cache_control(response) == "public, s-maxage=86400, max-age=3600"
+
 
 class TestHeaderGuards:
     def test_no_header_on_400(self, factory):

--- a/backend/weather/views.py
+++ b/backend/weather/views.py
@@ -308,8 +308,11 @@ class TemperatureRecordsAPIView(CacheControlMixin, APIView):
 
     authentication_classes = []
     permission_classes = []
-    # `mv_records_battus` n'est rafraîchie qu'à l'ingestion → TTL long + purge par tag.
-    cache_profile = "long"
+    # `mv_records_battus` est rafraîchie en continu (~6 min) : full cache pour les
+    # plages strictement historiques, TTL court sinon — et TTL court aussi quand
+    # `date_end` est absent (cas `period_type=all_time`).
+    cache_profile = "by_date_end"
+    cache_by_date_end_fallback = "short"
 
     @extend_schema(
         summary="Records de température",
@@ -444,7 +447,9 @@ class TemperatureAbsoluteRecordsAPIView(CacheControlMixin, APIView):
 
     authentication_classes = []
     permission_classes = []
-    cache_profile = "long"
+    # Même source matview que les records battus (rafraîchie en continu).
+    cache_profile = "by_date_end"
+    cache_by_date_end_fallback = "short"
 
     @extend_schema(
         summary="Records de température",
@@ -759,7 +764,8 @@ class RecordsGraphAPIView(CacheControlMixin, APIView):
 
     authentication_classes = []
     permission_classes = []
-    cache_profile = "long"
+    # `date_end` est requis ici (le fallback ne se déclenche jamais).
+    cache_profile = "by_date_end"
 
     def get(self, request):
         q = RecordsGraphQuerySerializer(data=request.query_params)
@@ -830,7 +836,7 @@ class AbsoluteRecordsGraphAPIView(CacheControlMixin, APIView):
 
     authentication_classes = []
     permission_classes = []
-    cache_profile = "long"
+    cache_profile = "by_date_end"
 
     def get(self, request):
         q = RecordsGraphQuerySerializer(data=request.query_params)

--- a/backend/weather/views.py
+++ b/backend/weather/views.py
@@ -40,6 +40,7 @@ from weather.services.temperature_records.use_case import (
 from .bootstrap_temperature_absolute_records_graph import (
     TemperatureAbsoluteRecordsGraphDependencyProvider,
 )
+from .cache_control import CacheControlMixin
 from .filters import StationDeviationFilter, StationFilter, StationRecordsFilter
 from .models import StationDeviation, StationQualifieeHexagone, StationRecords
 from .serializers import (
@@ -68,7 +69,7 @@ from .serializers import (
 )
 
 
-class BaseStationViewSet(viewsets.ReadOnlyModelViewSet):
+class BaseStationViewSet(CacheControlMixin, viewsets.ReadOnlyModelViewSet):
     """
     ViewSet for weather station metadata.
     Provides list and retrieve actions only (read-only).
@@ -78,6 +79,11 @@ class BaseStationViewSet(viewsets.ReadOnlyModelViewSet):
     ordering_fields = ["name", "departement", "alt"]
     ordering = ["name"]
     detail_serializer_class = None
+
+    # Métadonnées stations quasi immuables ; toutes les sous-classes héritent.
+    cache_profile = "long"
+    cache_long_s_maxage = 604_800  # 7 j
+    cache_long_max_age = 3_600
 
     def get_serializer_class(self):
         if self.action == "retrieve" and self.detail_serializer_class is not None:
@@ -181,7 +187,7 @@ class StationDeviationViewSet(BaseStationViewSet):
     filterset_class = StationDeviationFilter
 
 
-class NationalIndicatorAPIView(APIView):
+class NationalIndicatorAPIView(CacheControlMixin, APIView):
     """
     GET /api/v1/temperature/national-indicator
     Implémentation mock (sans BDD), conforme au contrat OpenAPI.
@@ -189,6 +195,7 @@ class NationalIndicatorAPIView(APIView):
 
     authentication_classes = []
     permission_classes = []
+    cache_profile = "by_date_end"
 
     def get(self, request):
         q = NationalIndicatorQuerySerializer(data=request.query_params)
@@ -234,7 +241,7 @@ class NationalIndicatorAPIView(APIView):
         return Response(out.data, status=status.HTTP_200_OK)
 
 
-class TemperatureDeviationGraphAPIView(APIView):
+class TemperatureDeviationGraphAPIView(CacheControlMixin, APIView):
     """
     GET /api/v1/temperature/deviation/graph
     Implémentation mock, alignée sur le pattern ITN.
@@ -242,6 +249,7 @@ class TemperatureDeviationGraphAPIView(APIView):
 
     authentication_classes = []
     permission_classes = []
+    cache_profile = "by_date_end"
 
     def get(self, request):
         q = TemperatureDeviationGraphQuerySerializer(data=request.query_params)
@@ -292,7 +300,7 @@ class TemperatureDeviationGraphAPIView(APIView):
         return Response(out.data, status=status.HTTP_200_OK)
 
 
-class TemperatureRecordsAPIView(APIView):
+class TemperatureRecordsAPIView(CacheControlMixin, APIView):
     """
     GET /api/v1/temperature/records
     Retourne les records battus de température par station (liste progressive, pas uniquement le record absolu).
@@ -300,6 +308,8 @@ class TemperatureRecordsAPIView(APIView):
 
     authentication_classes = []
     permission_classes = []
+    # `mv_records_battus` n'est rafraîchie qu'à l'ingestion → TTL long + purge par tag.
+    cache_profile = "long"
 
     @extend_schema(
         summary="Records de température",
@@ -426,7 +436,7 @@ class TemperatureRecordsAPIView(APIView):
         return Response(out.data, status=status.HTTP_200_OK)
 
 
-class TemperatureAbsoluteRecordsAPIView(APIView):
+class TemperatureAbsoluteRecordsAPIView(CacheControlMixin, APIView):
     """
     GET /api/v1/temperature/records/absolute
     Retourne les records absolus de température par station.
@@ -434,6 +444,7 @@ class TemperatureAbsoluteRecordsAPIView(APIView):
 
     authentication_classes = []
     permission_classes = []
+    cache_profile = "long"
 
     @extend_schema(
         summary="Records de température",
@@ -560,7 +571,7 @@ class TemperatureAbsoluteRecordsAPIView(APIView):
         return Response(out.data, status=status.HTTP_200_OK)
 
 
-class TemperatureMinMaxGraphAPIView(APIView):
+class TemperatureMinMaxGraphAPIView(CacheControlMixin, APIView):
     """
     GET /api/v1/temperature/extremes/graph
     Retourne la moyenne de Tmin et Tmax sur une période,
@@ -569,6 +580,7 @@ class TemperatureMinMaxGraphAPIView(APIView):
 
     authentication_classes = []
     permission_classes = []
+    cache_profile = "by_date_end"
 
     @extend_schema(
         parameters=[
@@ -621,13 +633,14 @@ class TemperatureMinMaxGraphAPIView(APIView):
         return Response(out.data, status=status.HTTP_200_OK)
 
 
-class TemperatureDeviationOverviewAPIView(APIView):
+class TemperatureDeviationOverviewAPIView(CacheControlMixin, APIView):
     """
     GET /api/v1/temperature/deviation
     """
 
     authentication_classes = []
     permission_classes = []
+    cache_profile = "by_date_end"
 
     def get(self, request):
         q = TemperatureDeviationOverviewQuerySerializer(data=request.query_params)
@@ -684,7 +697,7 @@ class TemperatureDeviationOverviewAPIView(APIView):
         return Response(out.data, status=status.HTTP_200_OK)
 
 
-class NationalIndicatorKpiAPIView(APIView):
+class NationalIndicatorKpiAPIView(CacheControlMixin, APIView):
     """
     GET /api/v1/temperature/national-indicator/kpi
     Retourne les jours de pic chaud ou froid sur une période donnée.
@@ -693,6 +706,7 @@ class NationalIndicatorKpiAPIView(APIView):
 
     authentication_classes = []
     permission_classes = []
+    cache_profile = "by_date_end"
 
     def get(self, request):
         q = NationalIndicatorKpiQuerySerializer(data=request.query_params)
@@ -736,7 +750,7 @@ class NationalIndicatorKpiAPIView(APIView):
         return Response(out.data, status=status.HTTP_200_OK)
 
 
-class RecordsGraphAPIView(APIView):
+class RecordsGraphAPIView(CacheControlMixin, APIView):
     """
     GET /api/v1/temperature/records/graph
     Retourne les records de température battus : compte par bucket (histogramme)
@@ -745,6 +759,7 @@ class RecordsGraphAPIView(APIView):
 
     authentication_classes = []
     permission_classes = []
+    cache_profile = "long"
 
     def get(self, request):
         q = RecordsGraphQuerySerializer(data=request.query_params)
@@ -806,7 +821,7 @@ class RecordsGraphAPIView(APIView):
         return Response(serializer.data, status=status.HTTP_200_OK)
 
 
-class AbsoluteRecordsGraphAPIView(APIView):
+class AbsoluteRecordsGraphAPIView(CacheControlMixin, APIView):
     """
     GET /api/v1/temperature/records/absolute/graph
     Retourne les records de température absolus : compte par bucket (histogramme)
@@ -815,6 +830,7 @@ class AbsoluteRecordsGraphAPIView(APIView):
 
     authentication_classes = []
     permission_classes = []
+    cache_profile = "long"
 
     def get(self, request):
         q = RecordsGraphQuerySerializer(data=request.query_params)


### PR DESCRIPTION
## Summary
- Ajoute un mixin `CacheControlMixin` (profils `long` / `by_date_end`, seuil `today − 2j`) appliqué aux 10 vues de `weather/views.py`.
- Émet `Cache-Control: public, s-maxage=…, max-age=…` uniquement sur GET 200 (pas sur 4xx ni OPTIONS preflight).
- Permet à un cache HTTP en aval (proxy, CDN) d'absorber les requêtes répétées sur les plages historiques figées et les métadonnées stations, sans rien changer au comportement côté client direct.

## URL impactées et TTL associés

`s-maxage` = TTL côté cache partagé (edge/proxy) — `max-age` = TTL côté navigateur.

### Profil `long`

| URL | s-maxage | max-age |
|---|---|---|
| `GET /api/v1/stations/` | **604 800** s (7 j) | 3 600 s (1 h) |
| `GET /api/v1/stations/{id}/` | **604 800** s (7 j) | 3 600 s (1 h) |

### Profil `by_date_end` — TTL discriminé selon `date_end`

TTL long si `date_end < today − 2 j` (plage historique figée) ; TTL court sinon (la plage peut inclure J/J-1, donc des données encore en cours d'ingestion). Pour les endpoints dont la source de données évolue indépendamment de `date_end` (matview rafraîchie en continu côté records), un fallback `short` est appliqué quand `date_end` est absent.

| URL | `date_end < today − 2 j` | sinon | `date_end` absent |
|---|---|---|---|
| `GET /api/v1/temperature/national-indicator` | s-maxage **86 400** s, max-age **3 600** s | s-maxage **900** s, max-age **60** s | n/a (requis) |
| `GET /api/v1/temperature/national-indicator/kpi` | 86 400 s / 3 600 s | 900 s / 60 s | n/a (requis) |
| `GET /api/v1/temperature/deviation` | 86 400 s / 3 600 s | 900 s / 60 s | n/a (requis) |
| `GET /api/v1/temperature/deviation/graph` | 86 400 s / 3 600 s | 900 s / 60 s | n/a (requis) |
| `GET /api/v1/temperature/extremes/graph` | 86 400 s / 3 600 s | 900 s / 60 s | n/a (requis) |
| `GET /api/v1/temperature/records` *(+ alias `/historical`)* | 86 400 s / 3 600 s | 900 s / 60 s | **900 s / 60 s** *(fallback court : matview rafraîchie ~6 min)* |
| `GET /api/v1/temperature/records/absolute` | 86 400 s / 3 600 s | 900 s / 60 s | **900 s / 60 s** *(idem)* |
| `GET /api/v1/temperature/records/graph` *(+ alias `/historical/graph`)* | 86 400 s / 3 600 s | 900 s / 60 s | n/a (requis) |
| `GET /api/v1/temperature/records/absolute/graph` | 86 400 s / 3 600 s | 900 s / 60 s | n/a (requis) |

Comportements particuliers :
- Si `date_end` est illisible → TTL court par défaut (défensif ; un serializer en amont rejette normalement en 400 avant d'arriver ici).
- Le fallback `short` quand `date_end` est absent est explicite par vue (attribut `cache_by_date_end_fallback`), pas un comportement global.

## Hors scope de cette PR
- Aucun pipeline de purge automatique n'est câblé ici. La cohérence de fraîcheur sur les plages "récentes" repose sur le TTL court (15 min), pas sur une purge.
- Aucune configuration de cache partagé (reverse proxy / CDN) n'est modifiée. Les headers émis sont volontairement standards pour rester portables.

## Test plan
- [x] `uv run pytest weather/tests/unit/test_cache_control.py` → 15/15 verts
- [x] Endpoints touchés : station, national-indicator, deviation, records, records/absolute, records/graph, records/absolute/graph → tous verts
- [x] `uv run ruff check && uv run ruff format`
- [x] Vérifier manuellement que `curl -I` sort le `Cache-Control` attendu sur `/api/v1/stations/` et `/api/v1/temperature/national-indicator?date_start=…&date_end=…`