### PR TITLE
pas d'autoscale si peu de données

### DIFF
--- a/frontend/app/components/charts/recordsCharts/recordsScatterChart.vue
+++ b/frontend/app/components/charts/recordsCharts/recordsScatterChart.vue
@@ -18,8 +18,10 @@ import {
     barSeries,
     buildTerritoryPlots,
     countByPeriod,
+    periodKey,
     scatterSeries,
 } from "~/utils/recordsChartUtils";
+import { dateToStringYMD } from "~/utils/date";
 import { useMapColors } from "~/constants/colors";
 import { FONT_CHARTS, GRAPH_RECORDS_POSITION } from "~/constants/fonts";
 import { xAxisTimeFormatter } from "~/utils/chartAxisFormatter";
@@ -70,24 +72,34 @@ const option = computed<ECOption>(() => {
     const barDataset = () => {
         const first = territoryPlots[0];
         if (!first) return [];
-        const hotByPeriod = countByPeriod(
-            first.hot,
-            props.adapter.granularity.value,
-        );
-        const coldByPeriod = countByPeriod(
-            first.cold,
-            props.adapter.granularity.value,
-        );
+        const granularity = props.adapter.granularity.value;
+        const hotByPeriod = countByPeriod(first.hot, granularity);
+        const coldByPeriod = countByPeriod(first.cold, granularity);
+
+        // Génère tous les buckets du range pour qu'ECharts calcule une largeur
+        // de barre d'1 période au lieu d'auto-scaler sur les rares points réels.
+        const allPeriodKeys: string[] = [];
+        const currentDate = new Date(props.adapter.pickedDateStart.value);
+        const dateEndTimestamp = props.adapter.pickedDateEnd.value.getTime();
+        while (currentDate.getTime() <= dateEndTimestamp) {
+            allPeriodKeys.push(
+                periodKey(dateToStringYMD(currentDate), granularity),
+            );
+            if (granularity === "year")
+                currentDate.setFullYear(currentDate.getFullYear() + 1);
+            else if (granularity === "month")
+                currentDate.setMonth(currentDate.getMonth() + 1);
+            else currentDate.setDate(currentDate.getDate() + 1);
+        }
+
         return [
             {
                 dimensions: ["period", "hot", "cold"],
-                source: Object.keys({ ...hotByPeriod, ...coldByPeriod })
-                    .sort()
-                    .map((period) => ({
-                        period,
-                        hot: hotByPeriod[period] ?? 0,
-                        cold: coldByPeriod[period] ?? 0,
-                    })),
+                source: allPeriodKeys.map((period) => ({
+                    period,
+                    hot: hotByPeriod[period] ?? 0,
+                    cold: coldByPeriod[period] ?? 0,
+                })),
             },
         ];
     };
@@ -124,8 +136,8 @@ const option = computed<ECOption>(() => {
         xAxis: plots.map((_, index) => ({
             type: "time",
             gridIndex: index,
-            min: props.adapter.pickedDateStart?.value,
-            max: props.adapter.pickedDateEnd?.value,
+            min: () => props.adapter.pickedDateStart?.value?.getTime(),
+            max: () => props.adapter.pickedDateEnd?.value?.getTime(),
             nameLocation: "middle",
             nameGap: 25,
             nameTextStyle: {


### PR DESCRIPTION
## Type de PR
- [x] Bugfix
- [ ] Feature
- [ ] Refactor
- [ ] Chore / Tech debt
- [ ] Documentation
- [ ] Autre (à préciser)

## Objectif
gérer affichage bar plot dans graphe record sous scatter plot si un seul jour avec données

## Contexte
https://github.com/dataforgoodfr/14_ValorisationDonneeMeteo/issues/634

## Changements
au lieu de n'insérer dans le dataset que les jours avec des records, on insère tous les jours du range (avec 0 si pas de record). ECharts calcule alors une largeur de barre d'1 jour (au lieu d'étaler sur tout le range faute de données), et l'axe reste dans les bornes correctes.

AVANT:
<img width="2662" height="1568" alt="image" src="https://github.com/user-attachments/assets/380ee1eb-f6ad-4be6-ad0b-86fa5eb84885" />


APRES:
<img width="819" height="537" alt="image" src="https://github.com/user-attachments/assets/62e5963d-029b-43f1-93bc-78c9eaf7cdeb" />


## Décisions techniques
<!-- Choix structurants, arbitrages, compromis. -->
<!-- Ce qui aurait pu être fait autrement. -->

## Impacts
- [ ] API / contrat
- [ ] Modèle de données / DB
- [ ] Calculs métier
- [ ] Performance
- [ ] Sécurité
- [ ] Infra / déploiement
- [ ] Aucun impact transverse identifié

## Tests
<!-- Décris ce qui a été fait dans cette PR pour vérifier le comportement introduit ou modifié. -->
- [ ] Tests unitaires
- [ ] Tests d’intégration
- [x] Tests manuels
- [ ] Non applicable (à justifier)

## Points d’attention pour la review
<!-- Parties sensibles du code, dette technique introduite, risques. -->

## Suivi
- [ ] Migration à prévoir
- [ ] Documentation à mettre à jour
- [ ] Tâche(s) de suivi à créer
