### PR TITLE
Bugfix/front/aligne scatter dot and bar

### DIFF
--- a/frontend/app/adapters/recordsSelectBarAdapter.ts
+++ b/frontend/app/adapters/recordsSelectBarAdapter.ts
@@ -94,7 +94,7 @@ export const useRecordsSelectBarAdapter =
                         if (!params.length) return '';
                         const first = params[0];
                         const toScatter = (v) => Array.isArray(v) ? {date: v[0], value: v[1], station: v[2]} : v;
-                        const toBar = (v) => Array.isArray(v) ? {period: v[0], hot: v[1], cold: v[2]} : v;
+                        const toBar = (v) => Array.isArray(v) ? {period: v[0], hot: v[2], cold: v[3]} : v;
                         if (first.seriesType === 'bar') {
                             const d = toBar(first.value);
                             const hotMarker = '<span style="display:inline-block;margin-right:4px;border-radius:10px;width:10px;height:10px;background-color:#d32F2F;"></span>';

--- a/frontend/app/components/charts/recordsCharts/recordsScatterChart.vue
+++ b/frontend/app/components/charts/recordsCharts/recordsScatterChart.vue
@@ -80,8 +80,10 @@ const option = computed<ECOption>(() => {
         // de barre d'1 période au lieu d'auto-scaler sur les rares points réels.
         const allPeriodKeys: string[] = [];
         const currentDate = new Date(props.adapter.pickedDateStart.value);
-        const pickedEnd = props.adapter.pickedDateEnd.value;
-        const dateEndStr = dateToStringYMD(pickedEnd);
+        // Comparaison en chaîne "YYYY-MM-DD" pour ignorer la composante heure :
+        // pickedDateStart/End peuvent être créés à l'heure courante (pas minuit),
+        // ce qui décalerait la borne de la boucle de quelques ms.
+        const dateEndStr = dateToStringYMD(props.adapter.pickedDateEnd.value);
         while (dateToStringYMD(currentDate) <= dateEndStr) {
             allPeriodKeys.push(
                 periodKey(dateToStringYMD(currentDate), granularity),
@@ -93,15 +95,13 @@ const option = computed<ECOption>(() => {
             else currentDate.setDate(currentDate.getDate() + 1);
         }
 
+        // ECharts centre les barres sur le timestamp du point. Pour que la barre
+        // de l'année/mois N occupe visuellement la bonne période, on positionne
+        // chaque barre au milieu de sa période (juillet pour une année, 16 pour un mois).
         const periodMidpointUTC = (key: string): number => {
-            if (granularity === "year") {
-                return Date.UTC(parseInt(key), 6, 2);
-            }
-            if (granularity === "month") {
-                const [year, month] = key.split("-").map(Number);
-                return Date.UTC(year!, month! - 1, 16);
-            }
             const [year, month, day] = key.split("-").map(Number);
+            if (granularity === "year") return Date.UTC(year!, 6, 2);
+            if (granularity === "month") return Date.UTC(year!, month! - 1, 16);
             return Date.UTC(year!, month! - 1, day!);
         };
 
@@ -150,6 +150,11 @@ const option = computed<ECOption>(() => {
         xAxis: plots.map((_, index) => ({
             type: "time",
             gridIndex: index,
+            // Date.UTC avec les composantes locales évite le décalage timezone :
+            // le date picker crée des dates à minuit LOCAL (ex. 1er mai 00:00 CEST
+            // = 30 avril 22:00 UTC). Utiliser .getTime() directement donnerait un
+            // max différent entre scatter et bar, ECharts auto-étendant l'axe bar
+            // pour loger la dernière barre → les deux grilles se désaligneraient.
             min: () => {
                 const startDate = props.adapter.pickedDateStart?.value;
                 if (!startDate) return Date.now();

--- a/frontend/app/components/charts/recordsCharts/recordsScatterChart.vue
+++ b/frontend/app/components/charts/recordsCharts/recordsScatterChart.vue
@@ -151,21 +151,30 @@ const option = computed<ECOption>(() => {
             type: "time",
             gridIndex: index,
             min: () => {
-                const s = props.adapter.pickedDateStart?.value;
-                if (!s) return Date.now();
-                return Date.UTC(s.getFullYear(), s.getMonth(), s.getDate());
+                const startDate = props.adapter.pickedDateStart?.value;
+                if (!startDate) return Date.now();
+                return Date.UTC(
+                    startDate.getFullYear(),
+                    startDate.getMonth(),
+                    startDate.getDate(),
+                );
             },
             max: () => {
-                const end = props.adapter.pickedDateEnd?.value;
-                if (!end) return Date.now();
-                const g = props.adapter.granularity.value;
-                if (g === "year") return Date.UTC(end.getFullYear() + 1, 0, 1);
-                if (g === "month")
-                    return Date.UTC(end.getFullYear(), end.getMonth() + 1, 1);
+                const endDate = props.adapter.pickedDateEnd?.value;
+                if (!endDate) return Date.now();
+                const granularity = props.adapter.granularity.value;
+                if (granularity === "year")
+                    return Date.UTC(endDate.getFullYear() + 1, 0, 1);
+                if (granularity === "month")
+                    return Date.UTC(
+                        endDate.getFullYear(),
+                        endDate.getMonth() + 1,
+                        1,
+                    );
                 return Date.UTC(
-                    end.getFullYear(),
-                    end.getMonth(),
-                    end.getDate() + 1,
+                    endDate.getFullYear(),
+                    endDate.getMonth(),
+                    endDate.getDate() + 1,
                 );
             },
             nameLocation: "middle",

--- a/frontend/app/components/charts/recordsCharts/recordsScatterChart.vue
+++ b/frontend/app/components/charts/recordsCharts/recordsScatterChart.vue
@@ -80,8 +80,9 @@ const option = computed<ECOption>(() => {
         // de barre d'1 période au lieu d'auto-scaler sur les rares points réels.
         const allPeriodKeys: string[] = [];
         const currentDate = new Date(props.adapter.pickedDateStart.value);
-        const dateEndTimestamp = props.adapter.pickedDateEnd.value.getTime();
-        while (currentDate.getTime() <= dateEndTimestamp) {
+        const pickedEnd = props.adapter.pickedDateEnd.value;
+        const dateEndStr = dateToStringYMD(pickedEnd);
+        while (dateToStringYMD(currentDate) <= dateEndStr) {
             allPeriodKeys.push(
                 periodKey(dateToStringYMD(currentDate), granularity),
             );
@@ -92,11 +93,24 @@ const option = computed<ECOption>(() => {
             else currentDate.setDate(currentDate.getDate() + 1);
         }
 
+        const periodMidpointUTC = (key: string): number => {
+            if (granularity === "year") {
+                return Date.UTC(parseInt(key), 6, 2);
+            }
+            if (granularity === "month") {
+                const [year, month] = key.split("-").map(Number);
+                return Date.UTC(year!, month! - 1, 16);
+            }
+            const [year, month, day] = key.split("-").map(Number);
+            return Date.UTC(year!, month! - 1, day!);
+        };
+
         return [
             {
-                dimensions: ["period", "hot", "cold"],
+                dimensions: ["period", "x", "hot", "cold"],
                 source: allPeriodKeys.map((period) => ({
                     period,
+                    x: periodMidpointUTC(period),
                     hot: hotByPeriod[period] ?? 0,
                     cold: coldByPeriod[period] ?? 0,
                 })),
@@ -123,21 +137,37 @@ const option = computed<ECOption>(() => {
                 return {
                     top: `${index * (100 / plots.length) + 8}%`,
                     height: `${100 / plots.length - 15}%`,
-                    left: 30,
+                    left: 60,
                     right: 10,
                 };
             }
 
             if (plot === "scatter") {
-                return { top: "8%", height: "55%", left: 30, right: 10 };
+                return { top: "8%", height: "55%", left: 60, right: 10 };
             }
-            return { top: "72%", height: "20%", left: 30, right: 10 };
+            return { top: "72%", height: "20%", left: 60, right: 10 };
         }),
         xAxis: plots.map((_, index) => ({
             type: "time",
             gridIndex: index,
-            min: () => props.adapter.pickedDateStart?.value?.getTime(),
-            max: () => props.adapter.pickedDateEnd?.value?.getTime(),
+            min: () => {
+                const s = props.adapter.pickedDateStart?.value;
+                if (!s) return Date.now();
+                return Date.UTC(s.getFullYear(), s.getMonth(), s.getDate());
+            },
+            max: () => {
+                const end = props.adapter.pickedDateEnd?.value;
+                if (!end) return Date.now();
+                const g = props.adapter.granularity.value;
+                if (g === "year") return Date.UTC(end.getFullYear() + 1, 0, 1);
+                if (g === "month")
+                    return Date.UTC(end.getFullYear(), end.getMonth() + 1, 1);
+                return Date.UTC(
+                    end.getFullYear(),
+                    end.getMonth(),
+                    end.getDate() + 1,
+                );
+            },
             nameLocation: "middle",
             nameGap: 25,
             nameTextStyle: {
@@ -189,26 +219,20 @@ const option = computed<ECOption>(() => {
                 }),
             ]),
             ...(showStackedBar
-                ? [
+                ? (["hot", "cold"] as const).map((type) =>
                       barSeries({
-                          name: "Records de chaleur",
+                          name:
+                              type === "hot"
+                                  ? "Records de chaleur"
+                                  : "Records de froid",
                           datasetIndex: territoryPlots.length * 2,
-                          encode: { x: "period", y: "hot" },
-                          color: mapColors.value.hot,
+                          encode: { x: "x", y: type },
+                          color: mapColors.value[type],
                           stack: "records",
                           xAxisIndex: 1,
                           yAxisIndex: 1,
                       }),
-                      barSeries({
-                          name: "Records de froid",
-                          datasetIndex: territoryPlots.length * 2,
-                          encode: { x: "period", y: "cold" },
-                          color: mapColors.value.cold,
-                          stack: "records",
-                          xAxisIndex: 1,
-                          yAxisIndex: 1,
-                      }),
-                  ]
+                  )
                 : []),
         ],
         title: territoryPlots.map((plot, index) => ({


### PR DESCRIPTION
## Type de PR
- [x] Bugfix
- [ ] Feature
- [ ] Refactor
- [ ] Chore / Tech debt
- [ ] Documentation
- [ ] Autre (à préciser)

## Objectif
bien aligner les Xitck des graphe scatter et bar plot de la page record

## Contexte
il y avait un désalignement et un manque de données 
<img width="140" height="359" alt="image" src="https://github.com/user-attachments/assets/a9a885a9-ec0e-4ae7-a535-f188fb6db2a1" />

US: https://github.com/dataforgoodfr/14_ValorisationDonneeMeteo/issues/640#issue-4541211630

et la donnée du dernier jours n'était pas affichée dans la bar plot (pas de 28/05/2026 dans le bar plot mais bien présent dans scatter)
<img width="227" height="356" alt="image" src="https://github.com/user-attachments/assets/25faf0b8-c228-4b6c-9057-04a2103e3ad1" />


## Changements
- aligne le milieu de la barre avec le 15 du mois si granularité mois et le mois de juin si granularité année
- utilise valeur UTC et froce echart à étendre la barre car config par defaut est NOK pour assurer alignement

- refacto showStackedBar

## Décisions techniques
    

## Impacts
- [ ] API / contrat
- [ ] Modèle de données / DB
- [ ] Calculs métier
- [ ] Performance
- [ ] Sécurité
- [ ] Infra / déploiement
- [ ] Aucun impact transverse identifié

## Tests
<!-- Décris ce qui a été fait dans cette PR pour vérifier le comportement introduit ou modifié. -->
- [ ] Tests unitaires
- [ ] Tests d’intégration
- [x] Tests manuels
- [ ] Non applicable (à justifier)

## Points d’attention pour la review
<!-- Parties sensibles du code, dette technique introduite, risques. -->

## Suivi
- [ ] Migration à prévoir
- [ ] Documentation à mettre à jour
- [ ] Tâche(s) de suivi à créer
